### PR TITLE
Nunit test adapter

### DIFF
--- a/CauldronMods.csproj
+++ b/CauldronMods.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/CauldronMods.csproj
+++ b/CauldronMods.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Install the NUnit test adapter to run the tests directly using the VS 2019 Test running.

NOTE: To make this work I had to switch the target framework version. At some point we'll probably have to switch it back.