### PR TITLE
Null reference check in Unwitting Henchmen

### DIFF
--- a/CauldronMods/Controller/Villains/Gray/Cards/UnwittingHenchmenCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/Cards/UnwittingHenchmenCardController.cs
@@ -24,24 +24,22 @@ namespace Cauldron.Gray
             List<DestroyCardAction> storedResults = new List<DestroyCardAction>();
             //At the end of the villain turn, destroy 1 equipment card.
             IEnumerator coroutine;
-            if (this.FindNumberOfHeroEquipmentInPlay() > 0)
+
+            coroutine = base.GameController.SelectAndDestroyCard(this.DecisionMaker, new LinqCardCriteria((Card c) => base.IsEquipment(c)), false, storedResults, cardSource: base.GetCardSource());
+            if (base.UseUnityCoroutines)
             {
-                coroutine = base.GameController.SelectAndDestroyCard(this.DecisionMaker, new LinqCardCriteria((Card c) => base.IsEquipment(c)), false, storedResults, cardSource: base.GetCardSource());
-                if (base.UseUnityCoroutines)
-                {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
-                }
-                //If a card is destroyed this way 
-                DestroyCardAction destroyAction = storedResults.FirstOrDefault<DestroyCardAction>();
-                if (destroyAction.WasCardDestroyed)
-                {
-                    //...{Gray} regains 3 HP...
-                    coroutine = base.GameController.GainHP(base.CharacterCard, new int?(3), cardSource: base.GetCardSource());
-                }
+                yield return base.GameController.StartCoroutine(coroutine);
+            }
+            else
+            {
+                base.GameController.ExhaustCoroutine(coroutine);
+            }
+            //If a card is destroyed this way 
+            DestroyCardAction destroyAction = storedResults.FirstOrDefault<DestroyCardAction>();
+            if(destroyAction != null && destroyAction.WasCardDestroyed)
+            {
+                //...{Gray} regains 3 HP...
+                coroutine = base.GameController.GainHP(base.CharacterCard, new int?(3), cardSource: base.GetCardSource());  
             }
             else
             {

--- a/CauldronMods/Controller/Villains/Gray/Cards/UnwittingHenchmenCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/Cards/UnwittingHenchmenCardController.cs
@@ -25,7 +25,7 @@ namespace Cauldron.Gray
             //At the end of the villain turn, destroy 1 equipment card.
             IEnumerator coroutine;
 
-            coroutine = base.GameController.SelectAndDestroyCard(this.DecisionMaker, new LinqCardCriteria((Card c) => base.IsEquipment(c)), false, storedResults, cardSource: base.GetCardSource());
+            coroutine = base.GameController.SelectAndDestroyCard(this.DecisionMaker, new LinqCardCriteria((Card c) => base.IsEquipment(c), "equipment"), false, storedResults, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/Testing/Villains/GrayTests.cs
+++ b/Testing/Villains/GrayTests.cs
@@ -686,5 +686,23 @@ namespace CauldronTests
             GoToEndOfTurn(gray);
             QuickHPCheck(0, -1);
         }
+
+        [Test()]
+        public void TestUnwittingHenchmenFailedDestroyEquipment()
+        {
+            SetupGameController(new string[] { "Cauldron.Gray", "Legacy", "Haka", "Ra", "TimeCataclysm" });
+            StartGame();
+            PlayCard("UnwittingHenchmen");
+            DealDamage(legacy, gray, 5, DamageType.Cold);
+            AddCannotDealTrigger(gray, gray.CharacterCard);
+
+            PlayCard("FixedPoint");
+            PlayCard("TheLegacyRing");
+            //At the end of the villain turn, destroy 1 equipment card.
+            //If a card is destroyed this way, {Gray} regains 3 HP. Otherwise this card deals the hero target with the highest HP 1 melee damage.
+            QuickHPStorage(gray, haka);
+            GoToEndOfTurn(gray);
+            QuickHPCheck(0, -1);
+        }
     }
 }


### PR DESCRIPTION
Also tightens up some edge cases where there exists an equipment but for whatever reason it doesn't get destroyed - indestructibility, replacement effects, etc.

Fixes #729 