### PR TITLE
Documentation workshop

### DIFF
--- a/Docs/CODE_OF_CONDUCT.md
+++ b/Docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+﻿# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team on discord. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/Docs/CODE_WISDOM.md
+++ b/Docs/CODE_WISDOM.md
@@ -1,0 +1,14 @@
+﻿# Assumulated Coding Wisdom
+
+## UsePowerNumerals
+UsePower implementation must use `GetPowerNumeral()` in place of hard coded integers.
+This is to support Guise + Harpy edge cases.
+This is only for actual numbers (1,2,3) and not words (one, two, three).
+
+## Revealed Cards
+When cards are revealed the engine moves those cards to a special location.
+Cards must be explicitly moved back to a real location before the end of the effect.
+
+
+
+

--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+﻿# Contributing
+
+We welcome contributions, including from newcomers with no prior modding experience.
+
+Don't know C#, that's ok, lots of Art resources need to be created.
+Don't know art, that's ok, lots of DeckLists that need proofreading.
+Don't like proofreading, that's ok, just play the Mod and report issues.
+
+First step to helping out is to join the [Discord](https://discord.gg/t6xupMv767).
+
+## Table of contents
+
+* [Resources and links](#resources-and-links)
+* [How to get started](#how-to-get-started)
+* [How to contribute code](#how-to-contribute-code)
+* [How to contribute art](#how-to-contribute-art)
+* [How to contribute music](#how-to-contribute-music)
+
+## Resources and links
+
+* Discusion: [Discord Invite](https://discord.gg/t6xupMv767)
+* Cauldron website: https://cauldron4.webnode.com/
+* Handlebra Mod Trello board: https://trello.com/b/vYBMImbg/sotm-workshop
+* Project Trello board: https://trello.com/b/Doyff7gB/cauldron-sotm-mod
+* BGG Forum: https://boardgamegeek.com/thread/2532898/mod-sentinels-digital 
+* SotM Full Card Breakdown Sheet - [Google Sheets](https://docs.google.com/spreadsheets/d/1F-4drbJyXUWxFg_EzzBsrprzPciAtRdZZLyUStl3abI/edit?usp=sharing)
+
+## How to get started
+
+1. Install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/)
+   * Community Edition is free and perfect for modders 
+   * When installing choose the C# and Game Development options
+   * You'll also want the select the .NET Core SDK's
+1. Install a GitHub client
+   * Microsoft has a integrated [GitHub Extension](https://visualstudio.github.com/) available
+   * Directions assume this is the route you choose.
+1. Connect to GitHub and get the project
+   * In Team Explorer, connect to your GitHub account
+   * Sync from https://github.com/SotMSteamMods/CauldronMods.git
+1. Build the Solution, and Run the Tests
+
+You will also want one or more .Net Decompilers
+* [dnSpy](https://github.com/dnSpy/dnSpy/releases) is easy to use and great for just looking
+* [ILSpy](https://github.com/icsharpcode/ILSpy/releases) generates better code if you plan on exporting code
+
+## How to contribute code
+
+## How to contribute art
+
+## How to contribute music
+
+We are still working this out

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+﻿MIT License
+
+Copyright (c) 2020 SotmSteamMods - CauldronMod Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,38 @@
 # CauldronMods
-Mod adaptations of the Cauldron decks for Sentinels of the Multiverse for Steam Workshop
+## The Cauldron decks for Sentinels of the Multiverse Digital
 ----------------------------------------------------------
 Links:
--Cauldron website: https://cauldron4.webnode.com/
--Trello board: https://trello.com/b/Doyff7gB/cauldron-sotm-mod
--BGG Forum: https://boardgamegeek.com/thread/2532898/mod-sentinels-digital 
+- Cauldron website: https://cauldron4.webnode.com/
+- Trello board: https://trello.com/b/Doyff7gB/cauldron-sotm-mod
+- BGG Forum: https://boardgamegeek.com/thread/2532898/mod-sentinels-digital 
 
-Currently included decks:
+To get started helping out take a look at:
+- [Code of Conduct](./Docs/CODE_OF_CONDUCT.md)
+- [Contributing](./Docs/CONTRIBUTING.md)
 
-HEROES:
--Baccarat
--Lady of the Wood
--Necro
+**How to I play this mod?**
 
-VILLAINS:
--Anathema
+You can't.
+Handelabra is implementing Mod support now.
+You can follow the development on [Handelabra's Discord](https://discordapp.com/invite/handelabra)
+channel with [Weekly Dev. Streams](https://www.youtube.com/playlist?list=PLGPBmjNUB43ick6QwxGIOMFFN5yKuTvQU).
 
-ENVIRONMENTS:
--The Wandering Isle
+**What are you working on them**
+
+We are working to implement the core Cauldron decks, and be ready out of the gate
+when mods are available to have Cauldron ready to play.
+
+- HEROES:
+  - Baccarat
+  - Doc Havoc - In Progress
+  - Lady of the Wood
+  - Necro
+  - The Knight
+  - The Stranger
+
+- VILLAINS:
+  - Anathema
+  - Tiamat - In Progress
+
+- ENVIRONMENTS:
+  - The Wandering Isle

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # CauldronMods
-## The Cauldron decks for Sentinels of the Multiverse Digital
+
+**What is the Cauldron**
+The Cauldron is a custom fan expansion for the [Sentinels of the Multiverse](http://sentinelsofthemultiverse.com/)
+cooperative card game by Greater Than Games.  These decks were designed by Matthew Bishop (@Tosx), his roommate, and his brother.
+The base set was begun around 2013, and the last set was completed in 2019.
+
+This project will bring the fantastic Cauldron Decks to [Sentinels of the Multiverse Digital](https://store.steampowered.com/app/337150/Sentinels_of_the_Multiverse/) as a Steam Workshop Mod.
+
 ----------------------------------------------------------
+
 Links:
+- Get the Game: [Steam](https://store.steampowered.com/app/337150/Sentinels_of_the_Multiverse/)
 - Cauldron website: https://cauldron4.webnode.com/
 - Trello board: https://trello.com/b/Doyff7gB/cauldron-sotm-mod
 - BGG Forum: https://boardgamegeek.com/thread/2532898/mod-sentinels-digital 


### PR DESCRIPTION
Documentation update for discussion and review.
Added a Code of Conduct, shamelessly stolen from the Jorbs Slay the Spire Mod Github
Added a Constributing doc, again shamelessly stolen, but heavily edited
Added a License file (MIT) just so we have something.  The Jorb's mode uses the same, so it seemed a reasonable default.
Edited and cleaned up the ReadMe
