### PR TITLE
Changed DestroySelf to DestroyCard to get proper text prompt

### DIFF
--- a/CauldronMods/Controller/Environments/CatchwaterHarbor/Cards/AbandonedFactoryCardController.cs
+++ b/CauldronMods/Controller/Environments/CatchwaterHarbor/Cards/AbandonedFactoryCardController.cs
@@ -60,7 +60,7 @@ namespace Cauldron.CatchwaterHarbor
 			// Ask player if they want to destroy this card
 			List<YesNoCardDecision> storedResults = new List<YesNoCardDecision>();
 			IEnumerator coroutine = base.GameController.MakeYesNoCardDecision(DecisionMaker,
-				SelectionType.DestroySelf, base.Card, storedResults: storedResults, cardSource: GetCardSource());
+				SelectionType.DestroyCard, base.Card, storedResults: storedResults, cardSource: GetCardSource());
 
 			if (base.UseUnityCoroutines)
 			{

--- a/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/TheresAlwaysABardCardController.cs
+++ b/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/TheresAlwaysABardCardController.cs
@@ -59,7 +59,7 @@ namespace Cauldron.DungeonsOfTerror
 
             //op3: destroy this card
             var response3 = DestroyThisCardResponse(pca);
-            var op3 = new Function(httc, "Destroy this card", SelectionType.DestroySelf, () => response3);
+            var op3 = new Function(httc, "Destroy this card", SelectionType.DestroyCard, () => response3);
 
             //Execute
             var options = new Function[] { op1, op2, op3 };

--- a/CauldronMods/Controller/Heroes/Cypher/Cards/BackupPlanCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cypher/Cards/BackupPlanCardController.cs
@@ -25,12 +25,8 @@ namespace Cauldron.Cypher
         public override void AddTriggers()
         {
             // When a non-hero card enters play, you may destroy this card.
-            base.AddTrigger<CardEntersPlayAction>(
-                p => !p.CardEnteringPlay.IsHero && GameController.IsCardVisibleToCardSource(p.CardEnteringPlay, GetCardSource()),
-                DestroySelfResponse,
-                TriggerType.DestroySelf,
-                TriggerTiming.After
-                );
+            base.AddTrigger<CardEntersPlayAction>(p => !p.CardEnteringPlay.IsHero && GameController.IsCardVisibleToCardSource(p.CardEnteringPlay, GetCardSource()),
+                DestroySelfResponse, TriggerType.DestroySelf, TriggerTiming.After);
 
             base.AddTriggers();
         }

--- a/CauldronMods/Controller/Heroes/Cypher/Cards/BackupPlanCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cypher/Cards/BackupPlanCardController.cs
@@ -25,8 +25,12 @@ namespace Cauldron.Cypher
         public override void AddTriggers()
         {
             // When a non-hero card enters play, you may destroy this card.
-            base.AddTrigger<CardEntersPlayAction>(p => !p.CardEnteringPlay.IsHero && GameController.IsCardVisibleToCardSource(p.CardEnteringPlay, GetCardSource()),
-                DestroySelfResponse, TriggerType.DestroySelf, TriggerTiming.After);
+            base.AddTrigger<CardEntersPlayAction>(
+                p => !p.CardEnteringPlay.IsHero && GameController.IsCardVisibleToCardSource(p.CardEnteringPlay, GetCardSource()),
+                DestroySelfResponse,
+                TriggerType.DestroySelf,
+                TriggerTiming.After
+                );
 
             base.AddTriggers();
         }
@@ -40,7 +44,7 @@ namespace Cauldron.Cypher
                 // Ask player if they want to destroy this card
                 List<YesNoCardDecision> storedResults = new List<YesNoCardDecision>();
                 routine = base.GameController.MakeYesNoCardDecision(base.HeroTurnTakerController,
-                    SelectionType.DestroySelf, base.Card, storedResults: storedResults, cardSource: GetCardSource());
+                    SelectionType.DestroyCard, base.Card, storedResults: storedResults, cardSource: GetCardSource());
 
                 if (base.UseUnityCoroutines)
                 {

--- a/CauldronMods/Controller/Heroes/DocHavoc/Cards/ImprovisedMineCardController.cs
+++ b/CauldronMods/Controller/Heroes/DocHavoc/Cards/ImprovisedMineCardController.cs
@@ -62,7 +62,7 @@ namespace Cauldron.DocHavoc
             List<YesNoCardDecision> storedResults = new List<YesNoCardDecision>();
 
             //ask player if they want to destroy this card
-            IEnumerator coroutine = GameController.MakeYesNoCardDecision(DecisionMaker, SelectionType.DestroySelf, Card,
+            IEnumerator coroutine = GameController.MakeYesNoCardDecision(DecisionMaker, SelectionType.DestroyCard, Card,
                                     storedResults: storedResults,
                                     cardSource: GetCardSource());
             if (base.UseUnityCoroutines)

--- a/CauldronMods/Controller/Heroes/Gargoyle/Cards/YourStrengthIsMineCardController.cs
+++ b/CauldronMods/Controller/Heroes/Gargoyle/Cards/YourStrengthIsMineCardController.cs
@@ -69,7 +69,7 @@ namespace Cauldron.Gargoyle
             Card target;
 
             // You may destroy this card at any time
-            coroutine = base.GameController.MakeYesNoCardDecision(DecisionMaker, SelectionType.DestroySelf, base.Card, action: dealDamageAction, storedResults: storedResults, cardSource: base.GetCardSource());
+            coroutine = base.GameController.MakeYesNoCardDecision(DecisionMaker, SelectionType.DestroyCard, base.Card, action: dealDamageAction, storedResults: storedResults, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);


### PR DESCRIPTION
Closes #1213 

This affected a few other cards as well. It looks like SelectionType.DestroySelf was not presenting the proper prompt, whereas SelectionType.DestroyCard was