### PR TITLE
Add check for game start

### DIFF
--- a/CauldronMods/Controller/Heroes/Impact/Cards/LocalMicrogravityCardController.cs
+++ b/CauldronMods/Controller/Heroes/Impact/Cards/LocalMicrogravityCardController.cs
@@ -12,7 +12,7 @@ namespace Cauldron.Impact
         private readonly string microKey = "LocalMicrogravityPreventionKey";
         public LocalMicrogravityCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            SpecialStringMaker.ShowHasBeenUsedThisTurn(microKey).Condition = () => Game.ActiveTurnTaker.IsEnvironment;
+            SpecialStringMaker.ShowHasBeenUsedThisTurn(microKey).Condition = () => Game.HasGameStarted && Game.ActiveTurnTaker.IsEnvironment;
         }
 
         public override IEnumerator Play()


### PR DESCRIPTION
Added a check to make sure the game is started before evaluating who the active turn taker is. Fixes a null exception.