### PR TITLE
Fix for 1042 - Vector Game Freezes on Start in Multiplayer

### DIFF
--- a/CauldronMods/Controller/Villains/Vector/CharacterCards/VectorTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/Vector/CharacterCards/VectorTurnTakerController.cs
@@ -24,7 +24,7 @@ namespace Cauldron.Vector
             }
 
             // At the start of the game, put {Vector}'s villain character cards into play, "Asymptomatic Carrier" side up, with 40 HP.
-            IEnumerator routine = base.GameController.SetHP(this.CharacterCard, StartingHp);
+            IEnumerator routine = base.GameController.SetHP(this.CharacterCard, StartingHp, cardSource: CharacterCardController.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(routine);


### PR DESCRIPTION
Closes #1042 

The SetHP call in the TurnTaker was missing a CardSource