### PR TITLE
Fix for 1113: Grasshopper kick and enraged terror bird

### DIFF
--- a/CauldronMods/Controller/Heroes/Cricket/Cards/GrasshopperKickCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cricket/Cards/GrasshopperKickCardController.cs
@@ -27,7 +27,6 @@ namespace Cauldron.Cricket
         {
             AddImmuneToDamageTrigger(dd => dd.Target == CharacterCard && dd.DamageSource.IsEnvironmentTarget && IsImmuneToEnvironmentDamage) ;
             AddTrigger((PhaseChangeAction pca) => pca.ToPhase.Phase == Phase.Start && pca.ToPhase.TurnTaker == TurnTaker, ResetImmunityProperty, TriggerType.Hidden, TriggerTiming.After);
-            ResetFlagAfterLeavesPlay(IsImmuneToEnvironmentDamageKey);
         }
 
         private IEnumerator ResetImmunityProperty(PhaseChangeAction pca)

--- a/CauldronMods/Controller/Heroes/Cricket/Cards/GrasshopperKickCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cricket/Cards/GrasshopperKickCardController.cs
@@ -9,7 +9,7 @@ namespace Cauldron.Cricket
     {
         public GrasshopperKickCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            SpecialStringMaker.ShowSpecialString(() => StatusEffectMessage, showInEffectsList: () => true).Condition = () => Game.HasGameStarted && Card.IsInPlayAndHasGameText && IsImmuneToEnvironmentDamage;
+            SpecialStringMaker.ShowSpecialString(() => StatusEffectMessage, showInEffectsList: () => true).Condition = () => Game.HasGameStarted && IsImmuneToEnvironmentDamage;
         }
 
         public readonly string IsImmuneToEnvironmentDamageKey = "IsImmuneToEnvironmentDamage";

