### PR TITLE
Ad-Hoc: Fixed Anathema failing test

### DIFF
--- a/Controller/Villains/Anathema/Cards/BiofeedbackCardController.cs
+++ b/Controller/Villains/Anathema/Cards/BiofeedbackCardController.cs
@@ -22,7 +22,7 @@ namespace Cauldron.Anathema
 				new TriggerType[] { TriggerType.GainHP },TriggerTiming.After,null,false,true,null,false,null,null,false,false);
 
 			//Whenever an arm, body, or head is destroyed by a Hero target, Anathema deals himself 2 psychic damage.
-			base.AddTrigger<DestroyCardAction>((DestroyCardAction dca) => this.IsArmHeadOrBody(dca.CardToDestroy.Card) && dca.CardSource.Card.IsTarget && dca.CardSource != null && dca.CardSource.Card.IsHero,
+			base.AddTrigger<DestroyCardAction>((DestroyCardAction dca) => this.IsArmHeadOrBody(dca.CardToDestroy.Card) && dca.CardSource != null && dca.CardSource.Card.IsTarget  && dca.CardSource.Card.IsHero,
 				(DestroyCardAction dca) => base.DealDamage(base.CharacterCard, base.CharacterCard, 2, DamageType.Psychic, false, false, false, null, null, null, false, base.GetCardSource(null)),
 				new TriggerType[] { TriggerType.DealDamage }, TriggerTiming.After, null, false, false, null, false, null, null, false, false);
 		}

--- a/Testing/Villains/AnathemaTests.cs
+++ b/Testing/Villains/AnathemaTests.cs
@@ -279,16 +279,17 @@ namespace CauldronTests
         [Test()]
         public void TestAnathemaAdvancedImmuneWhen3Targets()
         {
-            SetupGameController(new string[] { "Cauldron.Anathema", "Ra", "Megalopolis" },true,null,null,new string[] { "Cauldron.Anathema" },false,null,null,null);
+            SetupGameController(new string[] { "Cauldron.Anathema", "Ra", "Megalopolis" }, advanced: true,advancedIdentifiers: new string[] { "Cauldron.Anathema" });
             
             StartGame();
            
             GoToUsePowerPhase(ra);
 
-            List<Card> arms = GetListOfArmsInPlay(anathema);
+            List<Card> arms = (anathema.TurnTaker.PlayArea.Cards.Where(c => this.IsArm(c))).ToList();
+
 
             //destroy an arm to have 3 villain targets
-            DestroyCard(arms[0]);
+            DestroyCard(arms[0], ra.CharacterCard);
 
             //verify that there is only 1 arm in play now
             AssertNumberOfArmsInPlay(anathema, 1);


### PR DESCRIPTION
test was destroying without a CardSource and Biofeedback did not have the nullcheck in the correct order

Adjusted test to add in the cardsoure
Adjusted Biofeedback to correctly do the nullcheck