### PR TITLE
Use a conditional Trigger for the damage prevention incap

### DIFF
--- a/Controller/Heroes/Starlight/CharacterCards/StarlightCharacterCardController.cs
+++ b/Controller/Heroes/Starlight/CharacterCards/StarlightCharacterCardController.cs
@@ -1,5 +1,6 @@
 using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,9 +10,28 @@ namespace Cauldron.Starlight
 {
     public class StarlightCharacterCardController : StarlightSubCharacterCardController
     {
+
+        private static readonly string PreventDamageViaIncapPropertyKey = "StarlightIncapPreventDamageToOrByLowest";
+        private static readonly string PreventDamageViaIncapEffectMarker = "NeverCalledStarlightIncapPreventDamageToOrByLowest";
+        private bool? PreventDamageViaIncap
+        {
+            get;
+            set;
+        }
+
+        public override bool AllowFastCoroutinesDuringPretend
+        {
+            get
+            {
+                bool? incapIsActive = base.GetCardPropertyJournalEntryBoolean(PreventDamageViaIncapPropertyKey);
+                return !incapIsActive.HasValue || !incapIsActive.Value;
+            }
+        }
+
         public StarlightCharacterCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             SpecialStringMaker.ShowNumberOfCardsAtLocation(TurnTaker.Trash, new LinqCardCriteria((Card c) => IsConstellation(c), "constellation"));
+            AllowFastCoroutinesDuringPretend = false;
         }
 
         public override IEnumerator UsePower(int index = 0)
@@ -36,18 +56,21 @@ namespace Cauldron.Starlight
                 case 0:
                     {
                         //"Until the start of your next turn, prevent all damage that would be dealt to or by the target with the lowest HP.",
-                        OnDealDamageStatusEffect lowestTargetImmunity = new OnDealDamageStatusEffect(Card, "LowestTargetImmunity", "The target with the lowest HP is immune to damage and cannot deal damage.", new TriggerType[] { TriggerType.MakeImmuneToDamage }, TurnTaker, Card);
-                        lowestTargetImmunity.UntilStartOfNextTurn(TurnTaker);
-                        lowestTargetImmunity.CardSource = Card;
-                        lowestTargetImmunity.BeforeOrAfter = BeforeOrAfter.Before;
-                        IEnumerator coroutine = AddStatusEffect(lowestTargetImmunity);
-                        if (UseUnityCoroutines)
+                        //Secretly set a property on this card that is checked by triggers, in order to apply the effect.
+                        base.AddCardPropertyJournalEntry(PreventDamageViaIncapPropertyKey, true);
+                        //This status effect displays UI text but provides no behavior on its own.
+                        //The method name is fake. Another trigger clears the above property when this status effect is removed.
+                        OnPhaseChangeStatusEffect displayEffect = new OnPhaseChangeStatusEffect(Card, PreventDamageViaIncapEffectMarker, "The target with the lowest HP is immune to damage and cannot deal damage.", new TriggerType[] { }, base.Card);
+                        displayEffect.UntilStartOfNextTurn(base.TurnTaker);
+                        IEnumerator coroutine = base.AddStatusEffect(displayEffect);
+
+                        if (base.UseUnityCoroutines)
                         {
-                            yield return GameController.StartCoroutine(coroutine);
+                            yield return base.GameController.StartCoroutine(coroutine);
                         }
                         else
                         {
-                            GameController.ExhaustCoroutine(coroutine);
+                            base.GameController.ExhaustCoroutine(coroutine);
                         }
                         break;
                     }
@@ -83,6 +106,25 @@ namespace Cauldron.Starlight
 
 
             yield break;
+        }
+
+        public override void AddTriggers()
+        {
+            base.AddTriggers();
+
+            //Triggers for the damage prevention incap ability.
+            //Uses Triggers, because StatusEffects have no parallel to AllowFastCoroutinesDuringPretend.
+            base.AddTrigger<DealDamageAction>(PreventDamageViaIncapCriteria, PreventDamageViaIncapResponse, TriggerType.CancelAction, TriggerTiming.Before, outOfPlayTrigger: true);
+            Func<ExpireStatusEffectAction, bool> clearIncapEffectCriteria = (ExpireStatusEffectAction action) =>
+            {
+                if (action.StatusEffect is OnPhaseChangeStatusEffect)
+                {
+                    OnPhaseChangeStatusEffect effect = (OnPhaseChangeStatusEffect)action.StatusEffect;
+                    return effect.CardWithMethod == base.Card && effect.MethodToExecute == PreventDamageViaIncapEffectMarker;
+                }
+                return false;
+            };
+            base.AddTrigger<ExpireStatusEffectAction>(clearIncapEffectCriteria, ClearPreventDamageViaIncapResponse, TriggerType.Other, TriggerTiming.After, outOfPlayTrigger: true);
         }
 
         private IEnumerator DrawACardOrPlayConstellationFromTrash()
