### PR TITLE
Proper implementation of Quicksilver's Malleable Armor

### DIFF
--- a/Controller/Heroes/Quicksilver/Cards/MalleableArmorCardController.cs
+++ b/Controller/Heroes/Quicksilver/Cards/MalleableArmorCardController.cs
@@ -8,8 +8,6 @@ namespace Cauldron.Quicksilver
 {
     public class MalleableArmorCardController : CardController
     {
-        private bool _primedToSaveSelf = false;
-
         public MalleableArmorCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             base.SpecialStringMaker.ShowSpecialString(() => Journal.DealDamageEntriesThisTurn().Where((DealDamageJournalEntry ddje) => ddje.SourceCard == this.CharacterCard && ddje.Amount > 0).Any() ? "Quicksilver has dealt damage this turn." : "Quicksilver has not dealt damage this turn.");

--- a/Controller/Heroes/Quicksilver/Cards/MalleableArmorCardController.cs
+++ b/Controller/Heroes/Quicksilver/Cards/MalleableArmorCardController.cs
@@ -8,6 +8,8 @@ namespace Cauldron.Quicksilver
 {
     public class MalleableArmorCardController : CardController
     {
+        private bool _primedToSaveSelf = false;
+
         public MalleableArmorCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             base.SpecialStringMaker.ShowSpecialString(() => Journal.DealDamageEntriesThisTurn().Where((DealDamageJournalEntry ddje) => ddje.SourceCard == this.CharacterCard && ddje.Amount > 0).Any() ? "Quicksilver has dealt damage this turn." : "Quicksilver has not dealt damage this turn.");
@@ -42,7 +44,17 @@ namespace Cauldron.Quicksilver
         }
         public override void AddTriggers()
         {
-            //If {Quicksilver} would be reduced from greater than 1 HP to 0 or fewer HP...
+			//If {Quicksilver} would be reduced from greater than 1 HP to 0 or fewer HP...
+
+			//The default "AddWhenHPDropsToZeroOrBelowRestoreHPTriggers" doesn't let you put a criterion on the restore
+			//So I'll have to roll my own.
+
+			AddTrigger((DestroyCardAction dc) => dc.CardToDestroy.Card == this.CharacterCard && this.CharacterCard.HitPoints <= 0 && HitPointsBeforeMostRecentDamage > 1,
+						(DestroyCardAction dc) => PreventDestroyAndRestoreHitPointsResponse(dc, this.CharacterCard, null, 1, false, false, false),
+						new TriggerType[] { TriggerType.CancelAction },
+						TriggerTiming.Before);
+
+			/*
             base.AddTrigger<DealDamageAction>(delegate (DealDamageAction action)
             {
                 if (action.Target == base.CharacterCard && base.CharacterCard.HitPoints > 1)
@@ -57,6 +69,7 @@ namespace Cauldron.Quicksilver
                 TriggerType.WouldBeDealtDamage,
                 TriggerType.GainHP
             }, TriggerTiming.Before);
+			*/
         }
 
         private IEnumerator DealDamageResponse(DealDamageAction action)
@@ -66,6 +79,101 @@ namespace Cauldron.Quicksilver
             //...restore her to 1HP.
             base.CharacterCard.SetHitPoints(action.Amount + 1);
             yield break;
+        }
+
+		//copy-pasted from ILSpy
+		private IEnumerator PreventDestroyAndRestoreHitPointsResponse(GameAction action, Card cardThatGetsRestored, Func<GameAction, IEnumerator> runBeforeRestore, int numberOfHitPoints, bool destroyAfterwards, bool addToHPInsteadOfSet, bool onlyOncePerGame)
+		{
+			DestroyCardAction destroyCardAction = null;
+			DealDamageAction dealDamageAction = null;
+			if (action is DealDamageAction)
+			{
+				dealDamageAction = action as DealDamageAction;
+			}
+			if (action is DestroyCardAction)
+			{
+				destroyCardAction = action as DestroyCardAction;
+				if (destroyCardAction.ActionSource is DealDamageAction)
+				{
+					dealDamageAction = destroyCardAction.ActionSource as DealDamageAction;
+				}
+			}
+			if (numberOfHitPoints > 0)
+			{
+				if (onlyOncePerGame)
+				{
+					SetCardPropertyToTrueIfRealAction("OnlyRestoredHitPointsOncePerGame");
+				}
+				if ((destroyCardAction != null && destroyCardAction.CardToDestroy.Card == cardThatGetsRestored) || (dealDamageAction != null && dealDamageAction.Target == cardThatGetsRestored))
+				{
+					IEnumerator coroutine = CancelAction(action);
+					if (UseUnityCoroutines)
+					{
+						yield return GameController.StartCoroutine(coroutine);
+					}
+					else
+					{
+						GameController.ExhaustCoroutine(coroutine);
+					}
+				}
+				if (runBeforeRestore != null)
+				{
+					if (UseUnityCoroutines)
+					{
+						yield return GameController.StartCoroutine(runBeforeRestore(action));
+					}
+					else
+					{
+						GameController.ExhaustCoroutine(runBeforeRestore(action));
+					}
+				}
+				IEnumerator coroutine2;
+				if (addToHPInsteadOfSet)
+				{
+					coroutine2 = GameController.GainHP(cardThatGetsRestored, numberOfHitPoints, null, null, GetCardSource());
+				}
+				else
+				{
+					if (cardThatGetsRestored.MaximumHitPoints.HasValue)
+					{
+						numberOfHitPoints = Math.Min(numberOfHitPoints, cardThatGetsRestored.MaximumHitPoints.Value);
+					}
+					coroutine2 = GameController.SetHP(cardThatGetsRestored, numberOfHitPoints, GetCardSource());
+				}
+				if (UseUnityCoroutines)
+				{
+					yield return GameController.StartCoroutine(coroutine2);
+				}
+				else
+				{
+					GameController.ExhaustCoroutine(coroutine2);
+				}
+			}
+			if (destroyAfterwards)
+			{
+				IEnumerator coroutine3 = GameController.DestroyCard(DecisionMaker, Card, optional: false, null, null, null, null, null, null, null, null, GetCardSource());
+				if (UseUnityCoroutines)
+				{
+					yield return GameController.StartCoroutine(coroutine3);
+				}
+				else
+				{
+					GameController.ExhaustCoroutine(coroutine3);
+				}
+			}
+		}
+
+		private int HitPointsBeforeMostRecentDamage
+        {
+            get
+            {
+                DealDamageJournalEntry lastDamage = Journal.MostRecentDealDamageEntry((DealDamageJournalEntry dc) => dc.TargetCard == base.CharacterCard);
+                if (lastDamage != null && lastDamage.TargetCardsHitPointsAfterDamage != null)
+                {
+                    return lastDamage.Amount + (int)lastDamage.TargetCardsHitPointsAfterDamage;
+                }
+                return 0;
+            }
         }
     }
 }

