### PR TITLE
General - DestroyCardAction extension methods and cleanup

### DIFF
--- a/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalcyonCleanersCardController.cs
+++ b/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalcyonCleanersCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.HalberdExperimentalResearchCenter
 
             //Whenever this card destroys a Test Subject, play the top card of the environment deck.
             //criteria for this card destroying a test subject
-            Func<DestroyCardAction, bool> destroyCriteria = (DestroyCardAction destroy) => destroy.CardToDestroy != null && base.IsTestSubject(destroy.CardToDestroy.Card) && destroy.CardSource != null && destroy.CardSource.Card == base.Card;
+            Func<DestroyCardAction, bool> destroyCriteria = (DestroyCardAction destroy) => destroy.CardToDestroy != null && base.IsTestSubject(destroy.CardToDestroy.Card) && destroy.GetCardDestroyer() == base.Card;
             //When a card is destroyed that matches the above criteria, play the top card of the environment deck
             base.AddTrigger<DestroyCardAction>(destroyCriteria, PlayTheTopCardOfTheEnvironmentDeckWithMessageResponse, TriggerType.PlayCard, TriggerTiming.After);
         }

--- a/Controller/Environments/Northspar/Cards/AethiumVeinCardController.cs
+++ b/Controller/Environments/Northspar/Cards/AethiumVeinCardController.cs
@@ -18,7 +18,7 @@ namespace Cauldron.Northspar
         public override void AddTriggers()
         {
             //If this card is destroyed by a hero card and Tak Ahab is in play, place the top card of the villain deck beneath him.
-            Func<DestroyCardAction, bool> criteria = (DestroyCardAction dca) => dca.CardSource != null && dca.CardSource.Card.IsHero && base.IsTakAhabInPlay();
+            Func<DestroyCardAction, bool> criteria = (DestroyCardAction dca) => dca.WasDestroyedBy(c =>c.IsHero) && base.IsTakAhabInPlay();
             base.AddWhenDestroyedTrigger(this.WhenDestroyedResponse, new TriggerType[] { TriggerType.MoveCard }, criteria);
 
             //At the start of the environment turn, destroy this card and Tak Ahab's end of turn effect acts twice this turn.

--- a/Controller/ExtensionMethods.cs
+++ b/Controller/ExtensionMethods.cs
@@ -1,0 +1,30 @@
+﻿using Handelabra.Sentinels.Engine.Controller;
+using Handelabra.Sentinels.Engine.Model;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace Cauldron
+{
+    public static class ExtensionMethods
+    {
+        public static Card GetCardDestroyer(this DestroyCardAction action)
+        {
+            if (action.ResponsibleCard != null)
+                return action.ResponsibleCard;
+            if (action.CardSource != null)
+                return action.CardSource.Card;
+
+            return null;
+        }
+
+        public static bool WasDestroyedBy(this DestroyCardAction action, Func<Card, bool> criteria)
+        {
+            var card = GetCardDestroyer(action);
+            return criteria(card);
+        }
+
+    }
+}

--- a/Controller/Heroes/LadyOfTheWood/Cards/LadyOfTheWoodsRebirthCardController.cs
+++ b/Controller/Heroes/LadyOfTheWood/Cards/LadyOfTheWoodsRebirthCardController.cs
@@ -50,7 +50,7 @@ namespace Cauldron.LadyOfTheWood
 		public override void AddTriggers()
 		{
 			//Whenever LadyOfTheWood destroys a target, put a card from beneath this one into your hand.
-			Func<DestroyCardAction, bool> moveCriteria = (DestroyCardAction destroy) => destroy.CardSource != null && destroy.CardToDestroy.CanBeDestroyed && destroy.WasCardDestroyed && destroy.CardSource.Card.Owner == base.TurnTaker && destroy.CardToDestroy.Card.IsTarget;
+			Func<DestroyCardAction, bool> moveCriteria = (DestroyCardAction dca) => dca.GetCardDestroyer()?.Owner == base.TurnTaker && dca.CardToDestroy.CanBeDestroyed && dca.WasCardDestroyed  && dca.CardToDestroy.Card.IsTarget;
 			base.AddTrigger<DestroyCardAction>(moveCriteria, new Func<DestroyCardAction, IEnumerator>(this.MoveCardResponse), new TriggerType[] { TriggerType.MoveCard }, TriggerTiming.After);
 
 			//When there are no cards beneath this one, destroy this card.

--- a/Controller/Heroes/TangoOne/Cards/LineEmUpCardController.cs
+++ b/Controller/Heroes/TangoOne/Cards/LineEmUpCardController.cs
@@ -25,11 +25,7 @@ namespace Cauldron.TangoOne
         private bool LineEmUpTriggerCondition(DestroyCardAction destroyCard)
         {
             return destroyCard.WasCardDestroyed &&
-                    base.GameController.IsCardVisibleToCardSource(destroyCard.CardToDestroy.Card, base.GetCardSource()) &&
-                    (
-                        (destroyCard.ResponsibleCard != null && destroyCard.ResponsibleCard.Owner == this.TurnTaker) ||
-                        (destroyCard.CardSource != null && destroyCard.CardSource.Card != null && destroyCard.CardSource.Card.Owner == this.TurnTaker)
-                    );
+                    base.GameController.IsCardVisibleToCardSource(destroyCard.CardToDestroy.Card, base.GetCardSource()) && destroyCard.GetCardDestroyer()?.Owner == this.TurnTaker;
         }
 
         public override void AddTriggers()

--- a/Controller/Villains/Anathema/Cards/BiofeedbackCardController.cs
+++ b/Controller/Villains/Anathema/Cards/BiofeedbackCardController.cs
@@ -21,7 +21,7 @@ namespace Cauldron.Anathema
             base.AddTrigger<DealDamageAction>(damageCriteria, this.DealDamageResponse, TriggerType.GainHP, TriggerTiming.After);
 
             //Whenever an arm, body, or head is destroyed by a Hero target, Anathema deals himself 2 psychic damage.
-            Func<DestroyCardAction, bool> destroyCriteria = (DestroyCardAction dca) => dca.CardToDestroy != null && base.IsArmHeadOrBody(dca.CardToDestroy.Card) && dca.CardSource != null && dca.CardSource.Card.IsTarget && dca.CardSource.Card.IsHero;
+            Func<DestroyCardAction, bool> destroyCriteria = (DestroyCardAction dca) => dca.CardToDestroy != null && base.IsArmHeadOrBody(dca.CardToDestroy.Card) && dca.WasDestroyedBy(c => c.IsTarget && c.IsHero);
             base.AddTrigger<DestroyCardAction>(destroyCriteria, this.DestroyCardResponse, TriggerType.DealDamage, TriggerTiming.After);
         }
 

--- a/Controller/Villains/Anathema/CharacterCards/AnathemaCharacterCardController.cs
+++ b/Controller/Villains/Anathema/CharacterCards/AnathemaCharacterCardController.cs
@@ -58,8 +58,7 @@ namespace Cauldron.Anathema
 				base.AddSideTrigger(base.AddTrigger<DestroyCardAction>((DestroyCardAction destroyCard) => destroyCard.WasCardDestroyed 
 						&& this.IsArmHeadOrBody(destroyCard.CardToDestroy.Card) 
 						&& base.GameController.IsCardVisibleToCardSource(destroyCard.CardToDestroy.Card, this.GetCardSource())
-						&& destroyCard.CardSource != null
-						&& base.IsVillain(destroyCard.CardSource.Card),
+						&& destroyCard.WasDestroyedBy(c => IsVillain(c)),
 					new Func<DestroyCardAction, IEnumerator>(this.GainHpResponse), TriggerType.GainHP, TriggerTiming.After));
 				
 				if (base.IsGameAdvanced)

--- a/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
+++ b/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
@@ -37,6 +37,7 @@ namespace Cauldron.Gray
                 //Whenever a radiation card is destroyed by a hero card, {Gray} deals that hero {H - 1} energy damage.
                 //Whenever a copy of Radioactive Cascade is destroyed, {Gray} deals the hero with the highest HP {H - 1} energy damage.
                 base.AddSideTrigger(base.AddTrigger<DestroyCardAction>((DestroyCardAction action) => action.WasCardDestroyed && action.CardToDestroy.Card.DoKeywordsContain("radiation"), this.DestroyRadiationBackResponse, TriggerType.DealDamage, TriggerTiming.After));
+                
                 //Advanced - Reduce damage dealt to villain targets by 1.
                 if (Game.IsAdvanced)
                 {
@@ -158,15 +159,9 @@ namespace Cauldron.Gray
 
         private IEnumerator DestroyRadiationBackResponse(DestroyCardAction action)
         {
-            TurnTaker responsibleTurnTaker;
-            if (action.ResponsibleCard != null)
-            {
-                responsibleTurnTaker = action.ResponsibleCard.Owner;
-            }
-            else
-            {
-                responsibleTurnTaker = base.TurnTaker;
-            }
+            Card source = action.GetCardDestroyer();
+            TurnTaker responsibleTurnTaker = source?.Owner;
+
             //Whenever a radiation card is destroyed by a hero card, {Gray} deals that hero {H - 1} energy damage.
             IEnumerator coroutine;
             //if its not a hero destroying it do no damage

--- a/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
+++ b/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
@@ -1125,6 +1125,36 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestHalcyonCleanersTestSubjectKilledByCleaner()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Tachyon", "Cauldron.HalberdExperimentalResearchCenter");
+            StartGame();
+
+            GoToPlayCardPhase(halberd);
+
+            //we play out cleaner
+            Card cleaner = GetCard("HalcyonCleaners");
+            PlayCard(cleaner);
+            AssertIsInPlay(cleaner);
+
+            //play alpha to have a subject to destroy
+            Card alpha = GetCard("HalberdAlpha");
+            PlayCard(alpha);
+            AssertIsInPlay(alpha);
+
+            //stack deck with omega
+            Card omega = GetCard("HalberdOmega");
+            PutOnDeck(halberd, omega);
+            AssertInDeck(omega);
+
+            //Whenever this card destroys a Test Subject, play the top card of the environment deck.
+            DealDamage(cleaner, alpha, 99, DamageType.Cold);
+            //alpha should have been destroyed, causing omega to be played from the top of the environment deck
+            AssertInTrash(alpha);
+            AssertIsInPlay(omega);
+        }
+
+        [Test()]
         public void TestHalcyonCleanersTestSubjectDestroyedByNotCleaner()
         {
             SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Tachyon", "Cauldron.HalberdExperimentalResearchCenter");
@@ -1149,6 +1179,37 @@ namespace CauldronTests
 
             //Whenever this card destroys a Test Subject, play the top card of the environment deck.
             DestroyCard(alpha, baron.CharacterCard);
+            //alpha should have been destroyed, but since it was done by baron, no cards should be played
+            AssertInTrash(alpha);
+            AssertInDeck(omega);
+        }
+
+
+        [Test()]
+        public void TestHalcyonCleanersTestSubjectKilledByNotCleaner()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Tachyon", "Cauldron.HalberdExperimentalResearchCenter");
+            StartGame();
+
+            GoToPlayCardPhase(halberd);
+
+            //we play out cleaner
+            Card cleaner = GetCard("HalcyonCleaners");
+            PlayCard(cleaner);
+            AssertIsInPlay(cleaner);
+
+            //play alpha to have a subject to destroy
+            Card alpha = GetCard("HalberdAlpha");
+            PlayCard(alpha);
+            AssertIsInPlay(alpha);
+
+            //stack deck with omega
+            Card omega = GetCard("HalberdOmega");
+            PutOnDeck(halberd, omega);
+            AssertInDeck(omega);
+
+            //Whenever this card destroys a Test Subject, play the top card of the environment deck.
+            DealDamage(baron.CharacterCard, alpha, 99, DamageType.Cold);
             //alpha should have been destroyed, but since it was done by baron, no cards should be played
             AssertInTrash(alpha);
             AssertInDeck(omega);

--- a/Testing/Environments/NorthsparTests.cs
+++ b/Testing/Environments/NorthsparTests.cs
@@ -109,7 +109,7 @@ namespace CauldronTests
 
         [Test()]
         [Sequential]
-        public void DecklistTest_Frozen_IsFrozen([Values("LostInTheSnow", "RagingBlizzard", "Frostbite", "SnowShrieker", "FrozenSolid","WhatsLeftOfThem", "BitterCold" )] string frozen)
+        public void DecklistTest_Frozen_IsFrozen([Values("LostInTheSnow", "RagingBlizzard", "Frostbite", "SnowShrieker", "FrozenSolid", "WhatsLeftOfThem", "BitterCold")] string frozen)
         {
             SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.Northspar");
             StartGame();
@@ -423,7 +423,7 @@ namespace CauldronTests
             StartGame();
 
             Card makeshift = PlayCard("MakeshiftShelter");
-            
+
             Card bitter = PutInTrash("BitterCold");
             //At the start of the environment turn, you may shuffle a card from the environment trash into the deck. if Tak Ahab is in the environment trash, shuffle him into the deck."
             DecisionYesNo = true;
@@ -515,7 +515,7 @@ namespace CauldronTests
             Card supply = PlayCard("SupplyDepot");
             AssertInPlayArea(northspar, bitter);
             AssertInTrash(supply);
-        
+
         }
 
         [Test()]
@@ -590,11 +590,11 @@ namespace CauldronTests
             AssertOnTopOfDeck(northsparTop);
 
             //grab new top cards  for when we will move all cards from under him later
-           baronTop = baron.TurnTaker.Deck.TopCard;
-           raTop = ra.TurnTaker.Deck.TopCard;
-           legacyTop = legacy.TurnTaker.Deck.TopCard;
-           hakaTop = haka.TurnTaker.Deck.TopCard;
-           northsparTop = northspar.TurnTaker.Deck.TopCard;
+            baronTop = baron.TurnTaker.Deck.TopCard;
+            raTop = ra.TurnTaker.Deck.TopCard;
+            legacyTop = legacy.TurnTaker.Deck.TopCard;
+            hakaTop = haka.TurnTaker.Deck.TopCard;
+            northsparTop = northspar.TurnTaker.Deck.TopCard;
 
             MoveAllCards(northspar, takAhab.UnderLocation, northspar.TurnTaker.Trash);
 
@@ -686,8 +686,24 @@ namespace CauldronTests
             Card takAhab = PlayCard("TakAhab");
             AssertOnTopOfDeck(villainTopCard);
             //    If this card is destroyed by a hero card and Tak Ahab is in play, place the top card of the villain deck beneath him.",
-            
+
             DestroyCard(vein, ra.CharacterCard);
+            AssertUnderCard(takAhab, villainTopCard);
+        }
+
+        [Test()]
+        public void TestAethiumVein_KilledByHero_TakAhabInPlay()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.Northspar");
+            StartGame();
+
+            Card vein = PlayCard("AethiumVein");
+            Card villainTopCard = baron.TurnTaker.Deck.TopCard;
+            Card takAhab = PlayCard("TakAhab");
+            AssertOnTopOfDeck(villainTopCard);
+            //    If this card is destroyed by a hero card and Tak Ahab is in play, place the top card of the villain deck beneath him.",
+
+            DealDamage(ra.CharacterCard, vein, 99, DamageType.Energy);
             AssertUnderCard(takAhab, villainTopCard);
         }
 