--- a/Testing/Heroes/CricketTests.cs
+++ b/Testing/Heroes/CricketTests.cs
@@ -382,6 +382,51 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestGrasshopperKick_Destroyed()
+        {
+            SetupGameController(new string[] { "AkashBhuta", "Cauldron.Cricket", "Legacy", "Bunker", "TheScholar", "Megalopolis" });
+            StartGame();
+
+            Card kick = PlayCard("GrasshopperKick");
+            Card cramped = GetCard("CrampedQuartersCombat");
+            //{Cricket} deals 1 target 2 melee damage. {Cricket} is immune to damage dealt by environment targets until the start of your next turn.
+            QuickHPStorage(akash);
+            UsePower(kick);
+            QuickHPCheck(-2);
+
+            Card rail = PlayCard("PlummetingMonorail");
+            DestroyCard(kick);
+            //{Cricket} is immune to damage dealt by environment targets until the start of your next turn.
+            QuickHPStorage(cricket);
+            DealDamage(rail, cricket, 2, DamageType.Melee);
+            QuickHPCheck(0);
+        }
+
+        [Test()]
+        public void TestGrasshopperKick_ReEnterPlay()
+        {
+            SetupGameController(new string[] { "AkashBhuta", "Cauldron.Cricket", "Legacy", "Bunker", "TheScholar", "Megalopolis" });
+            StartGame();
+
+            Card kick = PlayCard("GrasshopperKick");
+            Card cramped = GetCard("CrampedQuartersCombat");
+            //{Cricket} deals 1 target 2 melee damage. {Cricket} is immune to damage dealt by environment targets until the start of your next turn.
+            QuickHPStorage(akash);
+            UsePower(kick);
+            QuickHPCheck(-2);
+
+            Card rail = PlayCard("PlummetingMonorail");
+            DestroyCard(kick);
+            //{Cricket} is immune to damage dealt by environment targets until the start of your next turn.
+
+            GoToEndOfTurn(cricket);
+            PlayCard(kick);
+            QuickHPStorage(cricket);
+            DealDamage(rail, cricket, 2, DamageType.Melee);
+            QuickHPCheck(-2);
+        }
+
+        [Test()]
         public void TestInfrasonicCollapseDestroyOngoing()
         {
             SetupGameController("AkashBhuta", "Cauldron.Cricket", "Legacy", "Bunker", "TheScholar", "Megalopolis");

--- a/Testing/Heroes/CricketTests.cs
+++ b/Testing/Heroes/CricketTests.cs
@@ -336,16 +336,17 @@ namespace CauldronTests
             DealDamage(rail, cricket, 2, DamageType.Melee);
             QuickHPCheck(0);
 
-            //Non targets deal damage
+            //Non targets and non-environment deal damage
             Card hostage = PlayCard("HostageSituation");
             DealDamage(hostage, cricket, 2, DamageType.Melee);
+            DealDamage(akash, cricket, 2, DamageType.Melee);
             if (cramped.IsInPlayAndHasGameText)
             {
-                QuickHPCheck(-3);
+                QuickHPCheck(-6);
             }
             else
             {
-                QuickHPCheck(-2);
+                QuickHPCheck(-4);
             }
 
             GoToStartOfTurn(cricket);

--- a/Testing/Heroes/CricketTests.cs
+++ b/Testing/Heroes/CricketTests.cs
@@ -384,15 +384,13 @@ namespace CauldronTests
         [Test()]
         public void TestGrasshopperKick_Destroyed()
         {
-            SetupGameController(new string[] { "AkashBhuta", "Cauldron.Cricket", "Legacy", "Bunker", "TheScholar", "Megalopolis" });
+            SetupGameController(new string[] { "BaronBlade", "Cauldron.Cricket", "Legacy", "Bunker", "TheScholar", "Megalopolis" });
             StartGame();
 
             Card kick = PlayCard("GrasshopperKick");
             Card cramped = GetCard("CrampedQuartersCombat");
             //{Cricket} deals 1 target 2 melee damage. {Cricket} is immune to damage dealt by environment targets until the start of your next turn.
-            QuickHPStorage(akash);
             UsePower(kick);
-            QuickHPCheck(-2);
 
             Card rail = PlayCard("PlummetingMonorail");
             DestroyCard(kick);
@@ -405,15 +403,13 @@ namespace CauldronTests
         [Test()]
         public void TestGrasshopperKick_ReEnterPlay()
         {
-            SetupGameController(new string[] { "AkashBhuta", "Cauldron.Cricket", "Legacy", "Bunker", "TheScholar", "Megalopolis" });
+            SetupGameController(new string[] { "BaronBlade", "Cauldron.Cricket", "Legacy", "Bunker", "TheScholar", "Megalopolis" });
             StartGame();
 
             Card kick = PlayCard("GrasshopperKick");
             Card cramped = GetCard("CrampedQuartersCombat");
             //{Cricket} deals 1 target 2 melee damage. {Cricket} is immune to damage dealt by environment targets until the start of your next turn.
-            QuickHPStorage(akash);
             UsePower(kick);
-            QuickHPCheck(-2);
 
             Card rail = PlayCard("PlummetingMonorail");
             DestroyCard(kick);

--- a/Testing/Heroes/CricketTests.cs
+++ b/Testing/Heroes/CricketTests.cs
@@ -360,6 +360,28 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestGrasshopperKick_EnragedTerrorBird()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Cricket", "Legacy", "Haka", "Tachyon", "Luminary", "Cauldron.WindmillCity", "Megalopolis", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            MoveCard(oblivaeon, "EnragedTerrorBird", oblivaeon.TurnTaker.FindSubDeck("MissionDeck"));
+            DecisionSelectFunction = 0;
+            GoToBeforeStartOfTurn(cricket);
+            RunActiveTurnPhase();
+            Card bird = GetCardInPlay("EnragedTerrorBird");
+            GoToPlayCardPhase(cricket);
+            Card kick = PlayCard("GrasshopperKick");
+            UsePower(kick);
+
+            //cricket should be immune to environment damage
+            QuickHPStorage(cricket);
+            DealDamage(bird, cricket, 3, DamageType.Projectile);
+            QuickHPCheckZero();
+
+        }
+
+        [Test()]
         public void TestInfrasonicCollapseDestroyOngoing()
         {
             SetupGameController("AkashBhuta", "Cauldron.Cricket", "Legacy", "Bunker", "TheScholar", "Megalopolis");


### PR DESCRIPTION
Enraged Terror Bird counts as an environment target, but not as environment, so it was not being picked up by the status effect criteria for what to be immune to. Re-implemented to use a trigger and card property instead. Also added special strings and messaging to mimic a normal status effect behavior.

Closes #1113 