### PR TITLE
Multi-Character Promo Improvements

### DIFF
--- a/Controller/Heroes/Starlight/CharacterCards/StarlightTurnTakerController.cs
+++ b/Controller/Heroes/Starlight/CharacterCards/StarlightTurnTakerController.cs
@@ -32,8 +32,9 @@ namespace Cauldron.Starlight
                 Card target = TurnTaker.FindCard(charID);
                 characterCards.Add(target);
 
-                Location destination = target.Location;
-                if (destination.Name == LocationName.OffToTheSide)
+                Location oldLocation = target.Location;
+                Location destination;
+                if (oldLocation.IsOffToTheSide)
                 {
                     //Log.Debug("Looking for destination...");
                     if (banish)
@@ -46,13 +47,19 @@ namespace Cauldron.Starlight
                         //Log.Debug("Putting in play...");
                         destination = TurnTaker.PlayArea;
                     }
+
+                    TurnTaker.MoveCard(target, destination);
+                    /*
+                    oldLocation.RemoveCard(target);
                     destination.AddCard(target);
+                    
                     if (target.Location.Name == LocationName.PlayArea && !GameController.Game.OrderedCardsInPlay.Contains(target))
                     {
                         //Log.Debug("But the game does not know that it is in play");
                         GameController.Game.AssignPlayCardIndex(target);
                         //Log.Debug($"Given index {target.PlayIndex}");
                     }
+                    */
                 }
 
             }

--- a/Controller/Heroes/Starlight/CharacterCards/StarlightTurnTakerController.cs
+++ b/Controller/Heroes/Starlight/CharacterCards/StarlightTurnTakerController.cs
@@ -88,8 +88,15 @@ namespace Cauldron.Starlight
             {
                 if (InstructionCardController != null)
                 {
-                    Log.Warning("There was a request for Nightlore Council Starlight's character card, which should be null.");
-                    return null;
+                    if (this.HasMultipleCharacterCards)
+                    {
+                        Log.Warning("There was a request for Nightlore Council Starlight's character card, which should be null.");
+                        return null;
+                    }
+                    else
+                    {
+                        Log.Debug("There was a request for Nightlore Council Starlight's character card before setup was complete. Returning instruction card to avoid potential null reference errors.");
+                    }
                 }
                 return base.CharacterCard;
             }

--- a/Controller/Heroes/TheKnight/CharacterCards/TheKnightTurnTakerController.cs
+++ b/Controller/Heroes/TheKnight/CharacterCards/TheKnightTurnTakerController.cs
@@ -32,9 +32,11 @@ namespace Cauldron.TheKnight
                 Card target = TurnTaker.FindCard(charID);
                 characterCards.Add(target);
 
-                Location destination = target.Location;
-                if (destination.Name == LocationName.OffToTheSide)
+                Location currentLoc = target.Location;
+
+                if (currentLoc.IsOffToTheSide)
                 {
+                    Location destination;
                     //Log.Debug("Looking for destination...");
                     if (banish)
                     {
@@ -46,13 +48,7 @@ namespace Cauldron.TheKnight
                         //Log.Debug("Putting in play...");
                         destination = TurnTaker.PlayArea;
                     }
-                    destination.AddCard(target);
-                    if (target.Location.Name == LocationName.PlayArea && !GameController.Game.OrderedCardsInPlay.Contains(target))
-                    {
-                        //Log.Debug("But the game does not know that it is in play");
-                        GameController.Game.AssignPlayCardIndex(target);
-                        //Log.Debug($"Given index {target.PlayIndex}");
-                    }
+                    TurnTaker.MoveCard(target, destination);
                 }
 
             }

