### PR TITLE
Mistress of fate + Ronin Knights/Nightlore Starlight

### DIFF
--- a/CauldronMods/Controller/Heroes/Starlight/CardSubClasses/MultiStarlightIndividualCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/CardSubClasses/MultiStarlightIndividualCardController.cs
@@ -1,0 +1,36 @@
+﻿using Handelabra.Sentinels.Engine.Controller;
+using Handelabra.Sentinels.Engine.Model;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Cauldron.Starlight
+{
+    public class MultiStarlightIndividualCardController : StarlightSubCharacterCardController
+	{
+
+        public MultiStarlightIndividualCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
+        {
+
+        }
+
+
+		public override IEnumerator BeforeFlipCardImmediateResponse(FlipCardAction flip)
+		{
+			if (!base.CardWithoutReplacements.IsFlipped)
+			{
+				RemoveTargetAction action = new RemoveTargetAction(base.GameController, base.CardWithoutReplacements);
+				IEnumerator coroutine = DoAction(action);
+				if (base.UseUnityCoroutines)
+				{
+					yield return base.GameController.StartCoroutine(coroutine);
+				}
+				else
+				{
+					base.GameController.ExhaustCoroutine(coroutine);
+				}
+				RemoveAllTriggers();
+			}
+		}
+	}
+}

