### PR TITLE
Phase residual desynchronization and Destroyed Obstacles

### DIFF
--- a/CauldronMods/Controller/Villains/PhaseVillain/Cards/ResidualDesynchronizationCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/Cards/ResidualDesynchronizationCardController.cs
@@ -23,7 +23,7 @@ namespace Cauldron.PhaseVillain
             base.AddReduceDamageTrigger((Card c) => base.IsObstacle(c), 1);
             //The first time a villain target is dealt damage each turn, it deals the source of that damage 2 energy damage.
             //per @Tosx, this is once per turn, NOT once per turn per target.
-            base.AddTrigger<DealDamageAction>((DealDamageAction action) => action.DidDealDamage && !base.HasBeenSetToTrueThisTurn("FirstTimeDamageDealt") && base.IsVillainTarget(action.Target),
+            base.AddTrigger<DealDamageAction>((DealDamageAction action) => action.DidDealDamage && !base.HasBeenSetToTrueThisTurn("FirstTimeDamageDealt") && base.IsVillainTarget(action.Target) && !action.Target.IsBeingDestroyed,
                     this.DealDamageResponse,
                     TriggerType.DealDamage,
                     TriggerTiming.After,

--- a/Testing/Villains/PhaseVillainTests.cs
+++ b/Testing/Villains/PhaseVillainTests.cs
@@ -619,6 +619,24 @@ namespace CauldronTests
             QuickHPCheck(-2, -1);
         }
 
+        [Test()]
+        public void TestResidualDesynchronization_DestroysTarget()
+        {
+            SetupGameController("Cauldron.PhaseVillain", "Haka", "Legacy", "TheScholar", "Megalopolis");
+            StartGame();
+
+            Card wall = GetCardInPlay("ReinforcedWall");
+            PlayCard("ResidualDesynchronization");
+
+            //Reduce damage dealt to Obstacles by 1.
+            //The first time a villain target is dealt damage each turn, it deals the source of that damage 2 energy damage.
+            //if the target is destroyed no damage should be dealt
+            QuickHPStorage(haka.CharacterCard);
+            DealDamage(haka.CharacterCard, wall, 20, DamageType.Melee, isIrreducible: true);
+            QuickHPCheck(0);
+            AssertInTrash(wall);
+        }
+
 
         [Test()]
         public void TestResidualDesynchronization_NoDamageIfTargetDestroyed()


### PR DESCRIPTION
This is not strictly necessary as the damage fizzles since the obstacle is out of play and won't deal damage but its more of a QoL fix so it doesn't cause the players confusion