### PR TITLE
Modified Tainted Blood Trigger Timing for Out of Order Phases

### DIFF
--- a/Controller/Heroes/Necro/Cards/TaintedBloodCardController.cs
+++ b/Controller/Heroes/Necro/Cards/TaintedBloodCardController.cs
@@ -15,7 +15,8 @@ namespace Cauldron.Necro
         public override void AddTriggers()
         {
             //At the end of your draw phase, Necro deals the undead target with the lowest HP 2 irreducible toxic damage.
-            base.AddPhaseChangeTrigger(tt => tt == base.HeroTurnTaker, p => p == Phase.End, _ => true, DealDamageResponse, new TriggerType[] { TriggerType.DealDamage }, TriggerTiming.Before);
+            //base.AddPhaseChangeTrigger(tt => tt == base.HeroTurnTaker, p => p == Phase.End, _ => true, DealDamageResponse, new TriggerType[] { TriggerType.DealDamage }, TriggerTiming.Before);
+            base.AddTrigger<PhaseChangeAction>((PhaseChangeAction p) => p.FromPhase.TurnTaker == base.TurnTaker && p.FromPhase.IsDrawCard, DealDamageResponse, TriggerType.DealDamage, TriggerTiming.Before);
         }
 
         private IEnumerator DealDamageResponse(PhaseChangeAction pca)


### PR DESCRIPTION
Previously, the trigger was tied to  the going to the End Phase, as that satisfies the criteria normally.

However if there is a card out that changes the turn order, such as Toppling Skyscraper in Superstorm Akela, this no longer was accurate. Changed to be tied to any phase change where the FromPhase was DrawCard