--- a/CauldronMods/Controller/Heroes/Starlight/CharacterCards/StarlightOfAsheronCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/CharacterCards/StarlightOfAsheronCharacterCardController.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Cauldron.Starlight
 {
-    public class StarlightOfAsheronCharacterCardController : StarlightSubCharacterCardController
+    public class StarlightOfAsheronCharacterCardController : MultiStarlightIndividualCardController
     {
         public StarlightOfAsheronCharacterCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {

--- a/CauldronMods/Controller/Heroes/Starlight/CharacterCards/StarlightOfCryosFourCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/CharacterCards/StarlightOfCryosFourCharacterCardController.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Cauldron.Starlight
 {
-    public class StarlightOfCryosFourCharacterCardController : StarlightSubCharacterCardController
+    public class StarlightOfCryosFourCharacterCardController : MultiStarlightIndividualCardController
     {
         public StarlightOfCryosFourCharacterCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {

--- a/CauldronMods/Controller/Heroes/Starlight/CharacterCards/StarlightOfTerraCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/CharacterCards/StarlightOfTerraCharacterCardController.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Cauldron.Starlight
 {
-    public class StarlightOfTerraCharacterCardController : StarlightSubCharacterCardController
+    public class StarlightOfTerraCharacterCardController : MultiStarlightIndividualCardController
     {
         public StarlightOfTerraCharacterCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {

--- a/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/MultiKnightIndividualCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/MultiKnightIndividualCardController.cs
@@ -1,0 +1,36 @@
+﻿using Handelabra.Sentinels.Engine.Controller;
+using Handelabra.Sentinels.Engine.Model;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Cauldron.TheKnight
+{
+    public class MultiKnightIndividualCardController : TheKnightUtilityCharacterCardController
+	{
+
+        public MultiKnightIndividualCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
+        {
+
+        }
+
+		public override IEnumerator BeforeFlipCardImmediateResponse(FlipCardAction flip)
+		{
+			if (!base.CardWithoutReplacements.IsFlipped)
+			{
+				RemoveTargetAction action = new RemoveTargetAction(base.GameController, base.CardWithoutReplacements);
+				IEnumerator coroutine = DoAction(action);
+				if (base.UseUnityCoroutines)
+				{
+					yield return base.GameController.StartCoroutine(coroutine);
+				}
+				else
+				{
+					base.GameController.ExhaustCoroutine(coroutine);
+				}
+				RemoveAllTriggers();
+			}
+		}
+
+	}
+}

--- a/CauldronMods/Controller/Heroes/TheKnight/CharacterCards/TheOldKnightCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CharacterCards/TheOldKnightCharacterCardController.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Cauldron.TheKnight
 {
-    public class TheOldKnightCharacterCardController : TheKnightUtilityCharacterCardController
+    public class TheOldKnightCharacterCardController : MultiKnightIndividualCardController
     {
         public TheOldKnightCharacterCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {

--- a/CauldronMods/Controller/Heroes/TheKnight/CharacterCards/TheYoungKnightCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CharacterCards/TheYoungKnightCharacterCardController.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Cauldron.TheKnight
 {
-    public class TheYoungKnightCharacterCardController : TheKnightUtilityCharacterCardController
+    public class TheYoungKnightCharacterCardController : MultiKnightIndividualCardController
     {
         public TheYoungKnightCharacterCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {

--- a/CauldronMods/Controller/Heroes/TheKnight/CharacterCards/WastelandRoninTheKnightCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CharacterCards/WastelandRoninTheKnightCharacterCardController.cs
@@ -95,7 +95,7 @@ namespace Cauldron.TheKnight
         {
             if (!base.Card.IsFlipped)
             {
-                AddSideTrigger(AddTrigger(FlipCriteria, (GameAction ga) => base.GameController.FlipCard(FindCardController(base.Card), treatAsPlayed: false, treatAsPutIntoPlay: false, null, null, GetCardSource()), TriggerType.FlipCard, TriggerTiming.After));
+                AddSideTrigger(AddTrigger(FlipCriteria, (GameAction ga) => base.GameController.FlipCard(FindCardController(base.Card), cardSource: GetCardSource()), TriggerType.FlipCard, TriggerTiming.After));
             }
             else
             {

--- a/Testing/Villains/TheMistressOfFateTests.cs
+++ b/Testing/Villains/TheMistressOfFateTests.cs
@@ -1408,6 +1408,62 @@ namespace CauldronTests
             AssertInTrash(chains);
             AssertNotFlipped(idealist);
         }
+
+        [Test]
+        public void TestHeroPreservation_RoninKnight()
+        {
+            SetupGameController("Cauldron.TheMistressOfFate", "Legacy", "Cauldron.TheKnight/WastelandRoninTheKnightCharacter", "Ra", "Megalopolis");
+            StartGame();
+            ResetDays();
+            FlipCard(fate);
+            ResetRFGCards();
+
+            DestroyCard(youngKnight);
+            DestroyCard(oldKnight);
+
+            AssertIncapacitated(knight);
+
+            FlipCard(fate);
+
+            AssertNotFlipped(youngKnight);
+            AssertNotFlipped(oldKnight);
+
+            AssertNumberOfCardsInHand(knight, 4);
+            AssertNumberOfCardsInDeck(knight, 36);
+            AssertNumberOfCardsInTrash(knight, 0);
+
+
+        }
+
+        [Test]
+        public void TestHeroPreservation_NightloreStarlight()
+        {
+            SetupGameController("Cauldron.TheMistressOfFate", "Legacy", "Cauldron.Starlight/NightloreCouncilStarlightCharacter", "Ra", "Megalopolis");
+            StartGame();
+            ResetDays();
+            FlipCard(fate);
+            ResetRFGCards();
+
+            DestroyCard(cryos);
+            DestroyCard(asheron);
+            DestroyCard(terra);
+
+
+            AssertIncapacitated(starlight);
+
+            FlipCard(fate);
+
+            AssertNotFlipped(cryos);
+            AssertNotFlipped(asheron);
+            AssertNotFlipped(terra);
+
+
+            AssertNumberOfCardsInHand(starlight, 4);
+            AssertNumberOfCardsInDeck(starlight, 36);
+            AssertNumberOfCardsInTrash(starlight, 0);
+
+
+        }
         [Test]
         public void TestHeroPreservationCaptainCosmicRequital()
         {


### PR DESCRIPTION
Ronin Knights and Nightlore Starlight caused all their cards to be removed from the game twice, resulting in the preservation by Mistress of Fate not working. Created new subclass based on the Sentinels to resolve issue

Closes #1202 