### PR TITLE
Softlock when Pyre Incaps in Oblivaeon mode

### DIFF
--- a/CauldronMods/Controller/Heroes/Pyre/CardSubClasses/PyreUtilityCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CardSubClasses/PyreUtilityCharacterCardController.cs
@@ -192,5 +192,25 @@ namespace Cauldron.Pyre
             }
             yield break;
         }
+
+        public override IEnumerator AfterFlipCardImmediateResponse()
+        {
+            SetOverrideTurnTakerIrradiatedMarkers();
+            return base.AfterFlipCardImmediateResponse();
+        }
+
+        public void SetOverrideTurnTakerIrradiatedMarkers()
+        {
+            if (!GameController.Game.IsOblivAeonMode)
+            {
+                return;
+            }
+
+            var allMarkers = TurnTaker.GetAllCards(false).Where((Card c) => !c.IsRealCard && c.Identifier == "IrradiatedMarker");
+            foreach (Card marker in allMarkers)
+            {
+                GameController.AddCardPropertyJournalEntry(marker, "OverrideTurnTaker", new string[] { "Cauldron.Pyre", marker.Identifier });
+            }
+        }
     }
 }

--- a/CauldronMods/Controller/Heroes/Pyre/CharacterCards/PyreTurnTakerController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CharacterCards/PyreTurnTakerController.cs
@@ -16,7 +16,7 @@ namespace Cauldron.Pyre
 
         public void MoveMarkersToSide()
         {
-            var markersInDeckOrHand = TurnTaker.GetAllCards(false).Where((Card c) => !c.IsRealCard && (c.Location == TurnTaker.Deck || c.Location == HeroTurnTaker.Hand));
+            var markersInDeckOrHand = TurnTaker.GetAllCards(false).Where((Card c) => !c.IsRealCard && c.Identifier == "IrradiatedMarker" && (c.Location == TurnTaker.Deck || c.Location == HeroTurnTaker.Hand));
             if(markersInDeckOrHand.Any())
             {
                 foreach(Card marker in markersInDeckOrHand)

--- a/Testing/Heroes/PyreTests.cs
+++ b/Testing/Heroes/PyreTests.cs
@@ -226,6 +226,17 @@ namespace CauldronTests
             UseIncapacitatedAbility(pyre, 2);
             AssertOnTopOfDeck(iron);
         }
+
+        [Test]
+        public void TestPyreIncaps_OblivaeonSoftlock()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Pyre", "Legacy", "Haka", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            SetupIncap(oblivaeon);
+            GoToAfterEndOfTurn(oblivaeon);
+            RunActiveTurnPhase();
+        }
         [Test]
         public void TestChromodynamicsDamageTrigger()
         {


### PR DESCRIPTION
The IrradiatedCard marker was getting confused on the new TurnTaker coming in. Added OverrideTurnTaker card property to fix the issue