--- a/Testing/Heroes/QuicksilverTests.cs
+++ b/Testing/Heroes/QuicksilverTests.cs
@@ -607,6 +607,22 @@ namespace CauldronTests
             DealDamage(apostate, quicksilver, 30, DamageType.Infernal);
             AssertHitPoints(quicksilver.CharacterCard, 1);
         }
+        [Test]
+        public void TestMalleableArmorWithRedirect()
+        {
+            SetupGameController("Apostate", "Cauldron.Quicksilver", "Legacy", "TheScholar", "RookCity");
+            StartGame();
+
+            //If {Quicksilver} would be reduced from greater than 1 HP to 0 or fewer HP, restore her to 1HP.
+            PlayCard("MalleableArmor");
+
+            PlayCard("AlchemicalRedirection");
+
+            SetHitPoints(quicksilver, 5);
+
+            DealDamage(apostate, quicksilver, 10, DamageType.Infernal);
+            AssertHitPoints(quicksilver.CharacterCard, 5);
+        }
 
         [Test]
         public void TestMalleableArmorDoesNotModifyDamageAmount()


### PR DESCRIPTION
The old version worked by setting Quicksilver's HP high enough to survive just before the blow hit, which ended up causing problems when it got redirected away from her at the last moment (she'd keep the boosted HP).

Now implemented by preventing the no-HP destruction and properly restoring her to 1HP.