### PR TITLE
Reveal from all decks Oblivaeon

### DIFF
--- a/CauldronMods/Controller/Heroes/Cricket/Cards/EchonavigationCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cricket/Cards/EchonavigationCardController.cs
@@ -15,7 +15,8 @@ namespace Cauldron.Cricket
         public override IEnumerator Play()
         {
             //Reveal the top card of each deck. You may replace or discard each card.",
-            IEnumerator coroutine = base.GameController.SelectTurnTakersAndDoAction(base.HeroTurnTakerController, new LinqTurnTakerCriteria((TurnTaker tt) => true), SelectionType.RevealTopCardOfDeck, (TurnTaker tt) => this.RevealCard_DiscardItOrPutItOnDeck(base.HeroTurnTakerController, base.FindTurnTakerController(tt), tt.Deck, false), allowAutoDecide: true, cardSource: base.GetCardSource());
+            IEnumerator coroutine = GameController.SelectLocationsAndDoAction(DecisionMaker, SelectionType.RevealTopCardOfDeck, l => l.IsDeck && !l.OwnerTurnTaker.IsIncapacitatedOrOutOfGame && l.IsRealDeck, (Location loc) => this.RevealCard_DiscardItOrPutItOnDeck(base.HeroTurnTakerController, base.FindTurnTakerController(loc.OwnerTurnTaker), loc, false), cardSource: GetCardSource());
+            //IEnumerator coroutine = base.GameController.SelectTurnTakersAndDoAction(base.HeroTurnTakerController, new LinqTurnTakerCriteria((TurnTaker tt) => true), SelectionType.RevealTopCardOfDeck, (TurnTaker tt) => this.RevealCard_DiscardItOrPutItOnDeck(base.HeroTurnTakerController, base.FindTurnTakerController(tt), tt.Deck, false), allowAutoDecide: true, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Cricket/Cards/EchonavigationCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cricket/Cards/EchonavigationCardController.cs
@@ -16,7 +16,6 @@ namespace Cauldron.Cricket
         {
             //Reveal the top card of each deck. You may replace or discard each card.",
             IEnumerator coroutine = GameController.SelectLocationsAndDoAction(DecisionMaker, SelectionType.RevealTopCardOfDeck, l => l.IsDeck && !l.OwnerTurnTaker.IsIncapacitatedOrOutOfGame && l.IsRealDeck, (Location loc) => this.RevealCard_DiscardItOrPutItOnDeck(base.HeroTurnTakerController, base.FindTurnTakerController(loc.OwnerTurnTaker), loc, false), cardSource: GetCardSource());
-            //IEnumerator coroutine = base.GameController.SelectTurnTakersAndDoAction(base.HeroTurnTakerController, new LinqTurnTakerCriteria((TurnTaker tt) => true), SelectionType.RevealTopCardOfDeck, (TurnTaker tt) => this.RevealCard_DiscardItOrPutItOnDeck(base.HeroTurnTakerController, base.FindTurnTakerController(tt), tt.Deck, false), allowAutoDecide: true, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Vanish/Cards/FlashReconCardController.cs
+++ b/CauldronMods/Controller/Heroes/Vanish/Cards/FlashReconCardController.cs
@@ -19,7 +19,8 @@ namespace Cauldron.Vanish
          */
         public override IEnumerator Play()
         {
-            var coroutine = GameController.SelectLocationsAndDoAction(DecisionMaker, SelectionType.RevealTopCardOfDeck, l => l.IsDeck && !l.OwnerTurnTaker.IsIncapacitatedOrOutOfGame && l.IsRealDeck, RevealTopCardAndReturn, cardSource: GetCardSource());
+            List<Card> revealedCards = new List<Card>();
+            var coroutine = GameController.SelectLocationsAndDoAction(DecisionMaker, SelectionType.RevealTopCardOfDeck, l => l.IsDeck && !l.OwnerTurnTaker.IsIncapacitatedOrOutOfGame && l.IsRealDeck, (Location loc) => RevealTopCardAndReturn(loc, revealedCards), cardSource: GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);
@@ -29,7 +30,18 @@ namespace Cauldron.Vanish
                 base.GameController.ExhaustCoroutine(coroutine);
             }
 
-            coroutine = base.GameController.SelectAndPlayCard(DecisionMaker, (Card c) => c.Location.IsDeck && base.GameController.IsLocationVisibleToSource(c.Location, base.GetCardSource()) && c == c.Location.TopCard, optional: false, isPutIntoPlay: true, GetCardSource(), "There are no cards in any decks.");
+            IEnumerable<Card> choices = FindCardsWhere((Card c) => c.Location.IsDeck && base.GameController.IsLocationVisibleToSource(c.Location, GetCardSource()) && c == c.Location.TopCard);
+            IEnumerable<CardController> cardsToFlip = choices.Except(revealedCards).Select(c => FindCardController(c));
+            coroutine = GameController.FlipCards(cardsToFlip, GetCardSource());
+            if (base.UseUnityCoroutines)
+            {
+                yield return base.GameController.StartCoroutine(coroutine);
+            }
+            else
+            {
+                base.GameController.ExhaustCoroutine(coroutine);
+            }
+            coroutine = SelectAndPlayCardWithFlipBack(DecisionMaker, choices, cardsToFlip);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);
@@ -41,10 +53,11 @@ namespace Cauldron.Vanish
             yield break;
         }
 
