### PR TITLE
Fix null reference error in Impact's base power

### DIFF
--- a/CauldronMods/Controller/Heroes/Impact/CharacterCards/ImpactCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Impact/CharacterCards/ImpactCharacterCardController.cs
@@ -58,7 +58,10 @@ namespace Cauldron.Impact
                 base.GameController.ExhaustCoroutine(coroutine);
             }
 
-            RemoveTrigger(previewBoost);
+            if (enoughOngoingsInPlay)
+            {
+                RemoveTrigger(previewBoost);
+            }
 
             var selectedTargets = targetDecision.SelectCardDecisions.Select(scd => scd.SelectedCard).Where((Card c) => c != null);
             if (selectedTargets.Count() == 0)


### PR DESCRIPTION
When there aren't any ongoings in play, it was trying to remove a null trigger