### PR TITLE
fix for #984 - stubborn goliath status effect

### DIFF
--- a/CauldronMods/Controller/Heroes/Titan/Cards/StubbornGoliathCardController.cs
+++ b/CauldronMods/Controller/Heroes/Titan/Cards/StubbornGoliathCardController.cs
@@ -64,6 +64,7 @@ namespace Cauldron.Titan
                 onDealDamageStatusEffect.TargetCriteria.IsNotSpecificCard = this.CharacterCard;
 
                 onDealDamageStatusEffect.UntilTargetLeavesPlay(dd.Target);
+                onDealDamageStatusEffect.TargetLeavesPlayExpiryCriteria.Card = this.CharacterCard;
                 onDealDamageStatusEffect.BeforeOrAfter = BeforeOrAfter.Before;
                 onDealDamageStatusEffect.CanEffectStack = true;
 


### PR DESCRIPTION
stubborn goliath's redirection status effect while strictly doesn't expire when titan is destroyed, doesn't make sense, as you can't redirect that damage to Titan anymore

Closes #984 