### PR TITLE
Terminus' Unusual suspects Bug Fix in Oblivaeon

### DIFF
--- a/CauldronMods/Controller/Heroes/Terminus/Cards/UnusualSuspectsCardController.cs
+++ b/CauldronMods/Controller/Heroes/Terminus/Cards/UnusualSuspectsCardController.cs
@@ -60,11 +60,20 @@ namespace Cauldron.Terminus
 
         private bool HasKeywordInAnyTrash(Card target)
         {
+            List<Location> trashes = new List<Location>();
+            foreach (TurnTaker tt in Game.TurnTakers)
+            {
+                if (tt.IsIncapacitatedOrOutOfGame) continue;
+                if (tt.Trash.BattleZone == Card.BattleZone && tt.Trash.IsRealTrash && GameController.IsLocationVisibleToSource(tt.Trash, GetCardSource()))
+                {
+                    trashes.Add(tt.Trash);
+                }
+                trashes = trashes.Concat(tt.SubTrashes.Where(l => l.BattleZone == Card.BattleZone && l.IsRealTrash && GameController.IsLocationVisibleToSource(l, GetCardSource()))).ToList();
+            }
             List<string> cardKeywords = target.GetKeywords().ToList();
-            List<Location> allTrash = base.GameController.AllTurnTakers.Where((tt) => !tt.IsIncapacitatedOrOutOfGame && tt.Trash.HasCards).Select((tt) => tt.Trash).ToList();
             bool matchesKeyword = false;
 
-            foreach (Location trash in allTrash)
+            foreach (Location trash in trashes)
             {
                 if (trash.Cards.Any(card => card.DoKeywordsContain(cardKeywords)))
                 {

--- a/Testing/Heroes/TerminusTest.cs
+++ b/Testing/Heroes/TerminusTest.cs
@@ -14,9 +14,6 @@ namespace CauldronTests
     [TestFixture()]
     public class TerminusTest : CauldronBaseTest
     {
-        protected Card terra { get { return GetCard("StarlightOfTerraCharacter"); } }
-        protected Card asheron { get { return GetCard("StarlightOfAsheronCharacter"); } }
-        protected Card cryos { get { return GetCard("StarlightOfCryosFourCharacter"); } }
 
         #region Terminus Utilities
         private string[] gameDecks => new string[] { "BaronBlade", "Cauldron.Terminus", "Legacy", "Bunker", "TheScholar", "Megalopolis" };
@@ -1596,6 +1593,25 @@ namespace CauldronTests
             PlayCard("UnusualSuspects");
             QuickTokenPoolCheck(2);
             QuickHPCheck(-2, 0, 0, 0, 0, -4);
+
+        }
+
+        [Test]
+        public void UnusualSuspectsOblivAeon()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Terminus", "Legacy", "Haka", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            DiscardTopCards(oblivaeon.TurnTaker.FindSubDeck("AeonMenDeck"), 3, oblivaeon.CharacterCardController.GetCardSource());
+
+            Card aeonWarrior = GetCard("AeonWarrior");
+            PlayCard(oblivaeon, aeonWarrior, overridePlayLocation: terminus.BattleZone.FindScion().PlayArea);
+
+            DecisionSelectTargets = new Card[] { aeonWarrior, null };
+            QuickHPStorage(aeonWarrior);
+            PlayCard("UnusualSuspects");
+            QuickHPCheck(-4);
+
 
         }
         #endregion Test Unusual Suspects


### PR DESCRIPTION
When checking if a card with a matching keyword existed in any trash, it was not checking sub trashes.

Closes #1272 