### PR TITLE
1929 Necro Rewind Crashes

### DIFF
--- a/CauldronMods/Controller/Heroes/Necro/CardSubClasses/NecroCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/CardSubClasses/NecroCardController.cs
@@ -24,7 +24,7 @@ namespace Cauldron.Necro
 
         protected bool IsHeroConsidering1929(Card card)
         {
-            if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
+            if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
             {
                 return IsVillain(card);
             }
@@ -33,7 +33,7 @@ namespace Cauldron.Necro
 
         protected bool IsVillianConsidering1929(Card card)
         {
-            if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
+            if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey)  == true)
             {
                 return card.IsHero;
             }
@@ -44,7 +44,7 @@ namespace Cauldron.Necro
         {
             get
             {
-                if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
+                if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
                 {
                     return "villain";
                 }
@@ -56,7 +56,7 @@ namespace Cauldron.Necro
         {
             get
             {
-                if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
+                if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
                 {
                     return "hero";
                 }


### PR DESCRIPTION
Similar to artifacts in Vault5, rewinds caused a game crash when playing certain cards with the power on 1929 necro active. Adding null checks seems to have resolved problems, although i don't have a super dependable way to test it