### PR TITLE
Fix Drift incapacitation

### DIFF
--- a/CauldronMods/Controller/Heroes/Drift/Shift Track/DualShiftTrackUtilityCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/Shift Track/DualShiftTrackUtilityCardController.cs
@@ -21,6 +21,7 @@ namespace Cauldron.Drift
 
         public override void AddTriggers()
         {
+            base.AddTriggers();
             //Once per turn you may do the following in order:
             //1. Place your active character on your current shift track space.
             //2. Place the shift token on your inactive character's shift track space.

--- a/CauldronMods/Controller/Heroes/Drift/Shift Track/ShiftTrackUtilityCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/Shift Track/ShiftTrackUtilityCardController.cs
@@ -14,5 +14,48 @@ namespace Cauldron.Drift
         {
 
         }
+
+        public override void AddStartOfGameTriggers()
+        {
+            if (Card.IsInPlay && Card.IsFlipped)
+            {
+                AddFlipTriggers();
+            }
+        }
+
+        public override void AddTriggers()
+        {
+            base.AddTriggers();
+            AddFlipTriggers();
+        }
+
+        private void AddFlipTriggers()
+        {
+            AddTrigger((FlipCardAction fc) => fc.CardToFlip == CharacterCardController, FlipThisCardResponse, TriggerType.Hidden, TriggerTiming.After);
+        }
+
+        public override IEnumerator AfterFlipCardImmediateResponse()
+        {
+            if (Card.IsFlipped)
+            {
+                RemoveAllTriggers(includingOutOfPlay: true, includeUnresolvedOnDestroyTriggers: false);
+                AddFlipTriggers();
+            }
+            else if (Card.IsInPlay)
+            {
+                RemoveInhibitor();
+                AddCardTriggers();
+            }
+            yield return null;
+        }
+
+        private IEnumerator FlipThisCardResponse(FlipCardAction fc)
+        {
+            if (Card.IsFlipped != CharacterCard.IsFlipped)
+            {
+                return GameController.FlipCard(this, cardSource: GetCardSource());
+            }
+            return DoNothing();
+        }
     }
 }

--- a/Testing/Heroes/DriftTests.cs
+++ b/Testing/Heroes/DriftTests.cs
@@ -96,6 +96,34 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestDriftIncap()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Drift", "Haka", "Bunker", "TheScholar", "Megalopolis");
+            StartGame();
+
+            DealDamage(baron, haka, 50, 0);
+            DealDamage(baron, bunker, 50, 0);
+            DealDamage(baron, scholar, 50, 0);
+            DealDamage(baron, drift, 50, 0);
+            AssertGameOver();
+        }
+
+        [Test()]
+        public void TestDriftResurrect()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Drift", "Haka", "Bunker", "TheScholar", "TheTempleOfZhuLong");
+            StartGame();
+
+            DealDamage(baron, drift, 50, 0);
+            AssertIncapacitated(drift);
+
+            PlayCard("RitesOfRevival");
+            GoToEndOfTurn(base.env);
+            AssertNotIncapacitatedOrOutOfGame(drift);
+            AssertNotFlipped(GetShiftTrack());
+        }
+
+        [Test()]
         public void TestDriftCharacter_InnatePower()
         {
             SetupGameController("BaronBlade", "Cauldron.Drift", "Haka", "Bunker", "TheScholar", "Megalopolis");


### PR DESCRIPTION
The Shift Track flips when Drift does, so its "Card.IsIncapacitated" returns true and the game recognizes that all heroes have been defeated.