### PR TITLE
Lady Of The Woods Thundergrey Ordering

### DIFF
--- a/Controller/Heroes/LadyOfTheWood/Cards/ThundergreyShawlCardController.cs
+++ b/Controller/Heroes/LadyOfTheWood/Cards/ThundergreyShawlCardController.cs
@@ -17,7 +17,7 @@ namespace Cauldron.LadyOfTheWood
 			ITrigger lateIrreducibleTrigger = new Trigger<DealDamageAction>(GameController,
 																(DealDamageAction dd) => dd.DamageSource.IsSameCard(base.CharacterCard) && dd.Amount <= 2,
 																RetroactiveIrreducibilityResponse,
-																new TriggerType[] { TriggerType.WouldBeDealtDamage },
+																new TriggerType[] { TriggerType.WouldBeDealtDamage, TriggerType.MakeDamageIrreducible },
 																TriggerTiming.Before,
 																GetCardSource(),
 																orderMatters: true);

--- a/Controller/Heroes/LadyOfTheWood/Cards/ThundergreyShawlCardController.cs
+++ b/Controller/Heroes/LadyOfTheWood/Cards/ThundergreyShawlCardController.cs
@@ -58,7 +58,17 @@ namespace Cauldron.LadyOfTheWood
 
 			foreach(ReduceDamageAction mod in reduceActions)
             {
-				coroutine = GameController.IncreaseDamage(dd, mod.AmountToReduce, cardSource: mod.CardSource);
+				IncreaseDamageAction restoreDamage = new IncreaseDamageAction(mod.CardSource, dd, mod.AmountToReduce, false);
+
+				//we do our best to make it have as little interaction as possible with things that respond to increasing damage
+				//since it's supposed to be retroactive undoing of damage decreases
+				restoreDamage.AllowTriggersToRespond = false;
+				restoreDamage.CanBeCancelled = false;
+
+				var wasUnincreasable = dd.IsUnincreasable;
+				dd.IsUnincreasable = false;
+
+				coroutine = GameController.DoAction(restoreDamage);
 				if (base.UseUnityCoroutines)
 				{
 					yield return GameController.StartCoroutine(coroutine);
@@ -67,6 +77,8 @@ namespace Cauldron.LadyOfTheWood
 				{
 					GameController.ExhaustCoroutine(coroutine);
 				}
+
+				dd.IsUnincreasable = wasUnincreasable;
             }
 			yield break;
         }

--- a/Testing/Heroes/LadyOfTheWoodTests.cs
+++ b/Testing/Heroes/LadyOfTheWoodTests.cs
@@ -1752,7 +1752,7 @@ namespace CauldronTests
             QuickHPStorage(baron);
             DealDamage(ladyOfTheWood, baron, 2, DamageType.Lightning);
             //because of suncast mantle, +3 damage, now 5
-            //it is not irreducible, so -5
+            //it is not irreducible, so -4 total
             QuickHPCheck(-4);
         }
         [Test()]
@@ -1783,7 +1783,34 @@ namespace CauldronTests
             QuickHPCheck(-3);
 
         }
+        [Test()]
+        public void TestThundergreyShawlWithUnincreasableDamage()
+        {
+            SetupGameController("BaronBladeTeam", "MissInformationTeam", "BugbearTeam", "Cauldron.LadyOfTheWood", "TheWraith", "TheSentinels", "Megalopolis");
 
+            StartGame();
+
+            //avoid having any of the starting card shenanigans mess things up
+            var villains = new List<TurnTakerController> { baronTeam, missinfoTeam, bugbearTeam };
+            foreach(TurnTakerController villain in villains)
+            {
+                PutOnDeck(villain, villain.TurnTaker.GetPlayAreaCards().Where((Card c) => !c.IsCharacter));
+            }
+
+            PlayCard("ThundergreyShawl");
+            PlayCard("StunBolt"); 
+            PlayCard("JudgeMental");
+
+            DecisionSelectTarget = ladyOfTheWood.CharacterCard;
+
+            //to give LOTW a putative "damage increase" from a hero card
+            UsePower("StunBolt");
+
+            QuickHPStorage(baronTeam);
+            DealDamage(ladyOfTheWood, baronTeam, 3, DamageType.Melee);
+
+            QuickHPCheck(-3);
+        }
         [Test()]
         public void TestWinter()
         {

--- a/Testing/Heroes/LadyOfTheWoodTests.cs
+++ b/Testing/Heroes/LadyOfTheWoodTests.cs
@@ -1755,6 +1755,34 @@ namespace CauldronTests
             //it is still irreducible, so -5
             QuickHPCheck(-5);
         }
+        [Test()]
+        public void TestThundergreyShawlIrreducibleOrdering()
+        {
+            //TGS should trigger if the damage totals to 2 or less, with boosts and reductions included
+            SetupGameController("Apostate", "Cauldron.LadyOfTheWood", "Legacy", "Haka", "Megalopolis");
+            StartGame();
+
+            Card sword = GetCardInPlay("Condemnation");
+            Card periapt = PlayCard("PeriaptOfWoe");
+
+            PlayCard("ThundergreyShawl");
+            PlayCard("Summer");
+            UsePower(legacy);
+
+            //total of +3 to fire damage
+
+            QuickHPStorage(sword);
+
+            DealDamage(ladyOfTheWood, sword, 1, DamageType.Fire);
+            DealDamage(ladyOfTheWood, periapt, 1, DamageType.Fire);
+
+            //1 damage +3 boost -2 DR = 2, so Shawl applies and Periapt takes the full 4
+            AssertInTrash(periapt);
+
+            //1 damage +3 boost -1 DR = 1, Shawl does not trigger and Condemnation takes 3
+            QuickHPCheck(-3);
+
+        }
 
         [Test()]
         public void TestWinter()

--- a/Testing/Heroes/LadyOfTheWoodTests.cs
+++ b/Testing/Heroes/LadyOfTheWoodTests.cs
@@ -1752,8 +1752,8 @@ namespace CauldronTests
             QuickHPStorage(baron);
             DealDamage(ladyOfTheWood, baron, 2, DamageType.Lightning);
             //because of suncast mantle, +3 damage, now 5
-            //it is still irreducible, so -5
-            QuickHPCheck(-5);
+            //it is not irreducible, so -5
+            QuickHPCheck(-4);
         }
         [Test()]
         public void TestThundergreyShawlIrreducibleOrdering()


### PR DESCRIPTION
Thundergrey Shawl is supposed to do one "damage check" after other modifiers have been applied, and then retroactively make the damage irreducible if needed. Unfortunately this check happens after the reduce damage actions have *already* changed the DamageAmount,  so we need to go back through the ModifyDamageAction list adding back in all the damage that was taken away. This probably looks awkward as heck in the UI, but I can't think of a better way to do it.