--- a/Controller/Heroes/TheKnight/CharacterCards/TheKnightTurnTakerController.cs
+++ b/Controller/Heroes/TheKnight/CharacterCards/TheKnightTurnTakerController.cs
@@ -88,8 +88,15 @@ namespace Cauldron.TheKnight
             {
                 if (InstructionCardController != null)
                 {
-                    Log.Warning("There was a request for the Wasteland Ronin Knights' character card, which should be null.");
-                    return null;
+                    if (this.HasMultipleCharacterCards)
+                    {
+                        Log.Warning("There was a request for the Wasteland Ronin Knights' character card, which should be null.");
+                        return null;
+                    }
+                    else
+                    {
+                        Log.Debug("There was a request for the Wasteland Ronin Knights' character card before setup was complete. Returning instruction card to avoid potential null reference errors.");
+                    }
                 }
                 return base.CharacterCard;
             }

--- a/Controller/Villains/TheRam/CharacterCards/PastTheRamCharacterCardController.cs
+++ b/Controller/Villains/TheRam/CharacterCards/PastTheRamCharacterCardController.cs
@@ -15,6 +15,12 @@ namespace Cauldron.TheRam
             SpecialStringMaker.ShowListOfCardsAtLocation(this.Card.UnderLocation, new LinqCardCriteria());
         }
 
+        public override void AddStartOfGameTriggers()
+        {
+            base.AddStartOfGameTriggers();
+            (TurnTakerController as TheRamTurnTakerController).HandleWintersEarly(false);
+        }
+
         public override void AddSideTriggers()
         {
             if(!Card.IsFlipped)

--- a/Controller/Villains/TheRam/CharacterCards/TheRamCharacterCardController.cs
+++ b/Controller/Villains/TheRam/CharacterCards/TheRamCharacterCardController.cs
@@ -14,6 +14,12 @@ namespace Cauldron.TheRam
             AddUpCloseTrackers();
         }
 
+        public override void AddStartOfGameTriggers()
+        {
+            base.AddStartOfGameTriggers();
+            (TurnTakerController as TheRamTurnTakerController).HandleWintersEarly(true);
+        }
+
         public override void AddSideTriggers()
         {
             if(!Card.IsFlipped)

--- a/Controller/Villains/TheRam/CharacterCards/TheRamTurnTakerController.cs
+++ b/Controller/Villains/TheRam/CharacterCards/TheRamTurnTakerController.cs
@@ -91,27 +91,6 @@ namespace Cauldron.TheRam
             return GameController.DoAction(upCloseToTrash);
         }
 
-        private IEnumerator HandleWinters(bool banish = true)
-        {
-            Card winters = FindCardsWhere((Card c) => c.Title == "Admiral Winters").FirstOrDefault();
-            if (winters == null || winters.Location != TurnTaker.OffToTheSide)
-            {
-                yield break;
-            }
-
-            Location targetLocation = banish ? TurnTaker.InTheBox : TurnTaker.PlayArea;
-            IEnumerator coroutine = GameController.MoveCard(this, winters, targetLocation);
-            if (UseUnityCoroutines)
-            {
-                yield return GameController.StartCoroutine(coroutine);
-            }
-            else
-            {
-                GameController.ExhaustCoroutine(coroutine);
-            }
-            yield break;
-        }
-
         public void HandleWintersEarly(bool banish = true)
         {
             Card winters = TurnTaker.FindCard("AdmiralWintersCharacter", true);

--- a/Controller/Villains/TheRam/CharacterCards/TheRamTurnTakerController.cs
+++ b/Controller/Villains/TheRam/CharacterCards/TheRamTurnTakerController.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 
+using Handelabra;
+
 namespace Cauldron.TheRam
 {
     public class TheRamTurnTakerController : TurnTakerController
@@ -18,16 +20,7 @@ namespace Cauldron.TheRam
             if (CharacterCardController is TheRamCharacterCardController)
             {
                 //"At the start of the game, put {TheRam}'s villain character cards into play, “Mechanical Juggernaut” side up.",
-
-                IEnumerator coroutine = HandleWinters(banish: true);
-                if (UseUnityCoroutines)
-                {
-                    yield return GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    GameController.ExhaustCoroutine(coroutine);
-                }
+                IEnumerator coroutine;
 
                 //"Search the villain deck for all copies of Up Close and put them in the trash. 
                 coroutine = MoveUpCloseToTrash();
@@ -65,16 +58,8 @@ namespace Cauldron.TheRam
             else
             {
                 //"At the start of the game, put {TheRam} and {AdmiralWinters}' villain character cards into play, “Amphibious Dreadnought” and “Dreadnought Pilot” sides up. 
+                IEnumerator coroutine;
 
-                IEnumerator coroutine = HandleWinters(banish: false);
-                if (UseUnityCoroutines)
-                {
-                    yield return GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    GameController.ExhaustCoroutine(coroutine);
-                }
                 //Search the villain deck for all copies of Up Close and put them in the trash. 
                 coroutine = MoveUpCloseToTrash();
                 if (UseUnityCoroutines)
@@ -125,6 +110,19 @@ namespace Cauldron.TheRam
                 GameController.ExhaustCoroutine(coroutine);
             }
             yield break;
+        }
+
+        public void HandleWintersEarly(bool banish = true)
+        {
+            Card winters = TurnTaker.FindCard("AdmiralWintersCharacter", true);
+            if (winters == null || winters.Location != TurnTaker.OffToTheSide)
+            {
+                Log.Debug("Failed to find Admiral Winters");
+                return;
+            }
+
+            Location targetLocation = banish ? TurnTaker.InTheBox : TurnTaker.PlayArea;
+            TurnTaker.MoveCard(winters, targetLocation);
         }
     }
 }

