### PR TITLE
Adhoc mod loading

### DIFF
--- a/Docs/ADHOC_MOD_LOADING.md
+++ b/Docs/ADHOC_MOD_LOADING.md
@@ -1,0 +1,7 @@
+﻿For ad-hoc loading, create a folder named "mods" alongside your Sentinels app/executable.
+
+Inside that folder, each mod must be in its own folder (example: mods/SampleMod).
+
+Each mod must have a file named manifest.json. This file specifies all of the information the game needs to load the mod.
+This can be located in the Docs folder as well.
+

--- a/Docs/manifest.json
+++ b/Docs/manifest.json
@@ -1,0 +1,29 @@
+{
+	"title": "Cauldron",
+	"author": "Cualdron Mod Team",
+	"description": "Fanmade expansions converted to the digital tabletop.",
+	"namespace":"Cualdron",
+	"dll":"CauldronMods.dll",
+	"decks":{
+		"heroes":{
+			"Baccarat",
+			"DocHavoc",
+			"TheKnight",
+			"LadyOfTheWood",
+			"Necro",
+			"Malichae",
+			"TheStranger",
+			"TangoOne"
+		},
+		"villains":{
+			"Anathema",
+			"Gray",
+			"Tiamat"
+		},
+		"environments":{
+			"FSCContinuanceWanderer",
+			"HalberdExperimentalResearchFacility",
+			"TheWanderingIsle"
+		}
+	}
+}


### PR DESCRIPTION
This branch contains a new md that explains how to adhoc load the mods (once implemented into Base SotM game).
This includes the manifest required for the game to find the decks.