### PR TITLE
Tango One's Wetwork Bug Fix in Oblivaeon

### DIFF
--- a/CauldronMods/Controller/Heroes/TangoOne/Cards/WetWorkCardController.cs
+++ b/CauldronMods/Controller/Heroes/TangoOne/Cards/WetWorkCardController.cs
@@ -74,13 +74,15 @@ namespace Cauldron.TangoOne
             Location deck;
             foreach(Location trash in allTrashes)
             {
-               scsd = new SelectCardsDecision(GameController, decisionMaker, c => c.Location == trash, SelectionType.ShuffleCardFromTrashIntoDeck,
-               numberOfCards: CardsToMoveFromTrash,
-               isOptional: false,
-               requiredDecisions: CardsToMoveFromTrash,
-               cardSource: GetCardSource());
-                
-                coroutine = GameController.SelectCardsAndDoAction(scsd, scd => GameController.MoveCard(decisionMaker, scd.SelectedCard, turnTaker.Deck, cardSource: GetCardSource()), cardSource: GetCardSource());
+                   scsd = new SelectCardsDecision(GameController, decisionMaker, c => c.Location == trash, SelectionType.ShuffleCardFromTrashIntoDeck,
+                   numberOfCards: CardsToMoveFromTrash,
+                   isOptional: false,
+                   requiredDecisions: CardsToMoveFromTrash,
+                   cardSource: GetCardSource());
+
+                   deck = trash.IsSubTrash ? turnTaker.FindSubDeck(trash.Identifier) : turnTaker.Deck;
+
+                coroutine = GameController.SelectCardsAndDoAction(scsd, scd => GameController.MoveCard(decisionMaker, scd.SelectedCard, deck, cardSource: GetCardSource()), cardSource: GetCardSource());
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);
@@ -90,7 +92,6 @@ namespace Cauldron.TangoOne
                     base.GameController.ExhaustCoroutine(coroutine);
                 }
 
-                deck = trash.IsSubTrash ? turnTaker.FindSubDeck(trash.Identifier) : turnTaker.Deck;
                 coroutine = base.GameController.ShuffleLocation(deck, cardSource: GetCardSource());
                 if (base.UseUnityCoroutines)
                 {

--- a/Testing/Heroes/TangoOneTests.cs
+++ b/Testing/Heroes/TangoOneTests.cs
@@ -1340,12 +1340,14 @@ namespace CauldronTests
             SetupGameController(new string[] { "OblivAeon", "Cauldron.TangoOne", "Legacy", "Haka", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
             StartGame();
 
+            Dictionary<Location, Card> topCardsOfSubDecks = new Dictionary<Location, Card>();
 
             SwitchBattleZone(haka);
 
             DiscardTopCards(oblivaeon, 1);
             foreach(Location subdeck in oblivaeon.TurnTaker.SubDecks.Where(d => d.IsRealDeck))
             {
+                topCardsOfSubDecks.Add(subdeck, subdeck.TopCard);
                 DiscardTopCards(subdeck, 1);
             }
             DiscardTopCards(tango, 1);
@@ -1366,10 +1368,12 @@ namespace CauldronTests
             foreach (Location subtrash in oblivaeon.TurnTaker.SubTrashes.Where(d => d.IsRealTrash))
             {
                 AssertNumberOfCardsAtLocation(subtrash, 0);
-
             }
 
-
+            foreach (Location subdeck in oblivaeon.TurnTaker.SubDecks.Where(d => d.IsRealDeck))
+            {
+                AssertAtLocation(topCardsOfSubDecks[subdeck], subdeck);
+            }
 
         }
 


### PR DESCRIPTION
While it was allowing you to choose subdecks and shuffling subdecks, it was returning to the main TurnTaker.Deck instead of the appropriate subdeck location.

Closes #1278 