--- a/Controller/Villains/Tiamat/CardSubClasses/HydraTiamatInstructionsCardController.cs
+++ b/Controller/Villains/Tiamat/CardSubClasses/HydraTiamatInstructionsCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.Tiamat
         protected abstract ITrigger[] AddFrontTriggers();
         protected abstract ITrigger[] AddFrontAdvancedTriggers();
         protected abstract ITrigger[] AddBackTriggers();
-        protected IEnumerator alternateElementCoroutine;
+        protected virtual IEnumerator alternateElementCoroutine => null;
 
         public string FirstHead { get; }
         public string SecondHead { get; }
@@ -107,6 +107,8 @@ namespace Cauldron.Tiamat
         {
             //Whenever the corresponding "Element of" Card enters play and the firstHead is decapitated, if the secondHead is active do the alternate response.
             IEnumerator coroutine = alternateElementCoroutine;
+            Log.Debug("Attempting AlternateElementResponse.");
+            Log.Debug($"Possible nulls: Firsthead? {FirstHeadCardController() == null} SecondHead? {SecondHeadCardController() == null} Alt coroutine? {alternateElementCoroutine == null}");
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/Controller/Villains/Tiamat/CardSubClasses/HydraTiamatInstructionsCardController.cs
+++ b/Controller/Villains/Tiamat/CardSubClasses/HydraTiamatInstructionsCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.Tiamat
         protected abstract ITrigger[] AddFrontTriggers();
         protected abstract ITrigger[] AddFrontAdvancedTriggers();
         protected abstract ITrigger[] AddBackTriggers();
-        protected virtual IEnumerator alternateElementCoroutine => null;
+        protected virtual IEnumerator alternateElementCoroutine => DoNothing();
 
         public string FirstHead { get; }
         public string SecondHead { get; }
@@ -107,8 +107,6 @@ namespace Cauldron.Tiamat
         {
             //Whenever the corresponding "Element of" Card enters play and the firstHead is decapitated, if the secondHead is active do the alternate response.
             IEnumerator coroutine = alternateElementCoroutine;
-            Log.Debug("Attempting AlternateElementResponse.");
-            Log.Debug($"Possible nulls: Firsthead? {FirstHeadCardController() == null} SecondHead? {SecondHeadCardController() == null} Alt coroutine? {alternateElementCoroutine == null}");
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/Controller/Villains/Tiamat/Cards/ElementalFrenzyCardController.cs
+++ b/Controller/Villains/Tiamat/Cards/ElementalFrenzyCardController.cs
@@ -13,10 +13,23 @@ namespace Cauldron.Tiamat
         public ElementalFrenzyCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             base.SpecialStringMaker.ShowNumberOfCardsUnderCard(base.Card);
-            this._primed = false;
+            this._primed = true;
         }
 
         private bool _primed;
+
+        public override void AddStartOfGameTriggers()
+        {
+            this._primed = true;
+            base.AddTrigger<CardEntersPlayAction>((CardEntersPlayAction cpa) => cpa.CardEnteringPlay == base.Card, this.MarkNotPrimed, TriggerType.Hidden, TriggerTiming.Before);
+        }
+
+        private IEnumerator MarkNotPrimed(CardEntersPlayAction cpa)
+        {
+            this._primed = false;
+            yield return null;
+            yield break;
+        }
 
         public override IEnumerator Play()
         {

--- a/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/HydraWinterTiamatCharacterCardController.cs
+++ b/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/HydraWinterTiamatCharacterCardController.cs
@@ -10,6 +10,12 @@ namespace Cauldron.Tiamat
 
         }
 
+        public override void AddStartOfGameTriggers()
+        {
+            base.AddStartOfGameTriggers();
+            (TurnTakerController as TiamatTurnTakerController).MoveStartingCards();
+        }
+
         protected override ITrigger[] AddFrontTriggers()
         {
             return new ITrigger[]

--- a/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/Instructions/HydraFrigidEarthTiamatInstructionsCardController.cs
+++ b/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/Instructions/HydraFrigidEarthTiamatInstructionsCardController.cs
@@ -12,12 +12,8 @@ namespace Cauldron.Tiamat
 
         }
 
-        public override IEnumerator Play()
-        {
-            //Whenever Element of Ice enters play and {WinterTiamatCharacter} is decapitated, if {EarthTiamatCharacter} is active she deals the hero target with the highest HP X melee damage, where X = {H} plus the number of Sky Breaker cards in the villain trash.
-            this.alternateElementCoroutine = base.DealDamageToHighestHP(base.SecondHeadCardController().Card, 1, (Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndNotUnderCard, (Card c) => this.PlusNumberOfACardInTrash(Game.H, "SkyBreaker"), DamageType.Melee);
-            yield break;
-        }
+        //Whenever Element of Ice enters play and {WinterTiamatCharacter} is decapitated, if {EarthTiamatCharacter} is active she deals the hero target with the highest HP X melee damage, where X = {H} plus the number of Sky Breaker cards in the villain trash.
+        protected override IEnumerator alternateElementCoroutine => base.DealDamageToHighestHP(base.SecondHeadCardController().Card, 1, (Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndNotUnderCard, (Card c) => this.PlusNumberOfACardInTrash(Game.H, "SkyBreaker"), DamageType.Melee);
 
         protected override ITrigger[] AddFrontTriggers()
         {

--- a/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/Instructions/HydraNoxiousFireTiamatInstructionsCardController.cs
+++ b/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/Instructions/HydraNoxiousFireTiamatInstructionsCardController.cs
@@ -13,12 +13,8 @@ namespace Cauldron.Tiamat
 
         }
 
-        public override IEnumerator Play()
-        {
-            //Whenever Element of Fire enters play and {InfernoTiamatCharacter} is decapitated, if {DecayTiamatCharacter} is active she deals each hero target X toxic damage, where X = 2 plus the number of Acid Breaths in the villain trash.
-            this.alternateElementCoroutine = base.DealDamage(base.SecondHeadCardController().Card, (Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndNotUnderCard, (Card c) => this.PlusNumberOfACardInTrash(2, "AcidBreath"), DamageType.Toxic);
-            yield break;
-        }
+        //Whenever Element of Fire enters play and {InfernoTiamatCharacter} is decapitated, if {DecayTiamatCharacter} is active she deals each hero target X toxic damage, where X = 2 plus the number of Acid Breaths in the villain trash.
+        protected override IEnumerator alternateElementCoroutine => base.DealDamage(base.SecondHeadCardController().Card, (Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndNotUnderCard, (Card c) => this.PlusNumberOfACardInTrash(2, "AcidBreath"), DamageType.Toxic);
 
         protected override ITrigger[] AddFrontTriggers()
         {

--- a/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/Instructions/HydraThunderousGaleTiamatInstructionsCardController.cs
+++ b/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/Instructions/HydraThunderousGaleTiamatInstructionsCardController.cs
@@ -13,13 +13,9 @@ namespace Cauldron.Tiamat
         {
 
         }
-
-        public override IEnumerator Play()
-        {
-            //Whenever Element of Lightning enters play and {StormTiamatCharacter} is decapitated, if {WindTiamatCharacter} is active she deals the X hero targets with the Highest HP {H - 1} projectile damage each, where X = 1 plus the number of ongoing cards in the villain trash.
-            this.alternateElementCoroutine = base.DealDamageToHighestHP(base.SecondHeadCardController().Card, 1, (Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndNotUnderCard, (Card c) => new int?(Game.H - 1), DamageType.Projectile, numberOfTargets: () => 1 + NumberOfOngoingsInTrash());
-            yield break;
-        }
+        
+        //Whenever Element of Lightning enters play and {StormTiamatCharacter} is decapitated, if {WindTiamatCharacter} is active she deals the X hero targets with the Highest HP {H - 1} projectile damage each, where X = 1 plus the number of ongoing cards in the villain trash.
+        protected override IEnumerator alternateElementCoroutine => base.DealDamageToHighestHP(base.SecondHeadCardController().Card, 1, (Card c) => c.IsHero && c.IsTarget && c.IsInPlayAndNotUnderCard, (Card c) => new int?(Game.H - 1), DamageType.Projectile, numberOfTargets: () => 1 + NumberOfOngoingsInTrash());
 
         protected override ITrigger[] AddFrontTriggers()
         {

--- a/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
+++ b/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
@@ -93,37 +93,5 @@ namespace Cauldron.Tiamat
                 TurnTaker.MoveCard(c, TurnTaker.InTheBox);
             }
         }
-
-        private IEnumerator ManageCharacters()
-        {
-            IEnumerator coroutine;
-            //Start in play
-            foreach (Card c in this.inPlay)
-            {
-                coroutine = base.GameController.PlayCard(this, c);
-                if (base.UseUnityCoroutines)
-                {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
-                }
-            }
-            //Banish to Box
-            foreach (Card c in this.inBox)
-            {
-                coroutine = base.GameController.MoveCard(this, c, base.TurnTaker.InTheBox);
-                if (base.UseUnityCoroutines)
-                {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
-                }
-            }
-            yield break;
-        }
     }
 }

--- a/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
+++ b/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
@@ -31,35 +31,11 @@ namespace Cauldron.Tiamat
             Card hydraEarthInstructions = base.TurnTaker.GetCardByIdentifier("HydraFrigidEarthTiamatInstructions");
             Card hydraDecayInstructions = base.TurnTaker.GetCardByIdentifier("HydraNoxiousFireTiamatInstructions");
             Card hydraWindInstructions = base.TurnTaker.GetCardByIdentifier("HydraThunderousGaleTiamatInstructions");
-            if (base.FindCardController(base.CharacterCard) is WinterTiamatCharacterCardController)
-            {//Regular Tiamat
-                this.inPlay = new Card[] { inferno, storm };
-                this.inBox = new Card[] { hydraInferno, hydraStorm, hydraEarth, hydraDecay, hydraWind, hydraEarthInstructions, hydraDecayInstructions, hydraWindInstructions };
-                IEnumerator coroutine = this.ManageCharacters();
-                if (base.UseUnityCoroutines)
-                {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
-                }
-            }
+
             if (base.FindCardController(base.CharacterCard) is HydraWinterTiamatCharacterCardController)
             {//Elemental Hydra
-                this.inBox = new Card[] { inferno, storm };
-                this.inPlay = new Card[] { hydraInferno, hydraStorm, hydraEarthInstructions, hydraDecayInstructions, hydraWindInstructions };
-                IEnumerator coroutine = this.ManageCharacters();
-                if (base.UseUnityCoroutines)
-                {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
-                }
                 //Secondary Heads start underneath other heads
-                coroutine = base.GameController.MoveCard(this, hydraEarth, winter.UnderLocation, flipFaceDown: true);
+                IEnumerator coroutine = base.GameController.MoveCard(this, hydraEarth, winter.UnderLocation, flipFaceDown: true);
                 IEnumerator coroutine2 = base.GameController.MoveCard(this, hydraDecay, hydraInferno.UnderLocation, flipFaceDown: true);
                 IEnumerator coroutine3 = base.GameController.MoveCard(this, hydraWind, hydraStorm.UnderLocation, flipFaceDown: true);
                 if (base.UseUnityCoroutines)
@@ -76,6 +52,46 @@ namespace Cauldron.Tiamat
                 }
             }
             yield break;
+        }
+
+        public void MoveStartingCards()
+        {
+            //Winter is in both, just has promoIdentifier differentiating
+            Card winter = base.TurnTaker.GetCardByIdentifier("WinterTiamatCharacter");
+            //Regular
+            Card inferno = base.TurnTaker.GetCardByIdentifier("InfernoTiamatCharacter");
+            Card storm = base.TurnTaker.GetCardByIdentifier("StormTiamatCharacter");
+            //Hydra
+            Card hydraStorm = base.TurnTaker.GetCardByIdentifier("HydraStormTiamatCharacter");
+            Card hydraInferno = base.TurnTaker.GetCardByIdentifier("HydraInfernoTiamatCharacter");
+            Card hydraEarth = base.TurnTaker.GetCardByIdentifier("HydraEarthTiamatCharacter");
+            Card hydraDecay = base.TurnTaker.GetCardByIdentifier("HydraDecayTiamatCharacter");
+            Card hydraWind = base.TurnTaker.GetCardByIdentifier("HydraWindTiamatCharacter");
+            Card hydraEarthInstructions = base.TurnTaker.GetCardByIdentifier("HydraFrigidEarthTiamatInstructions");
+            Card hydraDecayInstructions = base.TurnTaker.GetCardByIdentifier("HydraNoxiousFireTiamatInstructions");
+            Card hydraWindInstructions = base.TurnTaker.GetCardByIdentifier("HydraThunderousGaleTiamatInstructions");
+            if (base.FindCardController(base.CharacterCard) is WinterTiamatCharacterCardController)
+            {//Regular Tiamat
+                this.inPlay = new Card[] { inferno, storm };
+                this.inBox = new Card[] { hydraInferno, hydraStorm, hydraEarth, hydraDecay, hydraWind, hydraEarthInstructions, hydraDecayInstructions, hydraWindInstructions };
+            }
+            if (base.FindCardController(base.CharacterCard) is HydraWinterTiamatCharacterCardController)
+            {//Elemental Hydra
+                this.inBox = new Card[] { inferno, storm };
+                this.inPlay = new Card[] { hydraInferno, hydraStorm, hydraEarthInstructions, hydraDecayInstructions, hydraWindInstructions };
+            }
+            SneakManageCharacters();
+        }
+        private void SneakManageCharacters()
+        {
+            foreach (Card c in this.inPlay)
+            {
+                TurnTaker.MoveCard(c, TurnTaker.PlayArea);
+            }
+            foreach (Card c in this.inBox)
+            {
+                TurnTaker.MoveCard(c, TurnTaker.InTheBox);
+            }
         }
 
         private IEnumerator ManageCharacters()

--- a/Controller/Villains/Tiamat/CharacterCards/WinterTiamatCharacterCardController.cs
+++ b/Controller/Villains/Tiamat/CharacterCards/WinterTiamatCharacterCardController.cs
@@ -26,6 +26,12 @@ namespace Cauldron.Tiamat
             };
         }
 