@@ -128,39 +170,50 @@ namespace Cauldron.Starlight
             return HeroTurnTaker.Trash.Cards.Where((Card card) => IsConstellation(card) && GameController.CanPlayCard(FindCardController(card), false, null, false, true) == CanPlayCardResult.CanPlay);
         }
 
-        public IEnumerator LowestTargetImmunity(DealDamageAction dealDamage, HeroTurnTaker hero = null, StatusEffect effect = null, int[] powerNumerals = null)
+        private bool PreventDamageViaIncapCriteria(DealDamageAction dealDamage)
         {
-            List<bool> storedResults = new List<bool>();
+            bool? incapIsActive = base.GetCardPropertyJournalEntryBoolean(PreventDamageViaIncapPropertyKey);
+            return incapIsActive.HasValue && incapIsActive.Value;
+        }
 
-            //Is the target of the damage the lowest HP target?
-            IEnumerator coroutine = DetermineIfGivenCardIsTargetWithLowestOrHighestHitPoints(dealDamage.Target, highest: false, (Card card) => GameController.IsCardVisibleToCardSource(card, GetCardSource()), dealDamage, storedResults);
-            if (UseUnityCoroutines)
+        private IEnumerator PreventDamageViaIncapResponse(DealDamageAction dealDamage)
+        {
+            if (base.GameController.PretendMode)
             {
-                yield return GameController.StartCoroutine(coroutine);
-            }
-            else
-            {
-                GameController.ExhaustCoroutine(coroutine);
-            }
+                List<bool> storedResults = new List<bool>();
 
-            //If not, is the source of the damage the lowest HP target?
-            if (!storedResults.First() && dealDamage.DamageSource.IsTarget)
-            {
-                IEnumerator coroutine2 = DetermineIfGivenCardIsTargetWithLowestOrHighestHitPoints(dealDamage.DamageSource.Card, highest: false, (Card card) => GameController.IsCardVisibleToCardSource(card, GetCardSource()), dealDamage, storedResults);
+                //Is the target of the damage the lowest HP target?
+                IEnumerator coroutine = DetermineIfGivenCardIsTargetWithLowestOrHighestHitPoints(dealDamage.Target, highest: false, (Card card) => GameController.IsCardVisibleToCardSource(card, GetCardSource()), dealDamage, storedResults);
                 if (UseUnityCoroutines)
                 {
-                    yield return GameController.StartCoroutine(coroutine2);
+                    yield return GameController.StartCoroutine(coroutine);
                 }
                 else
                 {
-                    GameController.ExhaustCoroutine(coroutine2);
+                    GameController.ExhaustCoroutine(coroutine);
                 }
+
+                //If not, is the source of the damage the lowest HP target?
+                if (!storedResults.First() && dealDamage.DamageSource.IsTarget)
+                {
+                    IEnumerator coroutine2 = DetermineIfGivenCardIsTargetWithLowestOrHighestHitPoints(dealDamage.DamageSource.Card, highest: false, (Card card) => GameController.IsCardVisibleToCardSource(card, GetCardSource()), dealDamage, storedResults);
+                    if (UseUnityCoroutines)
+                    {
+                        yield return GameController.StartCoroutine(coroutine2);
+                    }
+                    else
+                    {
+                        GameController.ExhaustCoroutine(coroutine2);
+                    }
+                }
+
+                //If we answered yes to either question, prevent the damage.
+                this.PreventDamageViaIncap = storedResults.Contains(true);
             }
 
-            //If we answered yes to either question, prevent the damage.
-            if (storedResults.Contains(true))
+            if (this.PreventDamageViaIncap != null && this.PreventDamageViaIncap.Value)
             {
-                IEnumerator coroutine3 = CancelAction(dealDamage, showOutput: true, cancelFutureRelatedDecisions: true, null, isPreventEffect: true);
+                IEnumerator coroutine3 = base.CancelAction(dealDamage, showOutput: true, cancelFutureRelatedDecisions: true, null, isPreventEffect: true);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine3);
@@ -171,6 +224,16 @@ namespace Cauldron.Starlight
                 }
             }
 