@@ -708,6 +724,22 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestAethiumVein_KilledByNonHero_TakAhabInPlay()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.Northspar");
+            StartGame();
+
+            Card vein = PlayCard("AethiumVein");
+            Card villainTopCard = baron.TurnTaker.Deck.TopCard;
+            Card takAhab = PlayCard("TakAhab");
+            AssertOnTopOfDeck(villainTopCard);
+            //    If this card is destroyed by a hero card and Tak Ahab is in play, place the top card of the villain deck beneath him.",
+
+            DealDamage(baron.CharacterCard, vein, 99, DamageType.Energy);
+            AssertOnTopOfDeck(villainTopCard);
+        }
+
+        [Test()]
         public void TestAethiumVein_DestroyedByHero_TakAhabNotInPlay()
         {
             SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.Northspar");
@@ -718,6 +750,20 @@ namespace CauldronTests
             AssertOnTopOfDeck(villainTopCard);
             //  If this card is destroyed by a hero card and Tak Ahab is in play, place the top card of the villain deck beneath him.
             DestroyCard(vein, ra.CharacterCard);
+            AssertOnTopOfDeck(villainTopCard);
+        }
+
+        [Test()]
+        public void TestAethiumVein_KilledByHero_TakAhabNotInPlay()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.Northspar");
+            StartGame();
+
+            Card vein = PlayCard("AethiumVein");
+            Card villainTopCard = baron.TurnTaker.Deck.TopCard;
+            AssertOnTopOfDeck(villainTopCard);
+            //  If this card is destroyed by a hero card and Tak Ahab is in play, place the top card of the villain deck beneath him.
+            DealDamage(ra.CharacterCard, vein, 99, DamageType.Energy);
             AssertOnTopOfDeck(villainTopCard);
         }
 
