### PR TITLE
added missing promo title for dual drift

### DIFF
--- a/CauldronMods/DeckLists/Hero/DriftDeckList.json
+++ b/CauldronMods/DeckLists/Hero/DriftDeckList.json
@@ -929,6 +929,7 @@
         {
             "identifier": "DriftCharacter",
             "promoIdentifier": "DualDriftCharacter",
+            "promoTitle": "Dual Drift",
             "count": 1,
             "title": "Drift",
             "backgroundColor": "ECCD96",


### PR DESCRIPTION
closes #995 

![20210227082127_1](https://user-images.githubusercontent.com/32969943/109390031-db258080-78d4-11eb-9706-1e4d456c2240.jpg)
