### PR TITLE
Updated Anathema CardCounts

### DIFF
--- a/DeckLists/Villain/AnathemaDeckList.json
+++ b/DeckLists/Villain/AnathemaDeckList.json
@@ -137,7 +137,7 @@
         },
         {
             "identifier": "DoppelgangerStrike",
-            "count": 1,
+            "count": 2,
             "title": "Doppelganger Strike",
             "keywords": [
                 "one-shot"
@@ -161,7 +161,7 @@
         },
         {
             "identifier": "EnhancedSenses",
-            "count": 1,
+            "count": 2,
             "title": "Enhanced Senses",
             "keywords": [
                 "head"
@@ -209,7 +209,7 @@
         },
         {
             "identifier": "HeavyCarapace",
-            "count": 1,
+            "count": 2,
             "title": "Heavy Carapace",
             "keywords": [
                 "body"


### PR DESCRIPTION
Heavy Carapace, Enhanced Senses, and Doppelganger Strike were all at 1 copy instead of 2