@@ -980,8 +1026,8 @@ namespace CauldronTests
             AssertInTrash(eerie);
 
         }
-        
-         [Test()]
+
+        [Test()]
         public void TestFrostbite_EndOfTurn()
         {
             SetupGameController("BaronBlade", "Ra", "Legacy", "AbsoluteZero", "Cauldron.Northspar");
@@ -1265,7 +1311,7 @@ namespace CauldronTests
             //there are 4 frozen cards
             QuickShuffleStorage(northspar);
             GoToEndOfTurn(northspar);
-            if(FindCardsWhere((Card c) => IsFrozen(c) && northspar.TurnTaker.Trash.Cards.Contains(c) && c != ragingBlizzard).Count() == 2)
+            if (FindCardsWhere((Card c) => IsFrozen(c) && northspar.TurnTaker.Trash.Cards.Contains(c) && c != ragingBlizzard).Count() == 2)
             {
                 AssertNumberOfCardsInTrash(northspar, 3);
 

--- a/Testing/Heroes/LadyOfTheWoodTests.cs
+++ b/Testing/Heroes/LadyOfTheWoodTests.cs
@@ -1174,7 +1174,7 @@ namespace CauldronTests
         }
 
         [Test()]
-        public void TestRebirthMoveCardToHand()
+        public void TestRebirthMoveCardToHandByDestroy()
         {
             SetupGameController("BaronBlade", "Cauldron.LadyOfTheWood", "Ra", "Haka", "Megalopolis");
             StartGame();
@@ -1205,6 +1205,45 @@ namespace CauldronTests
             QuickHandStorage(ladyOfTheWood);
             //have lady of the wood destroy mdp
             DestroyCard(battalion, haka.CharacterCard);
+            //nothing should have been moved to hand
+            QuickHandCheck(0);
+            AssertNumberOfCardsUnderCard(rebirth, 2);
+            AssertUnderCard(rebirth, spring);
+            AssertUnderCard(rebirth, fall);
+        }
+
+
+        [Test()]
+        public void TestRebirthMoveCardToHandByDamage()
+        {
+            SetupGameController("BaronBlade", "Cauldron.LadyOfTheWood", "Ra", "Haka", "Megalopolis");
+            StartGame();
+
+            Card mdp = GetCardInPlay("MobileDefensePlatform");
+            Card battalion = PlayCard("BladeBattalion");
+
+            //stack trash
+            Card spring = PutInTrash("Spring");
+            Card fall = PutInTrash("Fall");
+            Card summer = PutInTrash("Summer");
+
+            //Whenever LadyOfTheWood destroys a target, put a card from beneath this one into your hand.
+            DecisionSelectCards = new Card[] { spring, fall, summer, summer };
+            Card rebirth = PlayCard("LadyOfTheWoodsRebirth");
+
+            QuickHandStorage(ladyOfTheWood);
+            //have lady of the wood destroy mdp
+            DealDamage(ladyOfTheWood.CharacterCard, mdp, 99, DamageType.Psychic);
+            //summer should have been moved to hand
+            QuickHandCheck(1);
+            AssertNumberOfCardsUnderCard(rebirth, 2);
+            AssertUnderCard(rebirth, spring);
+            AssertUnderCard(rebirth, fall);
+            AssertInHand(summer);
+
+            //check doesn't move when another hero destroys a target
+            QuickHandStorage(ladyOfTheWood);
+            DealDamage(haka.CharacterCard, battalion, 99, DamageType.Infernal);
             //nothing should have been moved to hand
             QuickHandCheck(0);
             AssertNumberOfCardsUnderCard(rebirth, 2);

--- a/Testing/Villains/AnathemaTests.cs
+++ b/Testing/Villains/AnathemaTests.cs
@@ -260,6 +260,62 @@ namespace CauldronTests
             QuickHPCheck(2);
         }
 
+
+        [Test()]
+        public void TestAnathemaGainsHPWhenVillainKillsArm()
+        {
+            SetupGameController("Cauldron.Anathema", "Ra", "Megalopolis");
+
+            StartGame();
+
+            //set anathema hp to 30 to give room to heal
+            SetHitPoints(anathema.CharacterCard, 30);
+            QuickHPStorage(anathema);
+
+            List<Card> arms = GetListOfArmsInPlay(anathema);
+            //have anathema destroy the arm to trigger healing
+            DealDamage(anathema.CharacterCard, arms[0], 99, DamageType.Psychic);
+
+            QuickHPCheck(2);
+        }
+
+        [Test()]
+        public void TestAnathemaGainsHPWhenVillainKillsBody()
+        {
+            SetupGameController("Cauldron.Anathema", "Ra", "Megalopolis");
+
+            StartGame();
+
+            //set anathema hp to 30 to give room to heal
+            SetHitPoints(anathema.CharacterCard, 30);
+            QuickHPStorage(anathema);
+
+            List<Card> body = GetListOfBodyInPlay(anathema);
+            //have anathema destroy the body to trigger healing
+            DealDamage(anathema.CharacterCard, body[0], 99, DamageType.Psychic);
+
+            QuickHPCheck(2);
+        }
+
+        [Test()]
+        public void TestAnathemaGainsHPWhenVillainKillsHead()
+        {
+            SetupGameController("Cauldron.Anathema", "Ra", "Megalopolis");
+
+            StartGame();
+
+            //set anathema hp to 30 to give room to heal
+            SetHitPoints(anathema.CharacterCard, 30);
+            QuickHPStorage(anathema);
+
+            List<Card> heads = GetListOfHeadsInPlay(anathema);
+            //have anathema destroy the head to trigger healing
+            DealDamage(anathema.CharacterCard, heads[0], 99, DamageType.Psychic);
+
+            QuickHPCheck(2);
+        }
+
+
         [Test()]
         public void TestAnathemaFlipsWhen0VillainTargets()
         {

--- a/Testing/Villains/AnathemaTests.cs
+++ b/Testing/Villains/AnathemaTests.cs
@@ -1307,16 +1307,21 @@ namespace CauldronTests
             GoToPlayCardPhase(anathema);
 
             //put an arm in play to test effect
-            PlayCard("KnuckleDragger");
+            var knuckle = PlayCard("KnuckleDragger");
 
             //put biofeedback in play
             PutIntoPlay("Biofeedback");
 
             //Whenever an arm, body, or head is destroyed by a Hero target, Anathema deals himself 2 psychic damage.
             QuickHPStorage(anathema);
-            DestroyCard(GetListOfArmsInPlay(anathema)[0], ra.CharacterCard);
+            DestroyCard(knuckle, ra.CharacterCard);
             QuickHPCheck(-2);
 
+            //reset and test with damage.
+            PlayCard(knuckle);
+            QuickHPStorage(anathema);
+            DealDamage(ra.CharacterCard, knuckle, 99, DamageType.Fire, true);
+            QuickHPCheck(-2);
 
         }
 

--- a/Testing/Villains/GrayTests.cs
+++ b/Testing/Villains/GrayTests.cs
@@ -279,13 +279,21 @@ namespace CauldronTests
         {
             SetupGameController(new string[] { "Cauldron.Gray", "Legacy", "Unity", "Ra", "TimeCataclysm" });
             StartGame();
+            var reaction = GetCardInPlay("ChainReaction");
             FlipCard(gray);
             Card bot = GetCard("RaptorBot");
             PlayCard(bot);
             //Whenever a radiation card is destroyed by a hero card, {Gray} deals that hero {H - 1} energy damage.
             QuickHPStorage(legacy, ra, unity);
-            DealDamage(bot, GetCardInPlay("ChainReaction"), 3, DamageType.Melee);
-            AssertInTrash("ChainReaction");
+            DealDamage(bot, reaction, 3, DamageType.Melee);
+            AssertInTrash(reaction);
+            QuickHPCheck(0, 0, -2);
+
+            //reset and test a destroy effect
+            PlayCard(reaction);
+            QuickHPStorage(legacy, ra, unity);
+            DestroyCard(reaction, bot);
+            AssertInTrash(reaction);
             QuickHPCheck(0, 0, -2);
         }
 


### PR DESCRIPTION
Triggers based on Destroy Card Actions that have conditions base on the Card/TurnTaker that destroyed the card all need to have the conditions revised to support both Damage Based destruction and Destroy effect based destruction.  I ran into the problem first with TangoOne's LineEmUp, and this is the same basic issue.

The conditions are just complicated enough that my preferred solution is to add utility extension methods for the conditions, but I want to make sure everybody's comfortable with the solution before I apply it across a half dozen cards.