### PR TITLE
Vanish's Forewarned Bug Fixes in Oblivaeon

### DIFF
--- a/Testing/Heroes/VanishTests.cs
+++ b/Testing/Heroes/VanishTests.cs
@@ -525,9 +525,15 @@ namespace CauldronTests
         {
             SetupGameController(new string[] { "OblivAeon", "Cauldron.Vanish", "Legacy", "Haka", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
             StartGame();
-
             GoToStartOfTurn(vanish);
-            AssertNumberOfChoicesInNextDecision(5, SelectionType.RevealTopCardOfDeck);
+
+            Card aeonWarrior = GetCard("AeonWarrior");
+            PlayCard(oblivaeon, aeonWarrior, overridePlayLocation: vanish.BattleZone.FindScion().PlayArea);
+            PlayCard(oblivaeon, borrScion, overridePlayLocation: vanish.BattleZone.FindScion().PlayArea);
+
+
+            AssertNumberOfChoicesInNextDecision(7, SelectionType.RevealTopCardOfDeck);
+            AssertNumberOfChoicesInNextDecision(7, SelectionType.PutIntoPlay);
             PlayCard("FlashRecon");
            
         }


### PR DESCRIPTION
While the revealed cards were able to look at subdecks, the play card was not.

Note about some current behavior: the OA subdecks (Aeon Men Deck and Scion Deck) only become "visible" if there is a target in play in the same battlezone as the card itself (in this case, forewarned). This is why we play and aeon man and scion at the start of the test.

Closes #1273 