### PR TITLE
Starlight and oblivaeon

### DIFF
--- a/CauldronMods/Controller/Heroes/Starlight/CardSubClasses/StarlightSubCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/CardSubClasses/StarlightSubCharacterCardController.cs
@@ -22,9 +22,9 @@ namespace Cauldron.Starlight
 
         public override void AddStartOfGameTriggers()
         {
-            if(IsCoreCharacterCard)
+            if(IsCoreCharacterCard && !Card.IsIncapacitatedOrOutOfGame && HeroTurnTakerController is StarlightTurnTakerController starlightTTC)
             {
-                (TurnTakerController as StarlightTurnTakerController).ManageCharactersOffToTheSide(true);
+                starlightTTC.ManageCharactersOffToTheSide(true);
             }
         }
 

--- a/CauldronMods/Controller/Heroes/Starlight/CharacterCards/NightloreCouncilStarlightCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/CharacterCards/NightloreCouncilStarlightCharacterCardController.cs
@@ -62,17 +62,25 @@ namespace Cauldron.Starlight
         }
         public override void AddStartOfGameTriggers()
         {
-            var cards = (HeroTurnTakerController as StarlightTurnTakerController).ManageCharactersOffToTheSide(false);
+            if(Card.IsIncapacitatedOrOutOfGame)
+            {
+                return;
+            }
+            if (HeroTurnTakerController is StarlightTurnTakerController starlightTTC)
+            {
 
-            _terra = cards.Where((Card c) => c.Identifier == "StarlightOfTerraCharacter").FirstOrDefault();
-            _asheron = cards.Where((Card c) => c.Identifier == "StarlightOfAsheronCharacter").FirstOrDefault();
-            _cryos = cards.Where((Card c) => c.Identifier == "StarlightOfCryosFourCharacter").FirstOrDefault();
+                var cards = starlightTTC.ManageCharactersOffToTheSide(false);
 
-            AddStartOfTurnTrigger((TurnTaker tt) => tt == this.TurnTaker && IsNextToConstellation(terra),
-                            (PhaseChangeAction pca) => TerraHealTeamResponse(),
-                            TriggerType.GainHP);
-            AddIncreaseDamageTrigger(AsheronBoostDamageCriteria, 1);
-            AddTrigger<CardEntersPlayAction>(CryosCardDrawCriteria, (CardEntersPlayAction cep) => DrawCard(), new List<TriggerType> { TriggerType.DrawCard }, TriggerTiming.After);
+                _terra = cards.Where((Card c) => c.Identifier == "StarlightOfTerraCharacter").FirstOrDefault();
+                _asheron = cards.Where((Card c) => c.Identifier == "StarlightOfAsheronCharacter").FirstOrDefault();
+                _cryos = cards.Where((Card c) => c.Identifier == "StarlightOfCryosFourCharacter").FirstOrDefault();
+
+                AddStartOfTurnTrigger((TurnTaker tt) => tt == this.TurnTaker && IsNextToConstellation(terra),
+                                (PhaseChangeAction pca) => TerraHealTeamResponse(),
+                                TriggerType.GainHP);
+                AddIncreaseDamageTrigger(AsheronBoostDamageCriteria, 1);
+                AddTrigger<CardEntersPlayAction>(CryosCardDrawCriteria, (CardEntersPlayAction cep) => DrawCard(), new List<TriggerType> { TriggerType.DrawCard }, TriggerTiming.After);
+            }
         }
 
         public IEnumerator TerraHealTeamResponse()

--- a/Testing/CauldronBaseTest.cs
+++ b/Testing/CauldronBaseTest.cs
@@ -27,6 +27,9 @@ namespace CauldronTests
         protected HeroTurnTakerController pyre { get { return FindHero("Pyre"); } }
         protected HeroTurnTakerController quicksilver { get { return FindHero("Quicksilver"); } }
         protected HeroTurnTakerController starlight { get { return FindHero("Starlight"); } }