-        private IEnumerator RevealTopCardAndReturn(Location loc)
+        private IEnumerator RevealTopCardAndReturn(Location loc, List<Card> revealedCards)
         {
             List<Card> result = new List<Card>();
-            var coroutine = GameController.RevealCards(this.TurnTakerController, loc, 1, result, revealedCardDisplay: RevealedCardDisplay.ShowRevealedCards, cardSource: GetCardSource());
+            List<RevealCardsAction> actionResult = new List<RevealCardsAction>();
+            var coroutine = GameController.RevealCards(this.TurnTakerController, loc, 1, result, revealedCardDisplay: RevealedCardDisplay.ShowRevealedCards, storedResultsAction: actionResult, cardSource: GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);
@@ -61,6 +74,73 @@ namespace Cauldron.Vanish
             else
             {
                 base.GameController.ExhaustCoroutine(coroutine);
+            }
+
+            if (!actionResult.Any())
+            {
+                yield break;
+            }
+
+            RevealCardsAction revealAction = actionResult.First();
+
+            if (!revealAction.RevealedCards.Any() && !revealAction.RemovedFromRevealedCards.Any())
+            {
+                yield break;
+            }
+
+            Card revealedCard = revealAction.RevealedCards.Any() ? revealAction.RevealedCards.First() : revealAction.RemovedFromRevealedCards.First();
+            revealedCards.Add(revealedCard);
+
+            yield break;
+        }
+
+        public IEnumerator SelectAndPlayCardWithFlipBack(HeroTurnTakerController hero, IEnumerable<Card> choices, IEnumerable<CardController> cardsToFlip)
+        {
+            if (!choices.Any((Card c) => GameController.CanPlayCard(FindCardController(c), isPutIntoPlay: true) == CanPlayCardResult.CanPlay))
+            {
+                IEnumerator coroutine = GameController.SendMessageAction("None of the cards can be played.", Priority.Medium, GetCardSource(), choices, showCardSource: true);
+                if (UseUnityCoroutines)
+                {
+                    yield return GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    GameController.ExhaustCoroutine(coroutine);
+                }
+                yield break;
+            }
+            SelectCardDecision selectCardDecision = new SelectCardDecision(GameController, hero, SelectionType.PutIntoPlay, choices, cardSource: GetCardSource());
+            IEnumerator coroutine2 = GameController.SelectCardAndDoAction(selectCardDecision, (SelectCardDecision d) => FlipAndPlayCard(hero, d.SelectedCard, cardsToFlip));
+            if (UseUnityCoroutines)
+            {
+                yield return GameController.StartCoroutine(coroutine2);
+            }
+            else
+            {
+                GameController.ExhaustCoroutine(coroutine2);
+            }
+        }
+
+        private IEnumerator FlipAndPlayCard(HeroTurnTakerController hero, Card selectedCard, IEnumerable<CardController> cardsToFlip)
+        {
+            IEnumerator coroutine = GameController.FlipCards(cardsToFlip, GetCardSource());
+            if (UseUnityCoroutines)
+            {
+                yield return GameController.StartCoroutine(coroutine);
+            }
+            else
+            {
+                GameController.ExhaustCoroutine(coroutine);
+            }
+
+            coroutine = GameController.PlayCard(hero, selectedCard, isPutIntoPlay: true, cardSource: GetCardSource());
+            if (UseUnityCoroutines)
+            {
+                yield return GameController.StartCoroutine(coroutine);
+            }
+            else
+            {
+                GameController.ExhaustCoroutine(coroutine);
             }
         }
     }

