### PR TITLE
Titan's Reversal When Cannot Deal Damage

### DIFF
--- a/CauldronMods/Controller/Heroes/Titan/Cards/ReversalCardController.cs
+++ b/CauldronMods/Controller/Heroes/Titan/Cards/ReversalCardController.cs
@@ -18,7 +18,7 @@ namespace Cauldron.Titan
         {
             List<SelectCardDecision> target = new List<SelectCardDecision>();
             //{Titan} deals 1 target 1 infernal damage.
-            IEnumerator coroutine = base.GameController.SelectTargetsAndDealDamage(base.HeroTurnTakerController, new DamageSource(base.GameController, base.CharacterCard), 1, DamageType.Infernal, 1, false, 1, storedResultsDecisions: target, cardSource: base.GetCardSource());
+            IEnumerator coroutine = base.GameController.SelectTargetsAndDealDamage(base.HeroTurnTakerController, new DamageSource(base.GameController, base.CharacterCard), 1, DamageType.Infernal, 1, false, 1, storedResultsDecisions: target, selectTargetsEvenIfCannotDealDamage: true, cardSource: base.GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/Testing/Heroes/TitanTests.cs
+++ b/Testing/Heroes/TitanTests.cs
@@ -927,6 +927,43 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestReversal_SecondEffectTriggering_ReduceTo0()
+        {
+            SetupGameController("Omnitron", "Cauldron.Titan", "Haka", "Bunker", "TheScholar", "Megalopolis");
+            StartGame();
+
+            //reduce damage being dealt to omni to 0
+            AddReduceDamageTrigger(omnitron, false, true, 1);
+            QuickHPStorage(omnitron);
+            PlayCard("Reversal");
+            QuickHPCheck(0);
+
+            //should still be redirected back
+            QuickHPStorage(omnitron, titan);
+            DealDamage(omnitron, titan, 2, DamageType.Melee, isIrreducible: true);
+            QuickHPCheck(-2, 0);
+
+        }
+
+        [Test()]
+        public void TestReversal_SecondEffectTriggering_CannotDealDamage()
+        {
+            SetupGameController("Omnitron", "Cauldron.Titan", "Haka", "Bunker", "TheScholar", "Megalopolis");
+            StartGame();
+
+            //titan can't deal damage
+            AddCannotDealNextDamageTrigger(titan, titan.CharacterCard);
+            QuickHPStorage(omnitron);
+            PlayCard("Reversal");
+            QuickHPCheck(0);
+
+            //should still be redirected back
+            QuickHPStorage(omnitron, titan);
+            DealDamage(omnitron, titan, 2, DamageType.Melee, isIrreducible: true);
+            QuickHPCheck(-2, 0);
+        }
+
+            [Test()]
         public void TestReversalToHand()
         {
             SetupGameController("Omnitron", "Cauldron.Titan", "Haka", "Bunker", "TheScholar", "Megalopolis");


### PR DESCRIPTION
Titan's redirection status effect was not being added if Titan can't deal damage.

Passed parameter to allow for selection of target to happen regardless