+        protected Card terra { get { return GetCard("StarlightOfTerraCharacter"); } }
+        protected Card asheron { get { return GetCard("StarlightOfAsheronCharacter"); } }
+        protected Card cryos { get { return GetCard("StarlightOfCryosFourCharacter"); } }
         protected HeroTurnTakerController tango { get { return FindHero("TangoOne"); } }
         protected HeroTurnTakerController terminus { get { return FindHero("Terminus"); } }
         protected HeroTurnTakerController knight { get { return FindHero("TheKnight"); } }

--- a/Testing/Heroes/StarlightTests.cs
+++ b/Testing/Heroes/StarlightTests.cs
@@ -454,6 +454,65 @@ namespace CauldronTests
             QuickHPCheck(-1);
             QuickHandCheck(1);
         }
+
+        [Test()]
+        public void TestCelestialAuraPower_Oblivaeon()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Ra", "Legacy", "Haka", "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            DealDamage(oblivaeon, ra, 100, DamageType.Fire, isIrreducible: true, ignoreBattleZone: true);
+            GoToAfterEndOfTurn(oblivaeon);
+            DecisionSelectFromBoxIdentifiers = new string[] { "Starlight" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Cauldron.Starlight";
+            RunActiveTurnPhase();
+
+            Card aura = GetCard("CelestialAura");
+            PlayCard(aura);
+
+            DecisionSelectPower = aura;
+            DecisionSelectTarget = oblivaeon.CharacterCard;
+
+            QuickHPStorage(oblivaeon);
+            QuickHandStorage(starlight);
+            UsePower(aura);
+
+            //should deal 1 damage and draw 1 card
+            QuickHPCheck(-1);
+            QuickHandCheck(1);
+        }
+
+        [Test()]
+        public void TestCelestialAuraPower_Oblivaeon_NightloreCouncilReplacement()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Starlight/NightloreCouncilStarlightCharacter", "Legacy", "Haka", "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            DealDamage(oblivaeon.CharacterCard, terra, 100, DamageType.Fire, isIrreducible: true, ignoreBattleZone: true);
+            DealDamage(oblivaeon.CharacterCard, asheron, 100, DamageType.Fire, isIrreducible: true, ignoreBattleZone: true);
+            DealDamage(oblivaeon.CharacterCard, cryos, 100, DamageType.Fire, isIrreducible: true, ignoreBattleZone: true);
+
+            GoToAfterEndOfTurn(oblivaeon);
+            DecisionSelectFromBoxIdentifiers = new string[] { "Starlight" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Cauldron.Starlight";
+            RunActiveTurnPhase();
+
+            Card aura = GetCard("CelestialAura");
+            PlayCard(aura);
+
+            DecisionSelectPower = aura;
+            DecisionSelectTarget = oblivaeon.CharacterCard;
+
+            QuickHPStorage(oblivaeon);
+            QuickHandStorage(starlight);
+            AssertNoDecision(SelectionType.HeroToDealDamage);
+
+            UsePower(aura);
+
+            //should deal 1 damage and draw 1 card
+            QuickHPCheck(-1);
+            QuickHandCheck(1);
+        }
         [Test()]
         public void TestCelestialAuraDamageToHeal()
         {

--- a/Testing/Heroes/StarlightVariantTests.cs
+++ b/Testing/Heroes/StarlightVariantTests.cs
@@ -20,10 +20,6 @@ namespace CauldronTests
             DealDamage(villain, starlight, 2, DamageType.Melee);
         }
 
-        protected Card terra { get { return GetCard("StarlightOfTerraCharacter"); } }
-        protected Card asheron { get { return GetCard("StarlightOfAsheronCharacter"); } }
-        protected Card cryos { get { return GetCard("StarlightOfCryosFourCharacter"); } }
-
         protected List<Card> EachStarlight { get { return new List<Card> { terra, asheron, cryos }; } }
         #endregion
         [Test()]


### PR DESCRIPTION
Fixes to the following situations:

*A non-Nightlore Council Starlight is brought in to a replace another hero. Her one-shots should not ask for who to deal the damage
*A non-Nightlore Council Starlight is brought in to replace Nightlore Council Starlight.  Nightlore Council Starlight should not be revived and put back into play.
*A non-Starlight hero is brought in to replace a Starlight character. None of the StartOfGame Starlight triggers should fire