### PR TITLE
Bugfixes gray baccarat

### DIFF
--- a/Controller/Heroes/Baccarat/Cards/AfterlifeEuchreCardController.cs
+++ b/Controller/Heroes/Baccarat/Cards/AfterlifeEuchreCardController.cs
@@ -20,7 +20,7 @@ namespace Cauldron.Baccarat
             IEnumerable<Function> functionChoices = new Function[]
             {
 				//Increase the next damage dealt by {Baccarat} by 1...
-				new Function(base.HeroTurnTakerController, "Increase the next damage dealt by Baccarat by 1", SelectionType.IncreaseNextDamage, () => base.AddStatusEffect(new IncreaseDamageStatusEffect(1){ NumberOfUses = new int?(1) })),
+				new Function(base.HeroTurnTakerController, "Increase the next damage dealt by Baccarat by 1", SelectionType.IncreaseNextDamage, () => base.AddStatusEffect(new IncreaseDamageStatusEffect(1){ SourceCriteria = { IsSpecificCard = base.CharacterCard }, NumberOfUses = new int?(1) })),
 
 				//...or {Baccarat} deals 1 target 2 toxic damage.
 				new Function(base.HeroTurnTakerController, "Baccarat deals 1 target 2 toxic damage", SelectionType.TurnTaker, () => base.GameController.SelectTargetsAndDealDamage(this.DecisionMaker, new DamageSource(base.GameController, base.CharacterCard), 2, DamageType.Toxic, new int?(1), false, new int?(1),cardSource: base.GetCardSource()))

--- a/DeckLists/Hero/CricketDeckList.json
+++ b/DeckLists/Hero/CricketDeckList.json
@@ -39,7 +39,7 @@
                 "default": "default placeholder",
                 "DynamoCharacter": "Dynamo placeholder"
             },
-            "complexity": 1
+            "complexity": 2
         },
         {
             "identifier": "AcousticDistortion",
@@ -456,7 +456,7 @@
                 "default": "default placeholder",
                 "DynamoCharacter": "Dynamo placeholder"
             },
-            "complexity": 1
+            "complexity": 2
         },
         {
             "identifier": "CricketCharacter",
@@ -497,7 +497,7 @@
                 "default": "default placeholder",
                 "DynamoCharacter": "Dynamo placeholder"
             },
-            "complexity": 1
+            "complexity": 2
         },
         {
             "identifier": "CricketCharacter",
@@ -537,7 +537,7 @@
                 "default": "default placeholder",
                 "DynamoCharacter": "Dynamo placeholder"
             },
-            "complexity": 1
+            "complexity": 2
         }
     ]
 }

--- a/DeckLists/Villain/GrayDeckList.json
+++ b/DeckLists/Villain/GrayDeckList.json
@@ -13,10 +13,6 @@
             "keywords": [
                 "villain"
             ],
-            "icons": [
-                "StartOfTurnAction"
-            ],
-            "advancedIcons": [],
             "body": "Walking Nuclear Reactor",
             "backgroundColor": "D99FC5",
             "foilBackgroundColor": "CD96C0",
@@ -35,10 +31,15 @@
                 "Whenever a radiation card is destroyed, destroy 1 hero ongoing or equipment card and {Gray} deals each non-villain target {H - 1} energy damage."
             ],
             "advanced": "Whenever a radiation card is destroyed, destroy a second hero ongoing or equipment card.",
+            "icons": [
+                "EndOfTurnAction",
+                "DealDamageEnergy",
+                "Destroy"
+            ],
             "flippedBody": "Catastrophic Meltdown",
             "flippedGameplay": [
                 "At the start of the villain turn, if there are 1 or 0 radiation cards in play, flip {Gray}'s character cards.",
-                "At the start of the villain turn, destroy all but 2 hero ongoing or equipment cards. {Gray} deals each hero target {H x 2} energy damage. Play the top card of the villain deck.",
+                "At the start of the villain turn, destroy all but 2 hero ongoing or equipment cards. {Gray} deals each hero target {H * 2} energy damage. Play the top card of the villain deck.",
                 "Whenever a radiation card is destroyed by a hero card, {Gray} deals that hero {H - 1} energy damage.",
                 "Whenever a copy of Radioactive Cascade is destroyed, {Gray} deals the hero with the highest HP {H - 1} energy damage."
             ],

--- a/DeckLists/Villain/GrayDeckList.json
+++ b/DeckLists/Villain/GrayDeckList.json
@@ -117,9 +117,8 @@
                 "radiation"
             ],
             "icons": [
-                "StartOfTurnAction",
+                "StartAndEndOfTurnAction",
                 "DealDamageEnergy",
-                "EndOfTurnAction",
                 "PlayCardNow"
             ],
             "body": [

--- a/DeckLists/Villain/GrayDeckList.json
+++ b/DeckLists/Villain/GrayDeckList.json
@@ -45,8 +45,7 @@
             "flippedAdvanced": "Reduce damage dealt to villain targets by 1.",
             "flippedIcons": [
                 "StartOfTurnAction",
-                "DestroyOngoing",
-                "DestroyEquipment",
+                "Destroy",
                 "DealDamageEnergy",
                 "PlayCardNow"
             ],

--- a/Testing/Heroes/BaccaratTests.cs
+++ b/Testing/Heroes/BaccaratTests.cs
@@ -529,6 +529,11 @@ namespace CauldronTests
             DecisionSelectFunction = 0;
             //Increase the next damage dealt by {Baccarat} by 1,
             PlayCard(euchre);
+            //Damage is only increased for Baccarat
+            QuickHPStorage(baccarat);
+            DealDamage(mdp, baccarat, 2, DamageType.Melee);
+            QuickHPCheck(-2);
+            //+1 damage
             QuickHPStorage(mdp);
             DealDamage(baccarat, mdp, 2, DamageType.Melee);
             QuickHPCheck(-3);


### PR DESCRIPTION
Closes #210 and #211 - The Gray Character Card flip now works
Closes #194 - Baccarat's Afterlife Euchre now only buffs his damage