+        public override void AddStartOfGameTriggers()
+        {
+            base.AddStartOfGameTriggers();
+            (TurnTakerController as TiamatTurnTakerController).MoveStartingCards();
+        }
+
         protected override ITrigger[] AddFrontAdvancedTriggers()
         {
             return new ITrigger[]

--- a/DeckLists/Hero/StarlightDeckList.json
+++ b/DeckLists/Hero/StarlightDeckList.json
@@ -455,31 +455,31 @@
             "flavorReference": "Chrono-Ranger, The Dark Millenia #11"
         },
         {
-            "identifier": "StarlightOfTerraCharacter",
-            "promoIdentifier": "StarlightOfTerraCharacter",
-            "count": 1,
-            "title": "Starlight",
-            "promoTitle": "Starlight of Terra",
-            "shortPromoTitle": "Terra",
-            "body": "Radiance",
-            "backgroundColor": "FBF8F9",
-            "foilBackgroundColor": "FEFEFE",
-            "hitpointColor": "C94742",
-            "character": true,
-            "powers": [
-                "Discard a card. Search your deck for a copy of Exodus and put it in your hand. Shuffle your deck."
-            ],
-            "icons": [
-                "HasPower",
-                "Discard",
-                "Search"
-            ],
-            "hitpoints": 13,
-            "nemesisIdentifiers": [
-                "Starlight"
-            ],
-            "flippedTitle": "Incapacitated",
-            "complexity": 1
+             "identifier": "StarlightOfCryosFourCharacter",
+             "promoIdentifier": "StarlightOfCryosFourCharacter",
+             "count": 1,
+             "title": "Starlight",
+             "promoTitle": "Starlight of Cryos-4",
+             "shortPromoTitle": "Cryos-4",
+             "body": "Voidgaze",
+             "backgroundColor": "FBF8F9",
+             "foilBackgroundColor": "FEFEFE",
+             "hitpointColor": "C94742",
+             "character": true,
+             "powers": [
+                 "This Starlight deals herself 2 irreducible cold damage. If she takes damage this way, play 2 constellations from your trash."
+             ],
+             "icons": [
+                 "HasPower",
+                 "DealDamageCold",
+                 "PlayCardNow"
+             ],
+             "hitpoints": 15,
+             "nemesisIdentifiers": [
+                 "Starlight"
+             ],
+             "flippedTitle": "Incapacitated",
+             "complexity": 1
          },
          {
              "identifier": "StarlightOfAsheronCharacter",
@@ -509,31 +509,31 @@
              "complexity": 1
          },
          {
-             "identifier": "StarlightOfCryosFourCharacter",
-             "promoIdentifier": "StarlightOfCryosFourCharacter",
-             "count": 1,
-             "title": "Starlight",
-             "promoTitle": "Starlight of Cryos-4",
-             "shortPromoTitle": "Cryos-4",
-             "body": "Voidgaze",
-             "backgroundColor": "FBF8F9",
-             "foilBackgroundColor": "FEFEFE",
-             "hitpointColor": "C94742",
-             "character": true,
-             "powers": [
-                 "This Starlight deals herself 2 irreducible cold damage. If she takes damage this way, play 2 constellations from your trash."
-             ],
-             "icons": [
-                 "HasPower",
-                 "DealDamageCold",
-                 "PlayCardNow"
-             ],
-             "hitpoints": 15,
-             "nemesisIdentifiers": [
-                 "Starlight"
-             ],
-             "flippedTitle": "Incapacitated",
-             "complexity": 1
+            "identifier": "StarlightOfTerraCharacter",
+            "promoIdentifier": "StarlightOfTerraCharacter",
+            "count": 1,
+            "title": "Starlight",
+            "promoTitle": "Starlight of Terra",
+            "shortPromoTitle": "Terra",
+            "body": "Radiance",
+            "backgroundColor": "FBF8F9",
+            "foilBackgroundColor": "FEFEFE",
+            "hitpointColor": "C94742",
+            "character": true,
+            "powers": [
+                "Discard a card. Search your deck for a copy of Exodus and put it in your hand. Shuffle your deck."
+            ],
+            "icons": [
+                "HasPower",
+                "Discard",
+                "Search"
+            ],
+            "hitpoints": 13,
+            "nemesisIdentifiers": [
+                "Starlight"
+            ],
+            "flippedTitle": "Incapacitated",
+            "complexity": 1
          }
     ],
     "promoCards": [

--- a/DeckLists/Villain/TheRamDeckList.json
+++ b/DeckLists/Villain/TheRamDeckList.json
@@ -358,12 +358,12 @@
                 "Vanish"
             ],
             "gameplay": [
-                "The heroes cannot win the game. If {AdmiralWinters} would be destroyed, flip his character cards instead.",
+                "The heroes cannot win the game. If {AdmiralWintersCharacter} would be destroyed, flip his character cards instead.",
                 "At the start of a hero's turn, if that hero is not Up Close, you may take a copy of Up Close from the villain trash and play it next to that hero.",
-                "{AdmiralWinters} is immune to damage from targets that are not up close. The first time {AdmiralWinters} would be dealt damage each turn, redirect that damage to {TheRam}.",
-                "At the end of the villain turn, {AdmiralWinters} deals {H} projectile damage to each hero that is not Up Close. Then, play the top X cards of the villain deck, where X is the number of copies of Up Close in play minus 1."
+                "{AdmiralWintersCharacter} is immune to damage from targets that are not up close. The first time {AdmiralWintersCharacter} would be dealt damage each turn, redirect that damage to {TheRam}.",
+                "At the end of the villain turn, {AdmiralWintersCharacter} deals {H} projectile damage to each hero that is not Up Close. Then, play the top X cards of the villain deck, where X is the number of copies of Up Close in play minus 1."
             ],
