### PR TITLE
Fix for #644 (kinda) - 1929 Tango One

### DIFF
--- a/Testing/Heroes/TangoOnePromoTests.cs
+++ b/Testing/Heroes/TangoOnePromoTests.cs
@@ -176,7 +176,6 @@ namespace CauldronTests
             StartGame();
 
             QuickHPStorage(legacy);
-
             DecisionSelectTarget = legacy.CharacterCard;
 
             GoToStartOfTurn(tango);
@@ -188,7 +187,16 @@ namespace CauldronTests
 
             GoToEndOfTurn(tango);
             QuickHPCheck(0); // Damage won't trigger until start of Tango's next turn
+
+            //save and load a few times to make sure the status effect sticks around
             SaveAndLoad();
+            GoToNextTurn();
+            SaveAndLoad();
+            GoToNextTurn();
+            SaveAndLoad();
+
+            //regrab the hp value of legaacy
+            QuickHPStorage(legacy);
             GoToEndOfTurn(tango);  // Go back around to Tango's turn
             QuickHPCheck(-3); // Damage should now have been attempted
         }

--- a/Testing/Heroes/TangoOnePromoTests.cs
+++ b/Testing/Heroes/TangoOnePromoTests.cs
@@ -188,7 +188,7 @@ namespace CauldronTests
 
             GoToEndOfTurn(tango);
             QuickHPCheck(0); // Damage won't trigger until start of Tango's next turn
-
+            SaveAndLoad();
             GoToEndOfTurn(tango);  // Go back around to Tango's turn
             QuickHPCheck(-3); // Damage should now have been attempted
         }


### PR DESCRIPTION
Closes #644 

I created a test that added in Save and Loading to 1929 Tango One power, and it goes off without a hitch. 
Closing the PR as cannot replicate but I figure the added lines into the test code is worth having, hence this PR