### PR TITLE
The knight and oblivaeon

### DIFF
--- a/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/RoninAssignableCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/RoninAssignableCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.TheKnight
             IEnumerator coroutine;
             if(this.TurnTakerControllerWithoutReplacements.HasMultipleCharacterCards && !_useSpecialAssignment)
             {
-                coroutine = SelectCardThisCardWillMoveNextTo(new LinqCardCriteria((Card c) => IsOwnCharacterCard(c), "Knight character"), storedResults, isPutIntoPlay, decisionSources);
+                coroutine = SelectCardThisCardWillMoveNextTo(new LinqCardCriteria((Card c) => IsOwnCharacterCard(c) && c.IsInPlayAndHasGameText && !c.IsIncapacitatedOrOutOfGame, "Knight character"), storedResults, isPutIntoPlay, decisionSources);
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/TheKnightCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/TheKnightCardController.cs
@@ -72,7 +72,7 @@ namespace Cauldron.TheKnight
         {
             if (base.HeroTurnTakerController.HasMultipleCharacterCards)
             {
-                var criteria = new LinqCardCriteria(c => IsOwnCharacterCard(c), "hero character cards");
+                var criteria = new LinqCardCriteria(c => IsOwnCharacterCard(c) && c.IsInPlayAndHasGameText && !c.IsIncapacitatedOrOutOfGame, "hero character cards");
                 var coroutine = base.GameController.SelectCardAndStoreResults(this.DecisionMaker, selectionType, criteria, results, false, cardSource: base.GetCardSource());
                 if (base.UseUnityCoroutines)
                 {

--- a/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/TheKnightUtilityCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/TheKnightUtilityCharacterCardController.cs
@@ -17,9 +17,9 @@ namespace Cauldron.TheKnight
 
         public override void AddStartOfGameTriggers()
         {
-            if (IsCoreCharacterCard)
+            if (IsCoreCharacterCard && !Card.IsIncapacitatedOrOutOfGame && HeroTurnTakerController is TheKnightTurnTakerController knightTTC)
             {
-                (TurnTakerController as TheKnightTurnTakerController).ManageCharactersOffToTheSide(true);
+                knightTTC.ManageCharactersOffToTheSide(true);
             }
         }
         public override void AddSideTriggers()

--- a/CauldronMods/Controller/Heroes/TheKnight/CharacterCards/WastelandRoninTheKnightCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CharacterCards/WastelandRoninTheKnightCharacterCardController.cs
@@ -40,20 +40,28 @@ namespace Cauldron.TheKnight
         }
         public override void AddStartOfGameTriggers()
         {
-            var cards = (HeroTurnTakerController as TheKnightTurnTakerController).ManageCharactersOffToTheSide(false);
+            if (Card.IsIncapacitatedOrOutOfGame)
+            {
+                return;
+            }
 
-            _youngKnight = cards.Where((Card c) => c.Identifier == "TheYoungKnightCharacter").FirstOrDefault();
-            _oldKnight = cards.Where((Card c) => c.Identifier == "TheOldKnightCharacter").FirstOrDefault();
+            if (HeroTurnTakerController is TheKnightTurnTakerController knightTTC)
+            {
+                var cards = knightTTC.ManageCharactersOffToTheSide(false);
+
+                _youngKnight = cards.Where((Card c) => c.Identifier == "TheYoungKnightCharacter").FirstOrDefault();
+                _oldKnight = cards.Where((Card c) => c.Identifier == "TheOldKnightCharacter").FirstOrDefault();
 
 
-            //"If you have no hero character targets in play, flip this card.",
-            //"When 1 of your equipment cards enter play, put it next to 1 of your active knights.",
-            //"When your cards refer to “The Knight”, choose 1 of your active knights. For equipment cards, you must choose the knight they are next to. Stalwart Shield does not reduce damage to the other knight's equipment targets.",
+                //"If you have no hero character targets in play, flip this card.",
+                //"When 1 of your equipment cards enter play, put it next to 1 of your active knights.",
+                //"When your cards refer to “The Knight”, choose 1 of your active knights. For equipment cards, you must choose the knight they are next to. Stalwart Shield does not reduce damage to the other knight's equipment targets.",
 
-            //"Whenever an equipment enters play next to The Young Knight, she deals 1 target 1 toxic damage.",
-            AddTrigger((CardEntersPlayAction cep) => IsEquipment(cep.CardEnteringPlay) && GetKnightCardUser(cep.CardEnteringPlay) == youngKnight, YoungKnightDamageResponse, TriggerType.DealDamage, TriggerTiming.After);
-            //"Whenever an equipment card enters play next to The Old Knight, draw a card."
-            AddTrigger((CardEntersPlayAction cep) => IsEquipment(cep.CardEnteringPlay) && GetKnightCardUser(cep.CardEnteringPlay) == oldKnight, OldKnightDrawResponse, TriggerType.DealDamage, TriggerTiming.After);
+                //"Whenever an equipment enters play next to The Young Knight, she deals 1 target 1 toxic damage.",
+                AddTrigger((CardEntersPlayAction cep) => IsEquipment(cep.CardEnteringPlay) && GetKnightCardUser(cep.CardEnteringPlay) == youngKnight, YoungKnightDamageResponse, TriggerType.DealDamage, TriggerTiming.After);
+                //"Whenever an equipment card enters play next to The Old Knight, draw a card."
+                AddTrigger((CardEntersPlayAction cep) => IsEquipment(cep.CardEnteringPlay) && GetKnightCardUser(cep.CardEnteringPlay) == oldKnight, OldKnightDrawResponse, TriggerType.DealDamage, TriggerTiming.After);
+            }
         }
 
         private IEnumerator YoungKnightDamageResponse(CardEntersPlayAction cep)

--- a/Testing/CauldronBaseTest.cs
+++ b/Testing/CauldronBaseTest.cs
@@ -30,6 +30,10 @@ namespace CauldronTests
         protected HeroTurnTakerController tango { get { return FindHero("TangoOne"); } }
         protected HeroTurnTakerController terminus { get { return FindHero("Terminus"); } }
         protected HeroTurnTakerController knight { get { return FindHero("TheKnight"); } }
+
+        protected Card youngKnight { get { return GetCard("TheYoungKnightCharacter"); } }
+        protected Card oldKnight { get { return GetCard("TheOldKnightCharacter"); } }
+
         protected HeroTurnTakerController stranger { get { return FindHero("TheStranger"); } }
         protected HeroTurnTakerController titan { get { return FindHero("Titan"); } }
         protected HeroTurnTakerController vanish { get { return FindHero("Vanish"); } }

--- a/Testing/Heroes/TheKnightTests.cs
+++ b/Testing/Heroes/TheKnightTests.cs
@@ -709,6 +709,60 @@ namespace CauldronTests
         }
 
         [Test]
+        [Description("TheKnight - HeavySwing in Oblivaeon")]
+        public void HeavySwing_OblivaeonSelectingWhoDealsDamage()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Ra", "Legacy", "Haka", "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            DealDamage(oblivaeon, ra, 100, DamageType.Fire, isIrreducible: true, ignoreBattleZone: true);
+            GoToAfterEndOfTurn(oblivaeon);
+            DecisionSelectFromBoxIdentifiers = new string[] { "TheKnight" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Cauldron.TheKnight";
+            RunActiveTurnPhase();
+           
+
+            Card heavy = PutInHand(knight, "HeavySwing");
+
+            PrintSeparator("Test");
+            GoToPlayCardPhase(knight);
+            QuickHPStorage(oblivaeon);
+            DecisionSelectTarget = oblivaeon.CharacterCard;
+            AssertNoDecision(SelectionType.HeroToDealDamage);
+            PlayCard(knight, heavy);
+            QuickHPCheck(-3);
+            AssertInTrash(heavy);
+        }
+
+        [Test]
+        [Description("TheKnight - HeavySwing in Oblivaeon")]
+        public void HeavySwing_OblivaeonSelectingWhoDealsDamage_IncappedRonins()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.TheKnight/WastelandRoninTheKnightCharacter", "Legacy", "Haka", "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            DealDamage(oblivaeon.CharacterCard, youngKnight, 100, DamageType.Fire, isIrreducible: true, ignoreBattleZone: true);
+            DealDamage(oblivaeon.CharacterCard, oldKnight, 100, DamageType.Fire, isIrreducible: true, ignoreBattleZone: true);
+
+            GoToAfterEndOfTurn(oblivaeon);
+            DecisionSelectFromBoxIdentifiers = new string[] { "TheKnight" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Cauldron.TheKnight";
+            RunActiveTurnPhase();
+
+
+            Card heavy = PutInHand(knight, "HeavySwing");
+
+            PrintSeparator("Test");
+            GoToPlayCardPhase(knight);
+            QuickHPStorage(oblivaeon);
+            DecisionSelectTarget = oblivaeon.CharacterCard;
+            AssertNoDecision(SelectionType.HeroToDealDamage);
+            PlayCard(knight, heavy);
+            QuickHPCheck(-3);
+            AssertInTrash(heavy);
+        }
+
+        [Test]
         [Description("TheKnight - KnightsHonor")]
         public void KnightsHonor_TestRedirect()
         {

--- a/Testing/Heroes/TheKnightVariantTests.cs
+++ b/Testing/Heroes/TheKnightVariantTests.cs
@@ -16,9 +16,6 @@ namespace CauldronTests
         #region HelperFunctions
         protected string HeroNamespace = "Cauldron.TheKnight";
 
-
-        protected Card youngKnight { get { return GetCard("TheYoungKnightCharacter"); } }
-        protected Card oldKnight { get { return GetCard("TheOldKnightCharacter"); } }
         private void SetupIncap(TurnTakerController villain)
         {
             SetHitPoints(knight, 1);


### PR DESCRIPTION
Fixes to the following situations:

*A non-Ronin Knight is brought in to a replace another hero. His one-shots should not ask for who to deal the damage
*A non-Ronin Knight is brought in to replace Ronin Knights. Ronin Knights should not be revived and put back into play.
*A non-Knight hero is brought in to replace a Knight character. None of the StartOfGame Knight triggers should fire