### PR TITLE
Restrict Drift's on-shift triggers to her own shifting

### DIFF
--- a/CauldronMods/Controller/Heroes/Drift/CardSubClasses/DriftBaseCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/CardSubClasses/DriftBaseCardController.cs
@@ -25,6 +25,7 @@ namespace Cauldron.Drift
 
         protected const string HasShifted = "HasShifted";
         protected const string ShiftTrack = "ShiftTrack";
+        protected const string ShiftPoolIdentifier = "ShiftPool";
 
         public int CurrentShiftPosition()
         {

--- a/CauldronMods/Controller/Heroes/Drift/Cards/MakeEverySecondCountCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/Cards/MakeEverySecondCountCardController.cs
@@ -18,10 +18,10 @@ namespace Cauldron.Drift
         public override void AddTriggers()
         {
             //{DriftPast} Whenever you shift {DriftL}, select a hero target. Reduce the next damage dealt to that target by 2.
-            base.AddTrigger<RemoveTokensFromPoolAction>((RemoveTokensFromPoolAction action) => base.IsTimeMatching(Past) && action.IsSuccessful && action.TokenPool.CurrentValue == 1, this.ShiftResponse, TriggerType.ReduceDamageOneUse, TriggerTiming.After);
+            base.AddTrigger<RemoveTokensFromPoolAction>((RemoveTokensFromPoolAction action) => base.IsTimeMatching(Past) && action.IsSuccessful && action.TokenPool.Identifier == ShiftPoolIdentifier && action.TokenPool.CurrentValue == 1, this.ShiftResponse, TriggerType.ReduceDamageOneUse, TriggerTiming.After);
 
             //{DriftFuture} Whenever you shift {DriftR}, select a hero target. Increase the next damage dealt by that target by 2.
-            base.AddTrigger<AddTokensToPoolAction>((AddTokensToPoolAction action) => base.IsTimeMatching(Future) && action.IsSuccessful && action.TokenPool.CurrentValue == 4, this.ShiftResponse, TriggerType.IncreaseDamage, TriggerTiming.After);
+            base.AddTrigger<AddTokensToPoolAction>((AddTokensToPoolAction action) => base.IsTimeMatching(Future) && action.IsSuccessful && action.TokenPool.Identifier == ShiftPoolIdentifier && action.TokenPool.CurrentValue == 4, this.ShiftResponse, TriggerType.IncreaseDamage, TriggerTiming.After);
         }
 
         private IEnumerator ShiftResponse(ModifyTokensAction action)

--- a/CauldronMods/Controller/Heroes/Drift/Cards/TransitionShockCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/Cards/TransitionShockCardController.cs
@@ -18,9 +18,9 @@ namespace Cauldron.Drift
         public override void AddTriggers()
         {
             //Whenever you shift from {DriftPast} to {DriftFuture}... 
-            base.AddTrigger<AddTokensToPoolAction>((AddTokensToPoolAction action) => action.IsSuccessful && action.TokenPool.CurrentValue == 3, this.DealDamageResponse, TriggerType.DealDamage, TriggerTiming.After);
+            base.AddTrigger<AddTokensToPoolAction>((AddTokensToPoolAction action) => action.IsSuccessful && action.TokenPool.Identifier == ShiftPoolIdentifier && action.TokenPool.CurrentValue == 3, this.DealDamageResponse, TriggerType.DealDamage, TriggerTiming.After);
             //...or from {DriftFuture} to {DriftPast}...
-            base.AddTrigger<RemoveTokensFromPoolAction>((RemoveTokensFromPoolAction action) => action.IsSuccessful && action.TokenPool.CurrentValue == 2, this.DealDamageResponse, TriggerType.DealDamage, TriggerTiming.After);
+            base.AddTrigger<RemoveTokensFromPoolAction>((RemoveTokensFromPoolAction action) => action.IsSuccessful && action.TokenPool.Identifier == ShiftPoolIdentifier && action.TokenPool.CurrentValue == 2, this.DealDamageResponse, TriggerType.DealDamage, TriggerTiming.After);
             //...{Drift} may deal 1 other target and herself 1 psychic damage.
         }
 

--- a/Testing/Heroes/DriftTests.cs
+++ b/Testing/Heroes/DriftTests.cs
@@ -936,6 +936,22 @@ namespace CauldronTests
             DealDamage(haka, haka, 3, DamageType.Melee);
             QuickHPCheck(-3);
         }
+        [Test]
+        public void TestMakeEverySecondCount_OnlyShiftTrack()
+        {
+            SetupGameController("Apostate", "Cauldron.Drift", "Setback", "Bunker", "TheScholar", "Megalopolis");
+            StartGame();
+
+            PlayCard("MakeEverySecondCount");
+
+            PlayCard("FriendlyFire");
+            DecisionYesNo = true;
+            GoToShiftPosition(3);
+
+            DealDamage(drift, apostate, 1, DamageType.Melee);
+            AssertMaxNumberOfDecisions(1);
+            DealDamage(drift, apostate, 1, DamageType.Melee);
+        }
 
         [Test]
         public void TestOutOfSync()
@@ -1171,6 +1187,18 @@ namespace CauldronTests
             DecisionYesNo = false;
             GoToShiftPosition(3);
             QuickHPCheckZero();
+        }
+        [Test]
+        public void TestTransitionShock_OnlyShiftTrack()
+        {
+            SetupGameController("Apostate", "Cauldron.Drift", "Setback", "Bunker", "TheScholar", "TimeCataclysm");
+            StartGame();
+
+            PlayCard(TransitionShock);
+            Card lookingUp = PlayCard("LookingUp");
+
+            AssertMaxNumberOfDecisions(1);
+            UsePower(lookingUp);
         }
     }
 }


### PR DESCRIPTION
Formerly they were going off if *any* token pool was modified to the proper amount.