### PR TITLE
Removed logic for adding back in the don't play cards logic when flip…

### DIFF
--- a/Controller/Environments/StSimeonsCatacombs/Cards/StSimeonsCatacombsInstructionsCardController.cs
+++ b/Controller/Environments/StSimeonsCatacombs/Cards/StSimeonsCatacombsInstructionsCardController.cs
@@ -222,16 +222,6 @@ namespace Cauldron.StSimeonsCatacombs
             this.AddSideTriggers();
             //remove all old side status effects, get new status effects
             this.RemoveSideEffects();
-            IEnumerator addStatusEffects = this.AddSideStatusEffect();
-            if (base.UseUnityCoroutines)
-            {
-                yield return base.GameController.StartCoroutine(addStatusEffects);
-            }
-            else
-            {
-                base.GameController.ExhaustCoroutine(addStatusEffects);
-
-            }
             yield break;
         }
 

--- a/Testing/Environments/StSimeonsCatacombsTests.cs
+++ b/Testing/Environments/StSimeonsCatacombsTests.cs
@@ -167,18 +167,18 @@ namespace CauldronTests
 
         }
 
-        [Test()]
-        public void TestCatacombsCantPlayCardsOnFront_FlippedBack()
-        {
-            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.StSimeonsCatacombs");
-            StartGame();
-            Card instructions = GetCard("StSimeonsCatacombsInstructions"); Card testCard = GetCard("CoalKid");
-            FlipCard(instructions);
-            FlipCard(instructions);
-            AssertNotFlipped(instructions);
-            AssertCannotPlayCards(catacombs, testCard);
+        //[Test()]
+        //public void TestCatacombsCantPlayCardsOnFront_FlippedBack()
+        //{
+        //    SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.StSimeonsCatacombs");
+        //    StartGame();
+        //    Card instructions = GetCard("StSimeonsCatacombsInstructions"); Card testCard = GetCard("CoalKid");
+        //    FlipCard(instructions);
+        //    FlipCard(instructions);
+        //    AssertNotFlipped(instructions);
+        //    AssertCannotPlayCards(catacombs, testCard);
 
-        }
+        //}
 
         [Test()]
         public void TestCatacombsCanPlayCardsOnBack()


### PR DESCRIPTION
…ped back to front

Sometimes, cards wouldn't play after being flipped - i think it has to do with this trigger. After some conversation in discord, I don't think we need this logic, as anything that flips other deck's cards arbirtarily is extremely game breaking
