### PR TITLE
Fix Doc Havoc promo

### DIFF
--- a/Controller/Heroes/DocHavoc/CharacterCards/FirstResponseDocHavocCharacterCardController.cs
+++ b/Controller/Heroes/DocHavoc/CharacterCards/FirstResponseDocHavocCharacterCardController.cs
@@ -36,9 +36,9 @@ namespace Cauldron.DocHavoc
 
             int targetsNumeral = GetPowerNumeral(0, PowerNumberOfTargets);
             int damageNumeral = GetPowerNumeral(1, PowerDamageToDeal);
-            DamageSource ds = new DamageSource(this.GameController, this.TurnTaker);
+            DamageSource ds = new DamageSource(this.GameController, this.Card);
             IEnumerator routine2 = base.GameController.SelectTargetsAndDealDamage(this.HeroTurnTakerController, ds, damageNumeral,
-                DamageType.Melee, targetsNumeral, true, 0, cardSource: base.GetCardSource());
+                DamageType.Melee, targetsNumeral, false, 0, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(routine2);

--- a/Testing/Heroes/DocHavocPromoTests.cs
+++ b/Testing/Heroes/DocHavocPromoTests.cs
@@ -53,7 +53,49 @@ namespace CauldronTests
             QuickHPCheck(-1);
             QuickHandCheck(1);
         }
+        [Test]
+        public void TestInnatePowerFirstResponseIsFromHavocCard()
+        {
+            SetupGameController("BaronBlade", DeckNamespaceFirstResponse, "Ra", "Legacy", "Megalopolis");
 
+            StartGame();
+
+            Card mdp = GetCardInPlay("MobileDefensePlatform");
+            QuickHPStorage(mdp);
+            QuickHandStorage(DocHavoc);
+            DecisionYesNo = true;
+            DecisionSelectTarget = mdp;
+            UsePower(legacy);
+            // Act
+            GoToUsePowerPhase(DocHavoc);
+            UsePower(DocHavoc);
+
+            // Assert
+            QuickHPCheck(-2);
+            QuickHandCheck(1);
+        }
+        [Test]
+        public void TestInnatePowerFirstResponseIsStandardMayDamage()
+        {
+            SetupGameController("BaronBlade", DeckNamespaceFirstResponse, "Ra", "Legacy", "Megalopolis");
+
+            StartGame();
+
+            Card mdp = GetCardInPlay("MobileDefensePlatform");
+            QuickHPStorage(mdp);
+            QuickHandStorage(DocHavoc);
+            DecisionYesNo = false;
+            DecisionSelectTargets = new Card[] { mdp, mdp, null };
+            // Act
+            GoToUsePowerPhase(DocHavoc);
+            UsePower(DocHavoc);
+            UsePower(DocHavoc);
+            UsePower(DocHavoc);
+
+            // Assert
+            QuickHPCheck(-2);
+            QuickHandCheck(3);
+        }
         [Test]
         public void TestInnatePowerFirstResponseNoDamage()
         {


### PR DESCRIPTION
Damage was sourced from TurnTaker instead of Card, also made damage non-optional, as setting RequiredTargets to 0 and allowing the player to choose "stop dealing damage" is fine.

Fixes #439 and #433 