### PR TITLE
Partial Islandquake fixes

### DIFF
--- a/Controller/Environments/TheWanderingIsle/Cards/IslandquakeCardController.cs
+++ b/Controller/Environments/TheWanderingIsle/Cards/IslandquakeCardController.cs
@@ -26,9 +26,9 @@ namespace Cauldron.TheWanderingIsle
             foreach (Card c in this.GetHeroesWhoCausedTeryxToGainHpLastRound())
             {
                 CannotDealDamageStatusEffect cannotDealDamageStatusEffect = new CannotDealDamageStatusEffect();
+                cannotDealDamageStatusEffect.SourceCriteria.IsSpecificCard = base.Card;
                 cannotDealDamageStatusEffect.TargetCriteria.IsSpecificCard = c;
-                cannotDealDamageStatusEffect.NumberOfUses = 1;
-                cannotDealDamageStatusEffect.UntilTargetLeavesPlay(c);
+                cannotDealDamageStatusEffect.UntilEndOfPhase(base.TurnTaker, Phase.Start);
                 cannotDealDamageStatusEffect.IsPreventEffect = true;
                 coroutine = base.AddStatusEffect(cannotDealDamageStatusEffect);
                 if (base.UseUnityCoroutines)

--- a/Controller/Environments/TheWanderingIsle/Cards/IslandquakeCardController.cs
+++ b/Controller/Environments/TheWanderingIsle/Cards/IslandquakeCardController.cs
@@ -15,33 +15,18 @@ namespace Cauldron.TheWanderingIsle
 
         public override void AddTriggers()
         {
-            // At the start of the environment turn, this card deals each target other than Teryx 4 sonic damage. Hero targets which caused Teryx to regain HP since the end of the last environment turn are immune to this damage.
+            // At the start of the environment turn, this card deals each target other than Teryx 4 sonic damage.
             base.AddStartOfTurnTrigger((TurnTaker tt) => tt == base.TurnTaker, this.DealDamageResponse, TriggerType.DealDamage);
+            // Hero targets which caused Teryx to regain HP since the end of the last environment turn are immune to this damage.
+            base.AddImmuneToDamageTrigger((DealDamageAction action) =>
+                //damage initiated by this card's text, a.k.a. "this damage"
+                action.CardSource.Card == base.Card && this.IsHeroTargetWhoCausedTeryxToGainHpLastRound(action.Target));
         }
 
         private IEnumerator DealDamageResponse(PhaseChangeAction pca)
         {
-            //make hero targets who caused Teryx to gain HP last round to become immune to the next damage
-            IEnumerator coroutine;
-            foreach (Card c in this.GetHeroesWhoCausedTeryxToGainHpLastRound())
-            {
-                CannotDealDamageStatusEffect cannotDealDamageStatusEffect = new CannotDealDamageStatusEffect();
-                cannotDealDamageStatusEffect.SourceCriteria.IsSpecificCard = base.Card;
-                cannotDealDamageStatusEffect.TargetCriteria.IsSpecificCard = c;
-                cannotDealDamageStatusEffect.UntilEndOfPhase(base.TurnTaker, Phase.Start);
-                cannotDealDamageStatusEffect.IsPreventEffect = true;
-                coroutine = base.AddStatusEffect(cannotDealDamageStatusEffect);
-                if (base.UseUnityCoroutines)
-                {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
-                }
-            }
-
             //this card deals each target other than Teryx 4 sonic damage
+            IEnumerator coroutine;
             coroutine = base.DealDamage(base.Card, (Card c) => c.Identifier != TeryxIdentifier, 4, DamageType.Sonic);
             if (base.UseUnityCoroutines)
             {
@@ -66,12 +51,11 @@ namespace Cauldron.TheWanderingIsle
             yield break;
         }
 
-        private List<Card> GetHeroesWhoCausedTeryxToGainHpLastRound()
+        private bool IsHeroTargetWhoCausedTeryxToGainHpLastRound(Card card)
         {
-            return base.GameController.Game.Journal.GainHPEntries()
-                        .Where(e => e.Round == this.Game.Round && e.TargetCard.Identifier == TeryxIdentifier && e.SourceCard.IsHero && e.SourceCard.IsTarget)
-                        .Select(e => e.SourceCard)
-                        .ToList();
+            return card.IsHero && card.IsTarget &&
+                base.GameController.Game.Journal.GainHPEntries()
+                        .Any(e => e.Round == this.Game.Round && e.TargetCard.Identifier == TeryxIdentifier && e.SourceCard == card);
         }
 
     }

--- a/Controller/Environments/TheWanderingIsle/Cards/IslandquakeCardController.cs
+++ b/Controller/Environments/TheWanderingIsle/Cards/IslandquakeCardController.cs
@@ -11,6 +11,7 @@ namespace Cauldron.TheWanderingIsle
     {
         public IslandquakeCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
+            base.SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => c.IsInPlay && this.IsHeroTargetWhoCausedTeryxToGainHpLastRound(c), "hero targets that have caused Teryx to regain HP", useCardsSuffix: false, useCardsPrefix: false, "hero target that has caused Teryx to regain HP", "hero targets that have caused Teryx to regain HP"));
         }
 
         public override void AddTriggers()

