### PR TITLE
Multi CharacterCard Support Improvements

### DIFF
--- a/Controller/Villains/Anathema/Cards/AnathemaRampageCardController.cs
+++ b/Controller/Villains/Anathema/Cards/AnathemaRampageCardController.cs
@@ -30,9 +30,19 @@ namespace Cauldron.Anathema
 			TurnTaker turnTaker = storedResults.FirstOrDefault();
 			if (turnTaker != null)
 			{
+				List<Card> results = new List<Card>();
+				coroutine = base.FindCharacterCardToTakeDamage(turnTaker, results, Card, base.H - 1, DamageType.Melee);
+				if (base.UseUnityCoroutines)
+				{
+					yield return base.GameController.StartCoroutine(coroutine);
+				}
+				else
+				{
+					base.GameController.ExhaustCoroutine(coroutine);
+				}
+
 				//Anathema deals the Hero target with the most cards in hand {H-1} melee damage.
-				HeroTurnTakerController hero = base.FindHeroTurnTakerController(turnTaker.ToHero());
-				IEnumerator coroutine2 = base.DealDamage(base.CharacterCard, hero.CharacterCard, base.H - 1, DamageType.Melee,cardSource: base.GetCardSource());
+				IEnumerator coroutine2 = base.DealDamage(base.CharacterCard, results.First(), base.H - 1, DamageType.Melee, cardSource: base.GetCardSource());
 				if (base.UseUnityCoroutines)
 				{
 					yield return base.GameController.StartCoroutine(coroutine2);

--- a/Controller/Villains/Anathema/Cards/EnhancedSensesCardController.cs
+++ b/Controller/Villains/Anathema/Cards/EnhancedSensesCardController.cs
@@ -2,6 +2,7 @@
 using Handelabra.Sentinels.Engine.Model;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Cauldron.Anathema
@@ -25,7 +26,18 @@ namespace Cauldron.Anathema
         private IEnumerator DealDamageResponse(PlayCardAction pc)
         {
 			//this card deals that Hero Character 1 sonic damage.
-			IEnumerator coroutine = base.DealDamage(base.Card, pc.CardToPlay.Owner.CharacterCard, 1, DamageType.Sonic, cardSource: base.GetCardSource());
+			List<Card> results = new List<Card>();
+			IEnumerator coroutine = base.FindCharacterCardToTakeDamage(pc.TurnTakerController.TurnTaker, results, Card, 1, DamageType.Sonic);
+			if (base.UseUnityCoroutines)
+			{
+				yield return base.GameController.StartCoroutine(coroutine);
+			}
+			else
+			{
+				base.GameController.ExhaustCoroutine(coroutine);
+			}
+
+			coroutine = base.DealDamage(base.Card, results.First(), 1, DamageType.Sonic, cardSource: base.GetCardSource());
 			if (base.UseUnityCoroutines)
 			{
 				yield return base.GameController.StartCoroutine(coroutine);

--- a/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
+++ b/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
@@ -1,6 +1,7 @@
 ﻿using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Cauldron.Gray
@@ -84,7 +85,7 @@ namespace Cauldron.Gray
             if (FindNumberOfHeroOngoingAndEquipmentInPlay() > 0)
             {
                 int? numberOfCards = new int?(1);
-                if(Game.IsAdvanced)
+                if (Game.IsAdvanced)
                 {
                     //Advanced - Whenever a radiation card is destroyed, destroy a second hero ongoing or equipment card.
                     numberOfCards = new int?(2);
@@ -169,19 +170,27 @@ namespace Cauldron.Gray
             //Whenever a radiation card is destroyed by a hero card, {Gray} deals that hero {H - 1} energy damage.
             IEnumerator coroutine;
             //if its not a hero destroying it do no damage
-            if (responsibleTurnTaker != null && responsibleTurnTaker.IsHero)
+            if (responsibleTurnTaker != null && responsibleTurnTaker.IsHero && !responsibleTurnTaker.IsIncapacitatedOrOutOfGame)
             {
-                if (responsibleTurnTaker.CharacterCard.IsInPlayAndHasGameText && !responsibleTurnTaker.CharacterCard.IsIncapacitatedOrOutOfGame)
+                List<Card> results = new List<Card>();
+                coroutine = base.FindCharacterCardToTakeDamage(responsibleTurnTaker, results, Card, Game.H - 1, DamageType.Energy);
+                if (base.UseUnityCoroutines)
                 {
-                    coroutine = base.DealDamage(base.Card, action.ResponsibleCard.Owner.CharacterCard, Game.H - 1, DamageType.Energy);
-                    if (base.UseUnityCoroutines)
-                    {
-                        yield return base.GameController.StartCoroutine(coroutine);
-                    }
-                    else
-                    {
-                        base.GameController.ExhaustCoroutine(coroutine);
-                    }
+                    yield return base.GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    base.GameController.ExhaustCoroutine(coroutine);
+                }
+
+                coroutine = base.DealDamage(base.Card, results.First(), Game.H - 1, DamageType.Energy);
+                if (base.UseUnityCoroutines)
+                {
+                    yield return base.GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    base.GameController.ExhaustCoroutine(coroutine);
                 }
             }
             //Whenever a copy of Radioactive Cascade is destroyed, {Gray} deals the hero with the highest HP {H - 1} energy damage.


### PR DESCRIPTION
While reviewing Owner.Deck references I found several cases where a Villain or Environment was dealing damage directly to Character car without checking for Multiple Character cards.

Added predicate call to FindCharacterCardToTakeDamage on Villain cards with hard coded calls to CharacterCard