### PR TITLE
Swarming Protocol Cypher fix

### DIFF
--- a/Controller/Heroes/Cypher/CharacterCards/SwarmingProtocolCypherCharacterCardController.cs
+++ b/Controller/Heroes/Cypher/CharacterCards/SwarmingProtocolCypherCharacterCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.Cypher
         public override IEnumerator UsePower(int index = 0)
         {
             // Play a card face down next to a hero. Until leaving play it gains keyword 'Augment' and text 'This hero is augmented', 
-            var destinations = FindCardsWhere(c => c.IsHeroCharacterCard && c.IsInPlayAndHasGameText && !c.IsIncapacitatedOrOutOfGame)
+            var destinations = FindCardsWhere(c => c.IsHeroCharacterCard && c.IsInPlayAndHasGameText && !c.IsIncapacitatedOrOutOfGame && c.IsRealCard)
                                     .Select(c => new MoveCardDestination(c.NextToLocation))
                                     .ToArray();
 


### PR DESCRIPTION
Previously, it was allowing a facedown card next to the instructions card. The select hero character card was not filtering on non-real cards, which was allowing that choice. Added to criteria