### PR TITLE
FSC Continuance Wanderer's Heart of Wanderer Bug Fixes in Oblivaeon

### DIFF
--- a/CauldronMods/Controller/Environments/FSCContinuanceWanderer/Cards/HeartOfTheWandererCardController.cs
+++ b/CauldronMods/Controller/Environments/FSCContinuanceWanderer/Cards/HeartOfTheWandererCardController.cs
@@ -39,14 +39,16 @@ namespace Cauldron.FSCContinuanceWanderer
         private IEnumerator EachTurnTakerResponse(TurnTakerController turnTakerController)
         {
             //...reveal the top card of each deck in turn order and either discard it or replace it.
-            List<Card> revealedCards = new List<Card>();
             TurnTaker turnTaker = turnTakerController.TurnTaker;
             List<Location> decks = new List<Location>();
             decks.Add(turnTaker.Deck);
             decks = decks.Concat(turnTaker.SubDecks.Where(l => l.BattleZone == Card.BattleZone && l.IsRealDeck)).ToList();
             IEnumerator coroutine;
+            Location trash;
             foreach (Location deck in decks)
             {
+                trash = deck.IsSubDeck ? turnTaker.FindSubTrash(deck.Identifier) : turnTaker.Trash;
+                List<Card> revealedCards = new List<Card>();
                 coroutine = base.GameController.RevealCards(turnTakerController, deck, 1, revealedCards, cardSource: GetCardSource());
                 if (base.UseUnityCoroutines)
                 {
@@ -62,7 +64,7 @@ namespace Cauldron.FSCContinuanceWanderer
                     coroutine = base.GameController.SelectLocationAndMoveCard(this.DecisionMaker, revealedCard, new MoveCardDestination[]
                     {
                         new MoveCardDestination(deck),
-                        FindCardController(revealedCard).GetTrashDestination()
+                        new MoveCardDestination(trash)
                     }, cardSource: base.GetCardSource());
                     if (base.UseUnityCoroutines)
                     {
@@ -73,6 +75,8 @@ namespace Cauldron.FSCContinuanceWanderer
                         base.GameController.ExhaustCoroutine(coroutine);
                     }
                 }
+
+
             }
             
             yield break;

--- a/CauldronMods/Controller/Environments/FSCContinuanceWanderer/Cards/HeartOfTheWandererCardController.cs
+++ b/CauldronMods/Controller/Environments/FSCContinuanceWanderer/Cards/HeartOfTheWandererCardController.cs
@@ -41,8 +41,11 @@ namespace Cauldron.FSCContinuanceWanderer
             //...reveal the top card of each deck in turn order and either discard it or replace it.
             TurnTaker turnTaker = turnTakerController.TurnTaker;
             List<Location> decks = new List<Location>();
-            decks.Add(turnTaker.Deck);
-            decks = decks.Concat(turnTaker.SubDecks.Where(l => l.BattleZone == Card.BattleZone && l.IsRealDeck)).ToList();
+            if (GameController.IsLocationVisibleToSource(TurnTaker.Deck, GetCardSource()))
+            {
+                decks.Add(turnTaker.Deck);
+            }
+            decks = decks.Concat(turnTaker.SubDecks.Where(l => l.BattleZone == Card.BattleZone && l.IsRealDeck && GameController.IsLocationVisibleToSource(l, GetCardSource()))).ToList();
             IEnumerator coroutine;
             Location trash;
             foreach (Location deck in decks)

--- a/Testing/Environments/FSCContinuanceWandererTests.cs
+++ b/Testing/Environments/FSCContinuanceWandererTests.cs
@@ -199,6 +199,9 @@ namespace CauldronTests
             SetupGameController(new string[] { "OblivAeon", "Cauldron.Cricket", "Legacy", "Haka", "Cauldron.FSCContinuanceWanderer", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
             StartGame();
             Card expectedMission = oblivaeon.TurnTaker.FindSubDeck("MissionDeck").TopCard;
+            Card aeonWarrior = GetCard("AeonWarrior");
+            PlayCard(oblivaeon, aeonWarrior, overridePlayLocation: envOne.BattleZone.FindScion().PlayArea);
+            PlayCard(oblivaeon, borrScion, overridePlayLocation: envOne.BattleZone.FindScion().PlayArea);
             GoToStartOfTurn(envOne);
             PlayCard("HeartOfTheWanderer");
             Card actualMission = oblivaeon.TurnTaker.FindSubDeck("MissionDeck").TopCard;


### PR DESCRIPTION
While it was choosing every subdeck, it was always revealing the card from the main deck and the trash option was only for the main deck.

Closes #1277 