### PR TITLE
Blackwood forest not loading in oa

### DIFF
--- a/CauldronMods/Controller/Environments/BlackwoodForest/Cards/VengefulSpiritsCardController.cs
+++ b/CauldronMods/Controller/Environments/BlackwoodForest/Cards/VengefulSpiritsCardController.cs
@@ -27,7 +27,12 @@ namespace Cauldron.BlackwoodForest
 
         public VengefulSpiritsCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            base.SpecialStringMaker.ShowListOfCardsAtLocation(FindLocationsWhere(location => location.IsRealTrash && location.IsVillain && GameController.IsLocationVisibleToSource(location, GetCardSource())).First(), new LinqCardCriteria(c => c.IsTarget, "target", useCardsSuffix: false, singular: "target", plural: "targets"));       
+            IEnumerable<Location> villainTrashes = FindLocationsWhere(location => location.IsRealTrash && location.IsVillain && GameController.IsLocationVisibleToSource(location, GetCardSource()));
+            foreach(Location loc in villainTrashes)
+            {
+                base.SpecialStringMaker.ShowListOfCardsAtLocation(loc, new LinqCardCriteria(c => c.IsTarget, "target", useCardsSuffix: false, singular: "target", plural: "targets"));
+
+            }
         }
 
         public override void AddTriggers()
@@ -141,5 +146,7 @@ namespace Cauldron.BlackwoodForest
                 base.GameController.ExhaustCoroutine(destroyRoutine);
             }
         }
+
+       
     }
 }

--- a/Testing/Environments/BlackwoodForestTests.cs
+++ b/Testing/Environments/BlackwoodForestTests.cs
@@ -28,6 +28,19 @@ namespace CauldronTests
             Assert.AreEqual(5, this.GameController.TurnTakerControllers.Count());
         }
 
+        [Test()]
+        public void TestBlackForestLoadsInOblivaeon()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Ra", "Legacy", "Haka", "Cauldron.BlackwoodForest", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+            Assert.AreEqual(8, this.GameController.TurnTakerControllers.Count());
+            AssertBattleZone(BlackwoodForest, bzOne);
+
+            Card spirit = PlayCard("VengefulSpirits");
+            PrintSpecialStringsForCard(spirit);
+
+        }
+
 
         [Test]
         public void TestOldBonesEmptyTrashPiles()


### PR DESCRIPTION
The Special String on Vengeful Spirits was erroring out. Made it safe by collecting list of all trashes and adding for each one. That way if there is none, nothing happens and if multiple multiple get added

Closes #1251 