+            if (!base.GameController.PretendMode)
+            {
+                this.PreventDamageViaIncap = null;
+            }
+            yield break;
+        }
+
+        protected IEnumerator ClearPreventDamageViaIncapResponse(ExpireStatusEffectAction expireAction)
+        {
+            base.AddCardPropertyJournalEntry(PreventDamageViaIncapPropertyKey, (bool?)null);
             yield break;
         }
     }

--- a/Controller/Heroes/Starlight/CharacterCards/StarlightCharacterCardController.cs
+++ b/Controller/Heroes/Starlight/CharacterCards/StarlightCharacterCardController.cs
@@ -108,23 +108,26 @@ namespace Cauldron.Starlight
             yield break;
         }
 
-        public override void AddTriggers()
+        public override void AddSideTriggers()
         {
-            base.AddTriggers();
+            base.AddSideTriggers();
 
-            //Triggers for the damage prevention incap ability.
-            //Uses Triggers, because StatusEffects have no parallel to AllowFastCoroutinesDuringPretend.
-            base.AddTrigger<DealDamageAction>(PreventDamageViaIncapCriteria, PreventDamageViaIncapResponse, TriggerType.CancelAction, TriggerTiming.Before, outOfPlayTrigger: true);
-            Func<ExpireStatusEffectAction, bool> clearIncapEffectCriteria = (ExpireStatusEffectAction action) =>
+            if (base.Card.IsFlipped)
             {
-                if (action.StatusEffect is OnPhaseChangeStatusEffect)
+                //Triggers for the damage prevention incap ability.
+                //Uses Triggers, because StatusEffects have no parallel to AllowFastCoroutinesDuringPretend.
+                base.AddSideTrigger(base.AddTrigger<DealDamageAction>(PreventDamageViaIncapCriteria, PreventDamageViaIncapResponse, TriggerType.CancelAction, TriggerTiming.Before));
+                Func<ExpireStatusEffectAction, bool> clearIncapEffectCriteria = (ExpireStatusEffectAction action) =>
                 {
-                    OnPhaseChangeStatusEffect effect = (OnPhaseChangeStatusEffect)action.StatusEffect;
-                    return effect.CardWithMethod == base.Card && effect.MethodToExecute == PreventDamageViaIncapEffectMarker;
-                }
-                return false;
-            };
-            base.AddTrigger<ExpireStatusEffectAction>(clearIncapEffectCriteria, ClearPreventDamageViaIncapResponse, TriggerType.Other, TriggerTiming.After, outOfPlayTrigger: true);
+                    if (action.StatusEffect is OnPhaseChangeStatusEffect)
+                    {
+                        OnPhaseChangeStatusEffect effect = (OnPhaseChangeStatusEffect)action.StatusEffect;
+                        return effect.CardWithMethod == base.Card && effect.MethodToExecute == PreventDamageViaIncapEffectMarker;
+                    }
+                    return false;
+                };
+                base.AddSideTrigger(base.AddTrigger<ExpireStatusEffectAction>(clearIncapEffectCriteria, ClearPreventDamageViaIncapResponse, TriggerType.Other, TriggerTiming.After));
+            }
         }
 
         private IEnumerator DrawACardOrPlayConstellationFromTrash()

--- a/Controller/Heroes/Starlight/CharacterCards/StarlightCharacterCardController.cs
+++ b/Controller/Heroes/Starlight/CharacterCards/StarlightCharacterCardController.cs
@@ -39,7 +39,6 @@ namespace Cauldron.Starlight
                         OnDealDamageStatusEffect lowestTargetImmunity = new OnDealDamageStatusEffect(Card, "LowestTargetImmunity", "The target with the lowest HP is immune to damage and cannot deal damage.", new TriggerType[] { TriggerType.MakeImmuneToDamage }, TurnTaker, Card);
                         lowestTargetImmunity.UntilStartOfNextTurn(TurnTaker);
                         lowestTargetImmunity.CardSource = Card;
-                        lowestTargetImmunity.SourceCriteria.IsTarget = true;
                         lowestTargetImmunity.BeforeOrAfter = BeforeOrAfter.Before;
                         IEnumerator coroutine = AddStatusEffect(lowestTargetImmunity);
                         if (UseUnityCoroutines)

