### PR TITLE
Varied fixes 12-8

### DIFF
--- a/Controller/Heroes/Baccarat/Cards/BringDownTheHouseCardController.cs
+++ b/Controller/Heroes/Baccarat/Cards/BringDownTheHouseCardController.cs
@@ -38,7 +38,7 @@ namespace Cauldron.Baccarat
             }
 
             //You may destroy up to X ongoing or environment cards, where X is the number of pairs you shuffled this way.
-            coroutine = base.GameController.SelectAndDestroyCards(this.HeroTurnTakerController, new LinqCardCriteria((Card c) => c.IsOngoing || c.IsEnvironment), X, true, new int?(0), responsibleCard: this.CharacterCard, cardSource: base.GetCardSource());
+            coroutine = base.GameController.SelectAndDestroyCards(this.HeroTurnTakerController, new LinqCardCriteria((Card c) => c.IsOngoing || c.IsEnvironment), X, requiredDecisions: new int?(0), responsibleCard: this.CharacterCard, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/Controller/Heroes/Baccarat/Cards/GraveyardBridgeCardController.cs
+++ b/Controller/Heroes/Baccarat/Cards/GraveyardBridgeCardController.cs
@@ -13,7 +13,7 @@ namespace Cauldron.Baccarat
     {
         public GraveyardBridgeCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-
+            base.SpecialStringMaker.ShowListOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => true));
         }
 
         public override IEnumerator Play()

--- a/Controller/Heroes/Baccarat/CharacterCards/BaccaratCharacterCardController.cs
+++ b/Controller/Heroes/Baccarat/CharacterCards/BaccaratCharacterCardController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.Baccarat
     {
         public BaccaratCharacterCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            base.SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => c.DoKeywordsContain("trick") && c.IsInTrash));
+            base.SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => c.DoKeywordsContain("trick") && c.IsInTrash, "trick"));
         }
 
         private List<Card> actedHeroes;

--- a/Controller/Heroes/Titan/Cards/ImmolateCardController.cs
+++ b/Controller/Heroes/Titan/Cards/ImmolateCardController.cs
@@ -10,7 +10,7 @@ namespace Cauldron.Titan
     {
         public ImmolateCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            base.SpecialStringMaker.ShowCardThisCardIsNextTo(base.GetCardThisCardIsNextTo());
+            //base.SpecialStringMaker.ShowCardThisCardIsNextTo(base.GetCardThisCardIsNextTo());
         }
 
         private const string FirstTimeDealingDamage = "FirstTimeDealingDamage";

--- a/Controller/Villains/SwarmEater/Cards/HuntingGroundsCardController.cs
+++ b/Controller/Villains/SwarmEater/Cards/HuntingGroundsCardController.cs
@@ -16,7 +16,7 @@ namespace Cauldron.SwarmEater
             //Increase damage dealt by {SwarmEater} to environment targets by 1.
             base.AddIncreaseDamageTrigger((DealDamageAction action) => action.DamageSource != null && action.Target.IsEnvironmentTarget && action.DamageSource.Card == base.CharacterCard, 1);
             //Whenever {SwarmEater} destroys a target, play the top card of the environment deck.
-            base.AddTrigger<DestroyCardAction>((DestroyCardAction action) => action.ResponsibleCard == base.CharacterCard, base.PlayTheTopCardOfTheEnvironmentDeckResponse, TriggerType.PlayCard, TriggerTiming.After);
+            base.AddTrigger<DestroyCardAction>((DestroyCardAction action) => action.ResponsibleCard == base.CharacterCard && action.WasCardDestroyed, base.PlayTheTopCardOfTheEnvironmentDeckResponse, TriggerType.PlayCard, TriggerTiming.After);
         }
     }
 }

--- a/Controller/Villains/SwarmEater/Cards/SubterranAugCardController.cs
+++ b/Controller/Villains/SwarmEater/Cards/SubterranAugCardController.cs
@@ -23,7 +23,7 @@ namespace Cauldron.SwarmEater
             base.AddStartOfTurnTrigger((TurnTaker tt) => base.Card.IsInPlayAndNotUnderCard && tt == base.TurnTaker, this.PlayVillainTargetResponse, TriggerType.PlayCard);
 
             //Absorb: The first time {SwarmEater} would be dealt damage each turn, reduce that damage by 1.
-            this._reduceDamage = base.AddReduceDamageTrigger((DealDamageAction action) => base.Card.Location.IsUnderCard && !base.HasBeenSetToTrueThisTurn(FirstTimeDamageDealt), this.ReduceDamageResponse, (Card c) => c == this.CardThatAbsorbedThis(), true);
+            this._reduceDamage = base.AddReduceDamageTrigger((DealDamageAction action) => action.Amount > 0 && base.Card.Location.IsUnderCard && !base.HasBeenSetToTrueThisTurn(FirstTimeDamageDealt), this.ReduceDamageResponse, (Card c) => c == this.CardThatAbsorbedThis(), true);
         }
 
         private IEnumerator PlayVillainTargetResponse(PhaseChangeAction p)

