### PR TITLE
Fix for 1032 - restful inn with multiple character cards

### DIFF
--- a/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/RestfulInnCardController.cs
+++ b/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/RestfulInnCardController.cs
@@ -65,7 +65,7 @@ namespace Cauldron.DungeonsOfTerror
                     if (httc.TurnTaker.HasMultipleCharacterCards)
                     {
                         List<SelectCardDecision> storedSelection = new List<SelectCardDecision>();
-                        coroutine = base.GameController.SelectCardAndStoreResults(httc, SelectionType.CharacterCard, httc.CharacterCards, storedSelection);
+                        coroutine = base.GameController.SelectCardAndStoreResults(httc, SelectionType.CharacterCard, httc.CharacterCards.Where(c => !c.IsIncapacitatedOrOutOfGame && c.IsRealCard), storedSelection);
                         if (base.UseUnityCoroutines)
                         {
                             yield return base.GameController.StartCoroutine(coroutine);

--- a/Testing/Environments/DungeonsOfTerrorTests.cs
+++ b/Testing/Environments/DungeonsOfTerrorTests.cs
@@ -607,6 +607,30 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestRestfulInn_MultipleCharsOffToTheSide()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.Titan", "Cauldron.DungeonsOfTerror");
+            StartGame();
+            DestroyNonCharacterVillainCards();
+            SetHitPoints(ra, 20);
+            SetHitPoints(legacy, 20);
+            SetHitPoints(ra, 20);
+            SetHitPoints(titan, 20);
+
+            //The first time a hero draws a card during their turn, they may discard it. 
+            //If they do, that hero regains 2HP. Increase HP regained this way by 1 if the top card of the environment trash is a fate card.
+            Card inn = PlayCard("RestfulInn");
+
+            GoToPlayCardPhase(titan);
+
+            DecisionYesNo = true;
+            AssertNumberOfChoicesInNextDecision(1, SelectionType.CharacterCard);
+            DrawCard(titan);
+
+
+        }
+
+        [Test()]
         public void TestRingOfForesight()
         {
             SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.DungeonsOfTerror");

--- a/Testing/Environments/DungeonsOfTerrorTests.cs
+++ b/Testing/Environments/DungeonsOfTerrorTests.cs
@@ -584,6 +584,29 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestRestfulInn_MultipleCharsWithIncaps()
+        {
+            SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "TheSentinels", "Cauldron.DungeonsOfTerror");
+            StartGame();
+            DestroyNonCharacterVillainCards();
+            SetHitPoints(ra, 20);
+            SetHitPoints(legacy, 20);
+            SetHitPoints(ra, 20);
+            //The first time a hero draws a card during their turn, they may discard it. 
+            //If they do, that hero regains 2HP. Increase HP regained this way by 1 if the top card of the environment trash is a fate card.
+            Card inn = PlayCard("RestfulInn");
+
+            DealDamage(baron, idealist, 1000, DamageType.Melee, true);
+            GoToPlayCardPhase(sentinels);
+
+            DecisionYesNo = true;
+            AssertNumberOfChoicesInNextDecision(3, SelectionType.CharacterCard);
+            DrawCard(sentinels);
+
+
+        }
+
+        [Test()]
         public void TestRingOfForesight()
         {
             SetupGameController("BaronBlade", "Ra", "Legacy", "Haka", "Cauldron.DungeonsOfTerror");


### PR DESCRIPTION
This also affects any hero in oblivaeon with incapped heroes in their play area

Closes #1032 