### PR TITLE
Add a Y/N prompt when Halberd 06 Foamcore is ambiguous

### DIFF
--- a/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdEtherCardController.cs
+++ b/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdEtherCardController.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 
@@ -6,6 +9,24 @@ namespace Cauldron.HalberdExperimentalResearchCenter
 {
     public class HalberdEtherCardController : TestSubjectCardController
     {
+        public override bool AllowFastCoroutinesDuringPretend
+        {
+            get
+            {
+                if (!base.GameController.PreviewMode)
+                {
+                    return IsHighestHitPointsUnique((Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndHasGameText);
+                }
+                return true;
+            }
+        }
+
+        private bool? PerformIncrease
+        {
+            get;
+            set;
+        }
+
         #region Constructors
 
         public HalberdEtherCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
@@ -31,7 +52,41 @@ namespace Cauldron.HalberdExperimentalResearchCenter
             base.AddIncreaseDamageTrigger(villainCriteria, 1);
 
             //increase damage dealt by hero targets by 1 if no chemical trigger is in play
-            base.AddIncreaseDamageTrigger(heroCriteria, 1);
+            base.AddTrigger<DealDamageAction>(heroCriteria, MaybeIncreaseDamageByHeroTargetResponse, TriggerType.IncreaseDamage, TriggerTiming.Before);
+        }
+
+        private IEnumerator MaybeIncreaseDamageByHeroTargetResponse(DealDamageAction dd)
+        {
+            if (base.GameController.PretendMode)
+            {
+                List<bool> storedResults = new List<bool>();
+                IEnumerator coroutine = base.DetermineIfGivenCardIsTargetWithLowestOrHighestHitPoints(dd.DamageSource.Card, highest: true, (Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndHasGameText, dd, storedResults);
+                if (base.UseUnityCoroutines)
+                {
+                    yield return base.GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    base.GameController.ExhaustCoroutine(coroutine);
+                }
+                PerformIncrease = storedResults.Count() > 0 && storedResults.First();
+            }
+            if (PerformIncrease.HasValue && PerformIncrease.Value)
+            {
+                IEnumerator coroutine2 = base.GameController.IncreaseDamage(dd, 1, cardSource: base.GetCardSource());
+                if (base.UseUnityCoroutines)
+                {
+                    yield return base.GameController.StartCoroutine(coroutine2);
+                }
+                else
+                {
+                    base.GameController.ExhaustCoroutine(coroutine2);
+                }
+            }
+            if (!base.GameController.PretendMode)
+            {
+                PerformIncrease = null;
+            }
         }
         #endregion Methods
     }

--- a/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdEtherCardController.cs
+++ b/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdEtherCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.HalberdExperimentalResearchCenter
 
         public HalberdEtherCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-
+            base.SpecialStringMaker.ShowHeroTargetWithHighestHP();
         }
 
         #endregion Constructors

--- a/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdFoamcoreCardController.cs
+++ b/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdFoamcoreCardController.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 
@@ -6,6 +9,26 @@ namespace Cauldron.HalberdExperimentalResearchCenter
 {
     public class HalberdFoamcoreCardController : TestSubjectCardController
     {
+        private ITrigger _reduceDamageTrigger;
+
+        public override bool AllowFastCoroutinesDuringPretend
+        {
+            get
+            {
+                if (!base.GameController.PreviewMode)
+                {
+                    return IsLowestHitPointsUnique((Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndHasGameText);
+                }
+                return true;
+            }
+        }
+
+        private bool? PerformReduction
+        {
+            get;
+            set;
+        }
+
         #region Constructors
 
         public HalberdFoamcoreCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
@@ -25,9 +48,43 @@ namespace Cauldron.HalberdExperimentalResearchCenter
             Func<DealDamageAction, bool> villainCriteria = (DealDamageAction dd) => base.IsChemicalTriggerInPlay() && IsVillainTarget(dd.Target);
 
             //If there are no Chemical Triggers in play, reduce damage dealt to the hero target with the lowest HP by 1.
-            base.AddReduceDamageTrigger(heroCriteria, (DealDamageAction dd) => 1);
+            _reduceDamageTrigger = base.AddTrigger<DealDamageAction>(heroCriteria, this.MaybeReduceDamageToHeroTargetResponse, TriggerType.ReduceDamage, TriggerTiming.Before);
             //Otherwise, reduce damage dealt to villain targets by 1.
             base.AddReduceDamageTrigger(villainCriteria, (DealDamageAction dd) => 1);
+        }
+
+        private IEnumerator MaybeReduceDamageToHeroTargetResponse(DealDamageAction dd)
+        {
+            if (base.GameController.PretendMode)
+            {
+                List<bool> storedResults = new List<bool>();
+                IEnumerator coroutine = base.DetermineIfGivenCardIsTargetWithLowestOrHighestHitPoints(dd.Target, highest: false, (Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndHasGameText, dd, storedResults);
+                if (base.UseUnityCoroutines)
+                {
+                    yield return base.GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    base.GameController.ExhaustCoroutine(coroutine);
+                }
+                PerformReduction = storedResults.Count() > 0 && storedResults.First();
+            }
+            if (PerformReduction.HasValue && PerformReduction.Value)
+            {
+                IEnumerator coroutine2 = base.GameController.ReduceDamage(dd, 1, _reduceDamageTrigger, base.GetCardSource());
+                if (base.UseUnityCoroutines)
+                {
+                    yield return base.GameController.StartCoroutine(coroutine2);
+                }
+                else
+                {
+                    base.GameController.ExhaustCoroutine(coroutine2);
+                }
+            }
+            if (!base.GameController.PretendMode)
+            {
+                PerformReduction = null;
+            }
         }
         #endregion Methods
     }

--- a/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdFoamcoreCardController.cs
+++ b/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdFoamcoreCardController.cs
@@ -33,7 +33,7 @@ namespace Cauldron.HalberdExperimentalResearchCenter
 
         public HalberdFoamcoreCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-
+            base.SpecialStringMaker.ShowHeroTargetWithLowestHP();
         }
 
         #endregion Constructors

--- a/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
+++ b/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
@@ -991,6 +991,43 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestHalberdEther_NoChemicalTriggers_TiedHighest()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.HalberdExperimentalResearchCenter");
+            StartGame();
+
+            //ra and legacy are tied fro the highest HP hero targets
+            SetHitPoints(ra.CharacterCard, 20);
+            SetHitPoints(legacy.CharacterCard, 20);
+            SetHitPoints(haka.CharacterCard, 10);
+
+            Card mdp = GetCardInPlay("MobileDefensePlatform");
+
+            GoToPlayCardPhase(halberd);
+
+            //we play out ether
+            Card ether = GetCard("HalberdEther");
+            PlayCard(ether);
+            AssertIsInPlay(ether);
+
+            //If there are no Chemical Triggers in play, increase damage dealt by the hero target with the highest HP by 1.
+
+            //choose ra as the highest hitpoints when asked
+            DecisionYesNo = true;
+            QuickHPStorage(mdp);
+            DealDamage(ra.CharacterCard, mdp, 3, DamageType.Fire);
+            //hero w/ highest hp damage should be +1
+            QuickHPCheck(-4);
+
+            //deny ra as the highest hitpoints when asked
+            DecisionYesNo = false;
+            QuickHPStorage(mdp);
+            DealDamage(ra.CharacterCard, mdp, 3, DamageType.Fire);
+            //damage was not increased
+            QuickHPCheck(-3);
+        }
+
+        [Test()]
         public void TestHalberdEther_WithChemicalTriggers()
         {
             SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.HalberdExperimentalResearchCenter");

--- a/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
+++ b/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
@@ -971,6 +971,8 @@ namespace CauldronTests
             AssertIsInPlay(ether);
 
             //If there are no Chemical Triggers in play, increase damage dealt by the hero target with the highest HP by 1.
+            AssertCardSpecialString(ether, 0, "Hero target with the highest HP: Ra.");
+
             //ra is the highest hp
             QuickHPStorage(mdp);
             DealDamage(ra.CharacterCard, mdp, 3, DamageType.Fire);
@@ -1011,6 +1013,7 @@ namespace CauldronTests
             AssertIsInPlay(ether);
 
             //If there are no Chemical Triggers in play, increase damage dealt by the hero target with the highest HP by 1.
+            AssertCardSpecialString(ether, 0, "Hero targets with the highest HP: Ra, Legacy.");
 
             //choose ra as the highest hitpoints when asked
             DecisionYesNo = true;

--- a/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
+++ b/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
@@ -693,6 +693,47 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestHalberdFoamcore_NoChemicalTriggers_TiedLowest()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.HalberdExperimentalResearchCenter");
+            StartGame();
+
+            //legacy and haka are tied for the lowest HP hero targets
+            SetHitPoints(ra.CharacterCard, 20);
+            SetHitPoints(legacy.CharacterCard, 10);
+            SetHitPoints(haka.CharacterCard, 10);
+
+            Card mdp = GetCardInPlay("MobileDefensePlatform");
+
+            GoToPlayCardPhase(halberd);
+
+            //we play out foamcore
+            Card foamcore = GetCard("HalberdFoamcore");
+            PlayCard(foamcore);
+            AssertIsInPlay(foamcore);
+
+            //If there are no Chemical Triggers in play, reduce damage dealt to the hero target with the lowest HP by 1.
+
+            //choose haka as the lowest hitpoints when asked
+            DecisionYesNo = true;
+            QuickHPStorage(haka.CharacterCard, mdp, ra.CharacterCard, legacy.CharacterCard);
+            DealDamage(baron, haka, 4, DamageType.Melee);
+            //damage should have been reduced by 1
+            QuickHPCheck(-3, 0, 0, 0);
+
+            //reset tied HP
+            SetHitPoints(legacy.CharacterCard, 10);
+            SetHitPoints(haka.CharacterCard, 10);
+
+            //deny haka as the lowest hitpoints when asked
+            DecisionYesNo = false;
+            QuickHPStorage(haka.CharacterCard, mdp, ra.CharacterCard, legacy.CharacterCard);
+            DealDamage(baron, haka, 4, DamageType.Melee);
+            //damage was dealt in full
+            QuickHPCheck(-4, 0, 0, 0);
+        }
+
+        [Test()]
         public void TestHalberdFoamcore_WithChemicalTriggers()
         {
             SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.HalberdExperimentalResearchCenter");

--- a/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
+++ b/Testing/Environments/HalberdExperimentalResearchCenterTests.cs
@@ -673,6 +673,8 @@ namespace CauldronTests
             AssertIsInPlay(foamcore);
 
             //If there are no Chemical Triggers in play, reduce damage dealt to the hero target with the lowest HP by 1.
+            AssertCardSpecialString(foamcore, 0, "Hero target with the lowest HP: Haka.");
+
             //haka has the lowest hitpoints
             QuickHPStorage(haka.CharacterCard, mdp, ra.CharacterCard, legacy.CharacterCard);
             DealDamage(baron, haka, 4, DamageType.Melee);
@@ -713,6 +715,7 @@ namespace CauldronTests
             AssertIsInPlay(foamcore);
 
             //If there are no Chemical Triggers in play, reduce damage dealt to the hero target with the lowest HP by 1.
+            AssertCardSpecialString(foamcore, 0, "Hero targets with the lowest HP: Legacy, Haka.");
 
             //choose haka as the lowest hitpoints when asked
             DecisionYesNo = true;


### PR DESCRIPTION
Fixes #161

Also adds a special string, though for now it makes no attempt to suppress the "hero with the lowest HP" special string when a chemical trigger is in play. Not sure if that's possible without rewriting the special string.