--- a/CauldronMods/Controller/Heroes/Vanish/Cards/FlashReconCardController.cs
+++ b/CauldronMods/Controller/Heroes/Vanish/Cards/FlashReconCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.Vanish
          */
         public override IEnumerator Play()
         {
-            var coroutine = GameController.SelectLocationsAndDoAction(DecisionMaker, SelectionType.RevealTopCardOfDeck, l => l.IsDeck && !l.OwnerTurnTaker.IsIncapacitatedOrOutOfGame, RevealTopCardAndReturn, cardSource: GetCardSource());
+            var coroutine = GameController.SelectLocationsAndDoAction(DecisionMaker, SelectionType.RevealTopCardOfDeck, l => l.IsDeck && !l.OwnerTurnTaker.IsIncapacitatedOrOutOfGame && l.IsRealDeck, RevealTopCardAndReturn, cardSource: GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Vanish/Cards/TacticalRelocationCardController.cs
+++ b/CauldronMods/Controller/Heroes/Vanish/Cards/TacticalRelocationCardController.cs
@@ -32,7 +32,7 @@ namespace Cauldron.Vanish
             bool done = false;
             IEnumerator coroutine;
 
-            var choices = GameController.GetAllCards().Where(c => c.IsHeroCharacterCard && c.IsInPlay && !c.IsIncapacitatedOrOutOfGame && GameController.IsCardVisibleToCardSource(c, GetCardSource()) &&!selected.Contains(c.Owner.ToHero())).ToArray();
+            var choices = GameController.GetAllCards().Where(c => c.IsHeroCharacterCard && c.IsInPlayAndHasGameText && !c.IsIncapacitatedOrOutOfGame && GameController.IsCardVisibleToCardSource(c, GetCardSource()) && c.BattleZone == BattleZone &&!selected.Contains(c.Owner.ToHero())).ToArray();
             while (choices.Length > 0 && !done)
             {
                 var previewDDA = new DealDamageAction(GameController, new DamageSource(GameController, CharacterCard), null, 3, DamageType.Energy);
@@ -80,7 +80,7 @@ namespace Cauldron.Vanish
                         damaged.Add(owner);
                     }
 
-                    choices = GameController.GetAllCards().Where(c => c.IsHeroCharacterCard && c.IsInPlay && !c.IsIncapacitatedOrOutOfGame && !selected.Contains(c.Owner.ToHero())).ToArray();
+                    choices = GameController.GetAllCards().Where(c => c.IsHeroCharacterCard && c.IsInPlayAndHasGameText && !c.IsIncapacitatedOrOutOfGame && GameController.IsCardVisibleToCardSource(c, GetCardSource()) && c.BattleZone == BattleZone && !selected.Contains(c.Owner.ToHero())).ToArray();
                 }
             }
 