--- a/Controller/Villains/SwarmEater/CharacterCards/SwarmEaterCharacterCardController.cs
+++ b/Controller/Villains/SwarmEater/CharacterCards/SwarmEaterCharacterCardController.cs
@@ -23,13 +23,13 @@ namespace Cauldron.SwarmEater
             {
                 //If Single-Minded Pursuit leaves play, flip {SwarmEater}'s villain character cards.
                 base.AddSideTrigger(base.AddTrigger<DestroyCardAction>((DestroyCardAction action) => action.CardToDestroy.Card.Identifier == SingleMindedPursuitIdent && action.WasCardDestroyed, base.FlipThisCharacterCardResponse, TriggerType.FlipCard, TriggerTiming.After));
-                
+
                 //At the start of the villain turn, {SwarmEater} deals the pursued target 3 psychic damage.
                 base.AddSideTrigger(base.AddDealDamageAtStartOfTurnTrigger(base.TurnTaker, base.Card, (Card c) => this.IsPursued(c), TargetType.All, 3, DamageType.Psychic));
-                
+
                 //Whenever a pursued hero deals damage to a target other than {SwarmEater}, you may move Single-Minded Pursuit next to that target.
                 base.AddSideTrigger(base.AddTrigger<DealDamageAction>((DealDamageAction action) => this.IsPursued(action.DamageSource.Card) && action.DamageSource.Card.IsHeroCharacterCard && action.Target != base.Card && action.Target != action.DamageSource.Card, this.ChangePursuedResponse, TriggerType.MoveCard, TriggerTiming.After));
-                
+
                 if (base.Game.IsAdvanced)
                 {
                     //Increase damage dealt by {SwarmEater} to environment targets by 1.
@@ -45,7 +45,7 @@ namespace Cauldron.SwarmEater
                 /**************Trigger added to Single-Minded Pursuit****************/
 
                 //Whenever a villain card is played {SwarmEater} deals the non-hero target other than itself with the lowest HP 3 melee damage.
-                base.AddSideTrigger(base.AddTrigger<PlayCardAction>((PlayCardAction action) => action.CardToPlay.IsVillain && action.WasCardPlayed, this.DealDamageResponse, TriggerType.DealDamage, TriggerTiming.After));
+                base.AddSideTrigger(base.AddTrigger<PlayCardAction>((PlayCardAction action) => action.CardToPlay.IsVillain && action.WasCardPlayed && !action.IsPutIntoPlay, this.DealDamageResponse, TriggerType.DealDamage, TriggerTiming.After));
                 if (base.Game.IsAdvanced)
                 {
                     //Whenever {SwarmEater} destroys a villain target, play the top card of the villain deck.

--- a/DeckLists/Hero/BaccaratDeckList.json
+++ b/DeckLists/Hero/BaccaratDeckList.json
@@ -78,7 +78,7 @@
             ],
             "body": [
                 "You may play a card.",
-                "You may use {Baccarat}'s innate power twice during your phase this turn."
+                "You may use {Baccarat}'s innate power twice during your power phase this turn."
             ],
             "flavorQuotes": [
                 {

--- a/DeckLists/Villain/SwarmEaterDeckList.json
+++ b/DeckLists/Villain/SwarmEaterDeckList.json
@@ -39,7 +39,7 @@
             "flippedGameplay": [
                 "At the start of the villain turn, {SwarmEater} deals the target other than itself with the lowest HP 2 melee damage.",
                 "Whenever Single-Minded Pursuit enters play, flip {SwarmEater}'s villain character cards.",
-                "Whenever a villain card is play {SwarmEater} deals the non-hero target other than itself with the lowest HP 3 melee damage."
+                "Whenever a villain card is played, {SwarmEater} deals the non-hero target other than itself with the lowest HP 3 melee damage."
             ],
             "flippedAdvanced": "Whenever {SwarmEater} destroys a villain target, play the top card of the villain deck.",
             "flippedIcons": [],

--- a/DeckLists/Villain/SwarmEaterDeckList.json
+++ b/DeckLists/Villain/SwarmEaterDeckList.json
@@ -32,7 +32,9 @@
             ],
             "advanced": "Increase damage dealt by {SwarmEater} to environment targets by 1.",
             "icons": [
-                "StartOfTurnAction"
+                "StartOfTurnAction",
+                "DealDamagePsychic",
+                "Manipulate"
             ],
             "advancedIcons": [],
             "flippedBody": "Assimiliating Nanoswarm",
@@ -42,7 +44,10 @@
                 "Whenever a villain card is played, {SwarmEater} deals the non-hero target other than itself with the lowest HP 3 melee damage."
             ],
             "flippedAdvanced": "Whenever {SwarmEater} destroys a villain target, play the top card of the villain deck.",
-            "flippedIcons": [],
+            "flippedIcons": [
+                "StartOfTurnAction",
+                "DealDamageMelee"
+            ],
             "flippedAdvancedIcons": [],
             "difficulty": 4,
             "openingLines": {
@@ -134,6 +139,7 @@
             ],
             "icons": [
                 "Indestructible",
+                "EndOfTurnAction",
                 "GainHP"
             ],
             "body": [
@@ -182,6 +188,7 @@
                 "one-shot"
             ],
             "icons": [
+                "MakeDamageIrreducible",
                 "DealDamageProjectile",
                 "DealDamageMelee"
             ],
@@ -478,6 +485,7 @@
             "advanced": "Single-Minded Pursuit is indestructible.",
             "icons": [
                 "RedirectDamage",
+                "EndOfTurnAction",
                 "PlayCardNow"
             ],
             "advancedIcons": [


### PR DESCRIPTION
Fixes for
- Swarm Eater
#453 - Subterran Aug not always reducing damage - not sure about this being a perfect fix
#450 - Flipped Swarm Eater no longer deals damage on cards "Put Into Play" only on "Play"
#449 - Character Card typo addressed
#447 - Hunting Grounds now only triggers if the target was actually destroyed
Decklist Icons updated
- Titan
#444 - Weird graphics around Immolate
- Baccarat
#436 - Bring Down the House should no longer keep asking Yes/No destroy a card and will instead just allow a skip
#377 - Typo on Ace in the Hole addressed
Character card now says "Trick Cards" not "Cards Cards" on the special string
Graveyard Bridge now has a Special String with all trashed cards