### PR TITLE
Slice ultimate freeze fix

### DIFF
--- a/CauldronMods/Controller/Villains/ScreaMachine/CharacterCards/SliceCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/ScreaMachine/CharacterCards/SliceCharacterCardController.cs
@@ -52,6 +52,9 @@ namespace Cauldron.ScreaMachine
                 GameController.ExhaustCoroutine(coroutine);
             }
 
+            if (!results.Any() || results.First() is null)
+                yield break;
+
             var effect = new CannotDealDamageStatusEffect();
             effect.SourceCriteria.IsAtLocation = results.First().Target.Owner.PlayArea;
             effect.UntilStartOfNextTurn(TurnTaker);

--- a/Testing/Villains/ScreaMachineTests.cs
+++ b/Testing/Villains/ScreaMachineTests.cs
@@ -445,6 +445,23 @@ namespace CauldronTests
             QuickHPCheck(0, -3, 0, 0, 0, 0, 0, 0);
         }
 
+        [Test()]
+        public void TestSliceUltimate_Freeze()
+        {
+            SetupGameController(new[] { "Cauldron.ScreaMachine", "Legacy", "Ra", "TheVisionary", "Bunker", "Megalopolis" }, advanced: false);
+            StartGame();
+
+            PlayCard("TelekineticCocoon");
+            DealDamage(slice, c => c.IsHeroCharacterCard, 999, DamageType.Energy);
+
+            string key = ScreaMachineBandmate.GetAbilityKey(ScreaMachineBandmate.Value.Slice);
+
+            FlipCard(slice);
+
+            GoToEndOfTurn(scream);
+
+        }
+
 
         [Test()]
         public void TestValentineAbility()


### PR DESCRIPTION
Slice's ultimate end of turn effect was missing null checks for if there was a hero target with the second lowest HP (ie only one hero left)