--- a/Testing/Heroes/StarlightTests.cs
+++ b/Testing/Heroes/StarlightTests.cs
@@ -205,6 +205,7 @@ namespace CauldronTests
             SetupIncap(baron);
             AssertIncapacitated(starlight);
             Card mdp = GetCardInPlay("MobileDefensePlatform");
+            Card impendingCasualty = GetCard("ImpendingCasualty");
 
             GoToUseIncapacitatedAbilityPhase(starlight);
             UseIncapacitatedAbility(starlight, 0);
@@ -212,6 +213,11 @@ namespace CauldronTests
             //as lowest HP target, Mobile Defense Platform should be immune to damage
             QuickHPStorage(mdp);
             DealDamage(haka, mdp, 2, DamageType.Melee);
+            QuickHPCheck(0);
+
+            //Mobile Defense Platform is also immune to damage from non-target sources
+            PlayCard(impendingCasualty);
+            DealDamage(impendingCasualty, mdp, 2, DamageType.Energy);
             QuickHPCheck(0);
 
             //But it should not be able to deal damage either.

--- a/Testing/Heroes/StarlightTests.cs
+++ b/Testing/Heroes/StarlightTests.cs
@@ -219,6 +219,7 @@ namespace CauldronTests
             PlayCard(impendingCasualty);
             DealDamage(impendingCasualty, mdp, 2, DamageType.Energy);
             QuickHPCheck(0);
+            DestroyCard(impendingCasualty);
 
             //But it should not be able to deal damage either.
             QuickHPStorage(haka);
@@ -242,6 +243,59 @@ namespace CauldronTests
             QuickHPStorage(battalion);
             DealDamage(haka, battalion, 2, DamageType.Melee);
             QuickHPCheck(-2);
+        }
+        [Test()]
+        public void TestStarlightIncap1_TiedLowest()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Starlight", "Haka", "Ra", "Megalopolis");
+            StartGame();
+
+            SetupIncap(baron);
+            AssertIncapacitated(starlight);
+            Card mdp = GetCardInPlay("MobileDefensePlatform");
+
+            GoToUseIncapacitatedAbilityPhase(starlight);
+            UseIncapacitatedAbility(starlight, 0);
+
+            //MDP and Ra are tied for lowest HP target
+            SetHitPoints(mdp, 10);
+            SetHitPoints(ra, 10);
+
+            //Choose MDP as lowest HP target, it should be immune to damage
+            DecisionsYesNo = new bool[] { true };
+            QuickHPStorage(mdp);
+            DealDamage(haka, mdp, 2, DamageType.Melee);
+            QuickHPCheck(0);
+
+            //Choose MDP as lowest HP target, it should be unable to deal damage
+            base.ResetDecisions();
+            DecisionsYesNo = new bool[] { true };
+            QuickHPStorage(haka);
+            DealDamage(mdp, haka, 2, DamageType.Melee);
+            QuickHPCheck(0);
+
+            //Deny MDP as lowest HP target, it should deal damage normally
+            base.ResetDecisions();
+            DecisionsYesNo = new bool[] { false };
+            QuickHPStorage(haka);
+            DealDamage(mdp, haka, 2, DamageType.Melee);
+            QuickHPCheck(-2);
+
+            //Deny MDP as lowest HP target, it should take damage normally
+            base.ResetDecisions();
+            DecisionsYesNo = new bool[] { false };
+            QuickHPStorage(mdp);
+            DealDamage(haka, mdp, 2, DamageType.Melee);
+            QuickHPCheck(-2);
+
+            //An unambiguously lowest HP target shouldn't get a choice
+            base.ResetDecisions();
+            DecisionsYesNo = new bool[] { };
+            PutIntoPlay("BladeBattalion");
+            Card battalion = GetCardInPlay("BladeBattalion");
+            QuickHPStorage(battalion);
+            DealDamage(haka, battalion, 2, DamageType.Melee);
+            QuickHPCheck(0);
         }
         [Test()]
         public void TestStarlightIncap2()


### PR DESCRIPTION
It needs to be able to block execution  when the player is choosing ambiguous lowest HP with AllowFastCoroutinesDuringPretend=false or similar, and that doesn't seem possible with status effects.
This is based on the proposed fix for Element of Lightning, though I clear the card property by defining a trigger on `ExpireStatusEffectAction`, so that it expires on status effect timing (status effects expire before normal "start of turn" triggers).

Also fix it ignoring damage from non-target sources (which should still be prevented if the "to the target with the lowest HP" side is triggered).