--- a/Testing/Environments/TheWanderingIsleTests.cs
+++ b/Testing/Environments/TheWanderingIsleTests.cs
@@ -14,6 +14,7 @@ namespace CauldronTests
         #region TheWanderingIsleHelperFunctions
 
         protected TurnTakerController isle { get { return FindEnvironment(); } }
+        protected HeroTurnTakerController stranger { get { return FindHero("TheStranger"); } }
 
         private bool IsTeryxInPlay(TurnTakerController ttc)
         {
@@ -687,6 +688,103 @@ namespace CauldronTests
             //ra was immune to damage and tachyon redirected damage to ra
             //blade and haka were hit
             QuickHPCheck(-4, 0, 0, -4, 0);
+        }
+
+        [Test()]
+        public void TestIslandquakeStartOfTurnHealTeryxDuringStartOfTurnTrigger()
+        {
+            SetupGameController("BaronBlade", "Cauldron.TheStranger", "Ra", "Haka", "Cauldron.TheWanderingIsle");
+            StartGame();
+
+            //destroy mdp so baron blade is not immune to damage
+            DestroyCard(GetCardInPlay("MobileDefensePlatform"));
+
+            Card teryx = PutIntoPlay("Teryx");
+
+            //set hitpoints so there is room to gain
+            SetHitPoints(teryx, 30);
+
+            var card = PutIntoPlay("Islandquake");
+            AssertInPlayArea(isle, card);
+
+            //both the stranger and ra have a mark of the blood thorn attached
+            GoToPlayCardPhase(stranger);
+            DecisionSelectCard = ra.CharacterCard;
+            Card rune1 = PutIntoPlay("MarkOfTheBloodThorn");
+            AssertNextToCard(rune1, ra.CharacterCard);
+            DecisionSelectCard = stranger.CharacterCard;
+            Card rune2 = PutIntoPlay("MarkOfTheBloodThorn");
+            AssertNextToCard(rune2, stranger.CharacterCard);
+
+            //the stranger uses 2x mark of the blood thorn to heal teryx when ra is damaged
+            base.ResetDecisions();
+            DecisionSelectTargets = new[] {
+                //islandquake targets ra
+                ra.CharacterCard,
+                //ra targets the stranger, via blood thorn
+                stranger.CharacterCard,
+                //the stranger targets teryx, via blood thorn
+                teryx,
+                //islandquake targets the stranger
+                stranger.CharacterCard,
+                //islandquake targets the remaining targets
+                baron.CharacterCard,
+                haka.CharacterCard
+            };
+
+            //At the start of the environment turn, this card deals each target other than Teryx 4 sonic damage. Hero targets which caused Teryx to regain HP since the end of the last environment turn are immune to this damage.
+            QuickHPStorage(baron.CharacterCard, stranger.CharacterCard, ra.CharacterCard, haka.CharacterCard, teryx);
+            GoToStartOfTurn(isle);
+
+            //stranger was immune, but took 1 damage from blood thorn
+            //blade ra, and haka were hit
+            //teryx healed from mainstay
+            QuickHPCheck(-4, -1, -4, -4, 1);
+        }
+
+        [Test()]
+        [Ignore("TODO:issues#199")]
+        public void TestIslandquakeStartOfTurnHealTeryxDuringDamage()
+        {
+            SetupGameController("BaronBlade", "VoidGuardMainstay", "Ra", "Haka", "Cauldron.TheWanderingIsle");
+            StartGame();
+
+            //destroy mdp so baron blade is not immune to damage
+            DestroyCard(GetCardInPlay("MobileDefensePlatform"));
+
+            Card teryx = PutIntoPlay("Teryx");
+
+            //set hitpoints so there is room to gain
+            SetHitPoints(teryx, 30);
+
+            //mainstay has preemptive payback in play
+            PutIntoPlay("PreemptivePayback");
+
+            var card = PutIntoPlay("Islandquake");
+            AssertInPlayArea(isle, card);
+
+            //mainstay uses preemptive payback to heal teryx before being hit
+            //yes, destroy preemptive payback
+            DecisionYesNo = true;
+            DecisionSelectTargets = new[] {
+                //islandquake targets mainstay
+                voidMainstay.CharacterCard,
+                //mainstay preemptively targets teryx, via preemptive payback
+                teryx,
+                //islandquake targets the remaining targets
+                baron.CharacterCard,
+                ra.CharacterCard,
+                haka.CharacterCard
+            };
+
+            //At the start of the environment turn, this card deals each target other than Teryx 4 sonic damage. Hero targets which caused Teryx to regain HP since the end of the last environment turn are immune to this damage.
+            QuickHPStorage(baron.CharacterCard, voidMainstay.CharacterCard, ra.CharacterCard, haka.CharacterCard, teryx);
+            GoToStartOfTurn(isle);
+
+            //mainstay was immune
+            //blade ra, and haka were hit
+            //teryx healed from mainstay
+            QuickHPCheck(-4, 0, -4, -4, 3);
         }
 
         [Test()]

