### PR TITLE
Fixed issue 113

### DIFF
--- a/Controller/Heroes/TangoOne/Cards/LineEmUpCardController.cs
+++ b/Controller/Heroes/TangoOne/Cards/LineEmUpCardController.cs
@@ -25,6 +25,7 @@ namespace Cauldron.TangoOne
         public override void AddTriggers()
         {
             base.AddTrigger<DestroyCardAction>(destroyCard => destroyCard.WasCardDestroyed
+                && destroyCard.ResponsibleCard != null 
                 && destroyCard.ResponsibleCard.Equals(this.Card.Owner.CharacterCard)
                 && base.GameController.IsCardVisibleToCardSource(destroyCard.CardToDestroy.Card,
                     base.GetCardSource()),


### PR DESCRIPTION
Line Em Up was actually the problem card in described scenario as it's DestroyCardAction trigger wasn't checking for null on the ResponsibleCard property when fired.
In some cases (like Akash's Rejuv. Entropy) it's null.

Fixes crash issue #113 