-            "advanced": "Reduce damage dealt to {AdmiralWinters} by 1.",
+            "advanced": "Reduce damage dealt to {AdmiralWintersCharacter} by 1.",
             "icons": [
                 "RedirectDamage",
                 "DealDamageProjectile",
@@ -411,7 +411,7 @@
                 "Baccarat"
             ],
             "setup": [
-                "At the start of the game, put {TheRam} and {AdmiralWinters}' villain character cards into play, “Amphibious Dreadnought” and “Dreadnought Pilot” sides up. Search the villain deck for all copies of Up Close and put them in the trash. Put 2 copies of Remote Mortar into play. Shuffle the villain deck."
+                "At the start of the game, put the villain character cards for {TheRam} and {AdmiralWintersCharacter} into play, “Amphibious Dreadnought” and “Dreadnought Pilot” sides up. Search the villain deck for all copies of Up Close and put them in the trash. Put 2 copies of Remote Mortar into play. Shuffle the villain deck."
             ],
             "gameplay": [
                 "If {TheRam} is destroyed remove this card from the game.",

--- a/Testing/Heroes/StarlightVariantTests.cs
+++ b/Testing/Heroes/StarlightVariantTests.cs
@@ -64,7 +64,7 @@ namespace CauldronTests
         {
             var nightloreDict = new Dictionary<string, string> { };
             nightloreDict["Cauldron.Starlight"] = "NightloreCouncilStarlightCharacter";
-            nightloreDict["Legacy"] = "GreatestLegacyCharacter";
+            nightloreDict["Legacy"] = "AmericasGreatestLegacyCharacter";
             SetupGameController(new List<string> { "BaronBlade", "Cauldron.Starlight", "Legacy", "Megalopolis" }, false, nightloreDict);
 
             Assert.AreEqual(4, this.GameController.TurnTakerControllers.Count());


### PR DESCRIPTION
Correct ordering of Nightlore Council Starlight portraits

Tiamat and 1929 Ram use the "sneaking cards in early" method so their portraits load at start of game.

Fix some issues with Hydra Tiamat related to reloads