### PR TITLE
Quicksilver combo improvements

### DIFF
--- a/CauldronMods/Controller/Heroes/Quicksilver/CardSubClasses/QuicksilverBaseCardController.cs
+++ b/CauldronMods/Controller/Heroes/Quicksilver/CardSubClasses/QuicksilverBaseCardController.cs
@@ -3,6 +3,7 @@ using Handelabra.Sentinels.Engine.Model;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Cauldron.Quicksilver
 {
@@ -37,12 +38,17 @@ namespace Cauldron.Quicksilver
 
         public IEnumerator ComboOrFinisherResponse()
         {
+            string comboMessage = "Deal yourself 2 melee damage and play a combo";
+            if(!HeroTurnTaker.Hand.Cards.Any(c => c.DoKeywordsContain("combo")))
+            {
+                comboMessage = "Deal yourself 2 melee damage to no effect";
+            }
             //You may play a Finisher, or {Quicksilver} may deal herself 2 melee damage and play a Combo.
             List<Function> functions = new List<Function> {
                 //You may play a Finisher,...
                 new Function(base.HeroTurnTakerController, "Play a finisher", SelectionType.PlayCard, () => base.GameController.SelectAndPlayCardFromHand(base.HeroTurnTakerController, true, cardCriteria: new LinqCardCriteria((Card c) => c.DoKeywordsContain("finisher"), "finisher"), cardSource: base.GetCardSource())),
                 //...{Quicksilver} may deal herself 2 melee damage and play a Combo.
-                new Function(base.HeroTurnTakerController, "Deal yourself 2 melee damage and play a combo", SelectionType.PlayCard, () => ContinueWithComboResponse())
+                new Function(base.HeroTurnTakerController, comboMessage, SelectionType.PlayCard, () => ContinueWithComboResponse())
             };
             IEnumerator coroutine = base.SelectAndPerformFunction(base.HeroTurnTakerController, functions, true);
             if (base.UseUnityCoroutines)

--- a/CauldronMods/Controller/Heroes/Quicksilver/Cards/LiquidMetalCardController.cs
+++ b/CauldronMods/Controller/Heroes/Quicksilver/Cards/LiquidMetalCardController.cs
@@ -12,6 +12,7 @@ namespace Cauldron.Quicksilver
     {
         public LiquidMetalCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
+            SpecialStringMaker.ShowNumberOfCardsAtLocation(HeroTurnTaker.Hand, cardCriteria: new LinqCardCriteria(c => c.DoKeywordsContain("combo"), "combo"));
         }
 
         public override IEnumerator Play()
@@ -56,7 +57,7 @@ namespace Cauldron.Quicksilver
             }
             List<YesNoCardDecision> storedResults = new List<YesNoCardDecision>();
             var fake = new DealDamageAction(GetCardSource(), new DamageSource(GameController, CharacterCard), CharacterCard, 2, DamageType.Melee);
-            coroutine = base.GameController.MakeYesNoCardDecision(base.HeroTurnTakerController, SelectionType.DealDamageSelf, base.Card, action: fake, storedResults: storedResults);
+            coroutine = base.GameController.MakeYesNoCardDecision(base.HeroTurnTakerController, SelectionType.DealDamageSelf, base.Card, action: fake, storedResults: storedResults, cardSource: GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/Testing/Heroes/QuicksilverTests.cs
+++ b/Testing/Heroes/QuicksilverTests.cs
@@ -189,6 +189,26 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestComboCombo_noCombosInHand()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Quicksilver", "Ra", "TheWraith", "Megalopolis");
+            StartGame();
+            DestroyNonCharacterVillainCards();
+
+            Card storm = GetCard("AlloyStorm", 1);
+            DiscardAllCards(quicksilver);
+            PutInHand(storm);
+
+            DecisionSelectFunction = 1;
+            DecisionSelectCard = storm;
+            //{Quicksilver} may deal herself 2 melee damage and play a Combo.
+            QuickHPStorage(baron, ra, quicksilver, wraith);
+            PlayCard(storm);
+            //Playing Alloy Storm twice pickinmg continue combo twice deals all non-hero -1x2 and Quicksilver -2x2
+            QuickHPCheck(-1, 0, -2, 0);
+        }
+
+        [Test()]
         public void TestComboFinisher()
         {
             SetupGameController("BaronBlade", "Cauldron.Quicksilver", "Ra", "TheWraith", "Megalopolis");


### PR DESCRIPTION
If there are no more combos in hand, the "Deal self damage to play a combo" now explicitly calls out "Deal self damage to no effect"