--- a/Testing/Environments/FSCContinuanceWandererTests.cs
+++ b/Testing/Environments/FSCContinuanceWandererTests.cs
@@ -193,6 +193,19 @@ namespace CauldronTests
             AssertNumberOfCardsInRevealed(fsc, 0);
         }
 
+        [Test]
+        public void TestHeartOfWandererOblivAeon()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Cricket", "Legacy", "Haka", "Cauldron.FSCContinuanceWanderer", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+            Card expectedMission = oblivaeon.TurnTaker.FindSubDeck("MissionDeck").TopCard;
+            GoToStartOfTurn(envOne);
+            PlayCard("HeartOfTheWanderer");
+            Card actualMission = oblivaeon.TurnTaker.FindSubDeck("MissionDeck").TopCard;
+
+            Assert.AreEqual(expectedMission, actualMission, $"Expected {expectedMission.Title} on the top of the Mission Deck. Instead it was {actualMission.Title}");
+            
+        }
         [Test()]
         public void TestHeartOfTheWandererTeamVillainDiscard()
         {

--- a/Testing/Heroes/CricketTests.cs
+++ b/Testing/Heroes/CricketTests.cs
@@ -272,6 +272,18 @@ namespace CauldronTests
             AssertOnTopOfDeck(topEnv);
         }
 
+        [Test]
+        public void TestEchonavigationOblivAeon()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Cricket", "Legacy", "Haka", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            GoToStartOfTurn(cricket);
+            AssertNumberOfChoicesInNextDecision(5, SelectionType.RevealTopCardOfDeck);
+            PlayCard("Echonavigation");
+
+        }
+
         [Test()]
         public void TestEnhancedHearing()
         {

--- a/Testing/Heroes/VanishTests.cs
+++ b/Testing/Heroes/VanishTests.cs
@@ -509,6 +509,18 @@ namespace CauldronTests
         }
 
         [Test]
+        public void FlashReconOblivAeon()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Vanish", "Legacy", "Haka", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            GoToStartOfTurn(vanish);
+            AssertNumberOfChoicesInNextDecision(5, SelectionType.RevealTopCardOfDeck);
+            PlayCard("FlashRecon");
+           
+        }
+
+        [Test]
         public void FlashRecon_OnlyCleanUpOwnRevealed()
         {
             SetupGameController("BaronBlade", "Cauldron.Vanish", "Ra", "TheWraith", "TheArgentAdept/DarkConductorArgentAdept", "Megalopolis");

--- a/Testing/Heroes/VanishTests.cs
+++ b/Testing/Heroes/VanishTests.cs
@@ -521,6 +521,27 @@ namespace CauldronTests
         }
 
         [Test]
+        public void FlashReconDarkMind()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Vanish", "Legacy", "Haka", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective", scionIdentifiers: new List<string>() { "DarkMindCharacter" }) ;
+            StartGame();
+
+            SwitchBattleZone(vanish);
+            SwitchBattleZone(legacy);
+            AssertBattleZone(mindScion, bzTwo);
+            AssertBattleZone(vanish, bzTwo);
+            AssertBattleZone(legacy, bzTwo);
+
+            PutOnDeck("TacticalRelocation");
+            PutOnDeck("Elusive");
+
+            //the test doesn't show the cards to choose from as flipped, but they are in the UI
+            GoToStartOfTurn(vanish);
+            PlayCard("FlashRecon");
+
+        }
+
+        [Test]
         public void FlashRecon_OnlyCleanUpOwnRevealed()
         {
             SetupGameController("BaronBlade", "Cauldron.Vanish", "Ra", "TheWraith", "TheArgentAdept/DarkConductorArgentAdept", "Megalopolis");


### PR DESCRIPTION
Cards that reveal from all decks should reveal from subdecks, but only real ones (not mission deck or fake scion turntaker decks)

Modified: Flash Recon, Echonavigation, Heart of the Wanderer

Closes #1029 
Closes #928 