--- a/Testing/Environments/TheWanderingIsleTests.cs
+++ b/Testing/Environments/TheWanderingIsleTests.cs
@@ -654,6 +654,42 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestIslandquakeStartOfTurnRedirectForMultipleHits()
+        {
+            SetupGameController("BaronBlade", "Ra", "Tachyon", "Haka", "Cauldron.TheWanderingIsle");
+            StartGame();
+
+            //destroy mdp so baron blade is not immune to damage
+            DestroyCard(GetCardInPlay("MobileDefensePlatform"));
+
+            Card teryx = PutIntoPlay("Teryx");
+
+            //set hitpoints so there is room to gain
+            SetHitPoints(teryx, 30);
+
+            GoToPlayCardPhase(ra);
+            //ra deals damage to teryx to cause hp gain and to be immune to islandquake damage
+            DealDamage(ra.CharacterCard, teryx, 5, DamageType.Fire);
+
+            //tachyon has synaptic interruption in play
+            PutIntoPlay("SynapticInterruption");
+
+            var card = PutIntoPlay("Islandquake");
+            AssertInPlayArea(isle, card);
+
+            //tachyon uses synaptic interruption to redirect damage to ra, who is immune to islandquake damage
+            DecisionRedirectTarget = ra.CharacterCard;
+
+            //At the start of the environment turn, this card deals each target other than Teryx 4 sonic damage. Hero targets which caused Teryx to regain HP since the end of the last environment turn are immune to this damage.
+            QuickHPStorage(baron.CharacterCard, ra.CharacterCard, tachyon.CharacterCard, haka.CharacterCard, teryx);
+            GoToStartOfTurn(isle);
+
+            //ra was immune to damage and tachyon redirected damage to ra
+            //blade and haka were hit
+            QuickHPCheck(-4, 0, 0, -4, 0);
+        }
+
+        [Test()]
         public void TestSongOfTheDeepPlay()
         {
             SetupGameController("BaronBlade", "Ra", "TheVisionary", "Haka", "Cauldron.TheWanderingIsle");


### PR DESCRIPTION
*Changes:*
* Add a QoL tooltip to Islandquake for hero targets that have healed Teryx.
* Grant the "immune to this damage" immunity as a persistent effect to fix most timing issues.

Partial #199 

*Limitations:*

"this damage" is identified using `CardSource`, which seems to mean "damage initiated by an effect on this card". There may be an edge case if a card that merges effects from multiple cards (similar to Guise's Uh Yeah I'm that Guy) is applied to environment cards.
The only other solution I could think of was passing a no-op `addStatusEffect` as a flag and doing an object identity check to find it in the ImmuneToDamageTrigger. Feels pretty hacky.

The Preemptive Payback test is ignored, because it doesn't work yet. It seems that the ImmuneToDamageTrigger has already determined it was non-applicable before Preemptive Payback allowed VG Mainstay to deal damage (otherwise he wouldn't be taking damage), and it's not being re-evaluated afterwards. Preemptive Payback explicitly checks for `dd.DamageSource.Card.IsIncapacitatedOrOutOfGame` to cancel the incoming damage cleanly if Mainstay was able to get the source removed, so proper handling might be an engine limitation?

The existing query for "hero targets that have healed Teryx" only finds targets that healed Teryx by Teryx's own effect, or were the `CardSource` for healing Teryx. Hippocratic Oath, Universal Donor, etc end up with the ongoing as the CardSource for the healing effect, so the hero isn't credited.