### PR TITLE
Fix Mara and Echelon status-effect damage issues

### DIFF
--- a/CauldronMods/Controller/Heroes/Echelon/Cards/OverwatchCardController.cs
+++ b/CauldronMods/Controller/Heroes/Echelon/Cards/OverwatchCardController.cs
@@ -17,7 +17,7 @@ namespace Cauldron.Echelon
 
         public OverwatchCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-
+            AddThisCardControllerToList(CardControllerListType.CanCauseDamageOutOfPlay);
         }
 
         public override IEnumerator UsePower(int index = 0)

--- a/CauldronMods/Controller/Heroes/MagnificentMara/Cards/DowsingCrystalCardController.cs
+++ b/CauldronMods/Controller/Heroes/MagnificentMara/Cards/DowsingCrystalCardController.cs
@@ -89,9 +89,9 @@ namespace Cauldron.MagnificentMara
                             {
                                 GameController.ExhaustCoroutine(coroutine);
                             }
+                            GameController.RemoveInhibitor(FindCardController(sourceCrystal));
                         }
 
-                        //GameController.RemoveInhibitor(FindCardController(sourceCrystal));
                         int numBoost = powerNumerals?[1] ?? 2;
                         coroutine = GameController.IncreaseDamage(dd, numBoost, false, dd.CardSource);
                         if (UseUnityCoroutines)

--- a/Testing/Heroes/EchelonTests.cs
+++ b/Testing/Heroes/EchelonTests.cs
@@ -592,6 +592,24 @@ namespace CauldronTests
             QuickHPCheck(-1, 0, 0);
         }
         [Test]
+        public void TestOverwatch_DamageWhileDestroyed()
+        {
+            SetupGameController("TheEnnead", DeckNamespace, "Ra", "Legacy", "Megalopolis");
+            StartGame();
+            DestroyNonCharacterVillainCards();
+
+            Card firstDemigod = FindCardsWhere((Card c) => c.IsActiveEnneadCharacter && c.IsInPlayAndHasGameText).FirstOrDefault();
+            Card overwatch = PlayCard("Overwatch");
+            UsePower(overwatch);
+            DestroyCard(overwatch);
+
+            DecisionYesNo = true;
+            SetHitPoints(firstDemigod, 2);
+            DealDamage(firstDemigod, echelon, 1, DamageType.Melee);
+            AssertFlipped(firstDemigod);
+            Assert.IsFalse(firstDemigod.IsTarget);
+        }
+        [Test]
         public void TestPracticedTeamwork()
         {
             SetupGameController("BaronBlade", DeckNamespace, "Ra", "Haka", "Megalopolis");

--- a/Testing/Heroes/MagnificentMaraTests.cs
+++ b/Testing/Heroes/MagnificentMaraTests.cs
@@ -493,6 +493,43 @@ namespace CauldronTests
             AssertInTrash(crystal);
         }
         [Test]
+        public void TestDowsingCrystalDoesRemoveTarget()
+        {
+            SetupGameController("TheEnnead", "Cauldron.MagnificentMara", "Ra", "Legacy", "Megalopolis");
+            StartGame();
+            DestroyNonCharacterVillainCards();
+
+            Card firstDemigod = FindCardsWhere((Card c) => c.IsActiveEnneadCharacter && c.IsInPlayAndHasGameText).FirstOrDefault();
+            Card crystal = PlayCard("DowsingCrystal");
+            UsePower(crystal);
+            DestroyCard(crystal);
+
+            DecisionYesNo = true;
+            DecisionSelectCards = new Card[] { ra.CharacterCard, firstDemigod };
+            SetHitPoints(firstDemigod, 2);
+            PlayCard("PoliceBackup");
+            AssertFlipped(firstDemigod);
+            Assert.IsFalse(firstDemigod.IsTarget);
+        }
+        [Test]
+        public void TestDowsingCrystalDoesRemoveTargetWhenDestroyingSelf()
+        {
+            SetupGameController("TheEnnead", "Cauldron.MagnificentMara", "Ra", "Legacy", "Megalopolis");
+            StartGame();
+            DestroyNonCharacterVillainCards();
+
+            Card firstDemigod = FindCardsWhere((Card c) => c.IsActiveEnneadCharacter && c.IsInPlayAndHasGameText).FirstOrDefault();
+            Card crystal = PlayCard("DowsingCrystal");
+            UsePower(crystal);
+
+            DecisionYesNo = true;
+            DecisionSelectCards = new Card[] { ra.CharacterCard, firstDemigod };
+            SetHitPoints(firstDemigod, 4);
+            PlayCard("PoliceBackup");
+            AssertFlipped(firstDemigod);
+            Assert.IsFalse(firstDemigod.IsTarget);
+        }
+        [Test]
         public void TestGlimpse()
         {
             SetupGameController("BaronBlade", "Cauldron.MagnificentMara", "Legacy", "TheSentinels", "TheScholar", "Megalopolis");


### PR DESCRIPTION
Overwatch wouldn't deal its damage at all if the card had been destroyed.
Dowsing Crystal had an odd bug where, if you blew it up for the damage boost, it would have enough permission to deal damage but not enough permission to remove the "targetable" status on things like Ennead Demigods.