### PR TITLE
Drift extra incap fix

### DIFF
--- a/CauldronMods/Controller/Heroes/Drift/CardSubClasses/DriftSubCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/CardSubClasses/DriftSubCharacterCardController.cs
@@ -2,6 +2,7 @@
 using Handelabra.Sentinels.Engine.Model;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Cauldron.Drift
@@ -211,6 +212,24 @@ namespace Cauldron.Drift
             {
                 base.GameController.ExhaustCoroutine(coroutine);
             }
+        }
+
+        protected override IEnumerator RemoveCardsFromGame(IEnumerable<Card> cardsEnum)
+        {
+            //add special code to remove shift track from game
+            cardsEnum = cardsEnum.Where((Card c) => !c.IsCharacter && !c.IsMissionCard && !c.Location.IsOffToTheSide);
+            List<Card> cards = cardsEnum.ToList();
+            cards.Add(GetShiftTrack());
+            IEnumerator coroutine = base.GameController.BulkMoveCards(base.TurnTakerController, cards, base.TurnTakerControllerWithoutReplacements.TurnTaker.OutOfGame);
+            if (base.UseUnityCoroutines)
+            {
+                yield return base.GameController.StartCoroutine(coroutine);
+            }
+            else
+            {
+                base.GameController.ExhaustCoroutine(coroutine);
+            }
+           
         }
     }
 }

--- a/CauldronMods/Controller/Villains/Mythos/CardSubClasses/MythosUtilityCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/CardSubClasses/MythosUtilityCardController.cs
@@ -47,6 +47,12 @@ namespace Cauldron.Mythos
 
         public bool IsTopCardMatching(string type)
         {
+
+            if (TurnTaker.Deck.NumberOfCards == 0)
+            {
+                return false;
+            }
+
             //Advanced: Activate all {MythosDanger} effects.
             if (base.Game.IsAdvanced && type == MythosDangerDeckIdentifier)
             {

--- a/CauldronMods/Controller/Villains/Mythos/CharacterCards/MythosCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/CharacterCards/MythosCharacterCardController.cs
@@ -262,6 +262,11 @@ namespace Cauldron.Mythos
 
         private bool IsTopCardMatching(string type)
         {
+            if(TurnTaker.Deck.NumberOfCards == 0)
+            {
+                return false;
+            }
+
             //Advanced - Back: Activate all {MythosDanger} effects.
             if (base.Game.IsAdvanced && base.CharacterCard.IsFlipped && type == MythosDangerDeckIdentifier)
             {

--- a/Testing/Villains/MythosTests.cs
+++ b/Testing/Villains/MythosTests.cs
@@ -439,6 +439,20 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestMythosBack_SoftlockWhenNoCardsInDeck()
+        {
+            SetupGameController(new string[] { "Cauldron.Mythos", "Legacy", "Bunker", "Haka", "Megalopolis" });
+            StartGame();
+
+            DiscardTopCards(mythos.TurnTaker.Deck, mythos.TurnTaker.Deck.NumberOfCards);
+            DecisionsYesNo = new bool[] { false, false, false };
+            AddTokensToDangerousInvestigationPool(3);
+
+            GoToEndOfTurn();
+            AssertNotGameOver();
+        }
+
+        [Test()]
         public void TestMythosBack_Madness_SkipPlay()
         {
             SetupGameController(new string[] { "Cauldron.Mythos", "Legacy", "Bunker", "Haka", "Megalopolis" });


### PR DESCRIPTION
So while the previous fix allowed Drift to be incapped, it did not allow for games to end in defeat when all heroes all incapped. This was due to Shift Track still being in play.

I overrided the RemoveCardsFromGame to also remove Shift Track which fixed said issue.