### PR TITLE
Tiamat element of lightning fixes

### DIFF
--- a/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatSubCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatSubCharacterCardController.cs
@@ -2,6 +2,7 @@
 using Handelabra.Sentinels.Engine.Model;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Cauldron.Tiamat
@@ -48,18 +49,17 @@ namespace Cauldron.Tiamat
         {
             if (ttc is HeroTurnTakerController httc)
             {
-                return httc.CharacterCardControllers.Any(chc => chc.GetCardPropertyJournalEntryBoolean(ElementOfLightningCardController.PreventDrawPropertyKey) == true);
+                bool? criteriaMet =  Game.Journal.GetCardPropertiesStringList(Card, ElementOfLightningCardController.PreventDrawPropertyKey)?.Any(id => id == httc.TurnTaker.Identifier);
+                return criteriaMet is null ? false : criteriaMet.Value;
             }
             return false;
         }
 
         protected IEnumerator ClearLightningEffectResponse(PhaseChangeAction action)
         {
-            //Clear the secret property from all Character Cards 
-            foreach (HeroTurnTaker hero in Game.HeroTurnTakers)
-            {
-                GameController.AddCardPropertyJournalEntry(hero.CharacterCard, ElementOfLightningCardController.PreventDrawPropertyKey, (bool?)null);
-            }
+            //Clear the secret property from this Character Card
+            List<string> empty = new List<string>();
+            GameController.AddCardPropertyJournalEntry(Card, ElementOfLightningCardController.PreventDrawPropertyKey, empty);
             yield break;
         }
     }

--- a/Testing/Villains/TiamatHydraTests.cs
+++ b/Testing/Villains/TiamatHydraTests.cs
@@ -908,6 +908,55 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestElementOfLightningCantDrawCards_MultiChar()
+        {
+            SetupGameController("Cauldron.Tiamat/HydraWinterTiamatCharacter", "Legacy", "Bunker", "Haka", "TheSentinels", "Megalopolis");
+            StartGame();
+            DrawCard(sentinels); ;
+            //The hero with most cards in hand cannot draw cards until start of next villain turn
+            PlayCard(tiamat, GetCard("ElementOfLightning"));
+            GoToStartOfTurn(legacy);
+            QuickHandStorage(legacy, bunker, haka, sentinels);
+            DrawCard(legacy);
+            DrawCard(bunker);
+            DrawCard(haka);
+            DrawCard(sentinels);
+            QuickHandCheck(1, 1, 1, 0);
+            GoToStartOfTurn(tiamat);
+            QuickHandStorage(sentinels);
+            DrawCard(sentinels);
+            QuickHandCheck(1);
+
+            PrintJournal();
+
+        }
+
+        [Test()]
+        public void TestElementOfLightningCantDrawCards_CompletionistGuise()
+        {
+            SetupGameController("Cauldron.Tiamat/HydraWinterTiamatCharacter", "Legacy", "Bunker", "Haka", "Guise/CompletionistGuiseCharacter", "Megalopolis");
+            StartGame();
+            DrawCard(bunker); ;
+            //The hero with most cards in hand cannot draw cards until start of next villain turn
+            PlayCard(tiamat, GetCard("ElementOfLightning"));
+            GoToStartOfTurn(legacy);
+            DecisionSelectCard = bunker.CharacterCard;
+            UsePower(guise);
+            QuickHandStorage(legacy, bunker, haka, guise);
+            DrawCard(legacy);
+            DrawCard(bunker);
+            DrawCard(haka);
+            DrawCard(guise);
+            QuickHandCheck(1, 0, 1, 1);
+            GoToStartOfTurn(tiamat);
+            QuickHandStorage(bunker);
+            DrawCard(bunker);
+            QuickHandCheck(1);
+
+            PrintJournal();
+        }
+
+        [Test()]
         public void TestElementOfLightningCanDrawCardsNextTurn()
         {
             SetupGameController("Cauldron.Tiamat/HydraWinterTiamatCharacter", "Legacy", "Bunker", "Haka", "Megalopolis");
@@ -1621,6 +1670,8 @@ namespace CauldronTests
             GoToStartOfTurn(tiamat);
             AssertNotGameOver();
         }
+
+       
 
         [Test()]
         public void TestReloadNotLosingInformation()

--- a/Testing/Villains/TiamatTests.cs
+++ b/Testing/Villains/TiamatTests.cs
@@ -933,8 +933,63 @@ namespace CauldronTests
             DrawCard(legacy);
             DrawCard(bunker);
             DrawCard(haka);
-            PrintJournal();
             QuickHandCheck(1, 0, 1);
+            GoToStartOfTurn(tiamat);
+            QuickHandStorage(bunker);
+            DrawCard(bunker);
+            QuickHandCheck(1);
+
+            PrintJournal();
+
+        }
+
+        [Test()]
+        public void TestElementOfLightningCantDrawCards_MultiChar()
+        {
+            SetupGameController("Cauldron.Tiamat", "Legacy", "Bunker", "Haka", "TheSentinels/AdamantSentinelsInstructions", "Megalopolis");
+            StartGame();
+            DrawCard(sentinels); ;
+            //The hero with most cards in hand cannot draw cards until start of next villain turn
+            PlayCard(tiamat, GetCard("ElementOfLightning"));
+            GoToStartOfTurn(legacy);
+            QuickHandStorage(legacy, bunker, haka, sentinels);
+            DrawCard(legacy);
+            DrawCard(bunker);
+            DrawCard(haka);
+            DrawCard(sentinels);
+            QuickHandCheck(1, 1, 1, 0);
+            GoToStartOfTurn(tiamat);
+            QuickHandStorage(sentinels);
+            DrawCard(sentinels);
+            QuickHandCheck(1);
+
+            PrintJournal();
+
+        }
+
+        [Test()]
+        public void TestElementOfLightningCantDrawCards_CompletionistGuise()
+        {
+            SetupGameController("Cauldron.Tiamat", "Legacy", "Bunker", "Haka",  "Guise/CompletionistGuise", "Megalopolis");
+            StartGame();
+            DrawCard(bunker); ;
+            //The hero with most cards in hand cannot draw cards until start of next villain turn
+            PlayCard(tiamat, GetCard("ElementOfLightning"));
+            GoToStartOfTurn(legacy);
+            DecisionSelectCard = bunker.CharacterCard;
+            UsePower(guise);
+            QuickHandStorage(legacy, bunker, haka, guise);
+            DrawCard(legacy);
+            DrawCard(bunker);
+            DrawCard(haka);
+            DrawCard(guise);
+            QuickHandCheck(1, 0, 1, 1);
+            GoToStartOfTurn(tiamat);
+            QuickHandStorage(bunker);
+            DrawCard(bunker);
+            QuickHandCheck(1);
+
+            PrintJournal();
         }
 
         [Test()]


### PR DESCRIPTION
Closes #982 

Previously, Element of Lightning kept track of who isn't allowed to draw by character card, but that doesn't work for multi characters or if Completionist Guise swaps out the character card.

Changed the implementation to go based on the TurnTaker instead