### PR TITLE
Gray's Start of Turn Flipped Destruction and Fixed Point

### DIFF
--- a/CauldronMods/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
@@ -90,7 +90,7 @@ namespace Cauldron.Gray
         {
             IEnumerator coroutine;
             //...destroy 1 hero ongoing or equipment card and {Gray} deals each non-villain target {H - 1} energy damage
-            if (FindNumberOfHeroOngoingAndEquipmentInPlay() > 0)
+            if (FindNumberOfDestructibleHeroOngoingAndEquipmentInPlay() > 0)
             {
                 int? numberOfCards = new int?(1);
                 if (Game.IsAdvanced)
@@ -121,9 +121,21 @@ namespace Cauldron.Gray
             yield break;
         }
 
-        private int? FindNumberOfHeroOngoingAndEquipmentInPlay()
+        private int? FindNumberOfDestructibleHeroOngoingAndEquipmentInPlay()
         {
-            return new int?(base.FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsHero && (c.IsOngoing || base.IsEquipment(c)), false, null, false).Count<Card>());
+            return new int?(base.FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsHero && (c.IsOngoing || base.IsEquipment(c)) && CanBeDestroyedByGray(c)).Count());
+        }
+
+        private int? FindNumberOHeroOngoingAndEquipmentInPlay()
+        {
+            return new int?(base.FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsHero && (c.IsOngoing || base.IsEquipment(c))).Count());
+        }
+
+        private bool CanBeDestroyedByGray(Card c)
+        {
+            CardController controller = GameController.DoesAnyCardControllerMakeAnotherCardIndestructible(c);
+            Card card = DoesAnyStatusEffectControllerMakeACardIndestructible(c);
+            return controller is null && card is null;
         }
 
         private int? FindNumberOfEnvironmentInPlay()
@@ -135,7 +147,7 @@ namespace Cauldron.Gray
         {
             //...destroy all but 2 hero ongoing or equipment cards. 
             IEnumerator coroutine;
-            while (this.FindNumberOfHeroOngoingAndEquipmentInPlay() > 2)
+            while (this.FindNumberOfDestructibleHeroOngoingAndEquipmentInPlay() > 2)
             {
                 coroutine = base.GameController.SelectAndDestroyCard(this.DecisionMaker, new LinqCardCriteria((Card c) => c.IsHero && (c.IsOngoing || base.IsEquipment(c))), false);
                 if (base.UseUnityCoroutines)
@@ -147,6 +159,21 @@ namespace Cauldron.Gray
                     base.GameController.ExhaustCoroutine(coroutine);
                 }
             }
+
+            //add message if ended because of indestructible
+            if(FindNumberOHeroOngoingAndEquipmentInPlay() > 2)
+            {
+                coroutine = GameController.SendMessageAction($"Some hero ongoing or equipment cards are indestructible, so there are more than 2 of them still in play.", Priority.Medium, GetCardSource(), showCardSource: true);
+                if (base.UseUnityCoroutines)
+                {
+                    yield return base.GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    base.GameController.ExhaustCoroutine(coroutine);
+                }
+            }
+
             //...{Gray} deals each hero target {H x 2} energy damage.
             coroutine = base.GameController.DealDamage(this.DecisionMaker, base.Card, (Card c) => c.IsHero, Game.H * 2, DamageType.Energy, cardSource: base.GetCardSource());
             //...Play the top card of the villain deck.
@@ -210,5 +237,19 @@ namespace Cauldron.Gray
             }
             yield break;
         }
+
+        private Card DoesAnyStatusEffectControllerMakeACardIndestructible(Card card)
+        {
+            foreach (StatusEffectController statusEffectController in GameController.StatusEffectManager.StatusEffectControllers)
+            {
+                Card card2 = statusEffectController.AskIfCardIsIndestructible(card);
+                if (card2 != null)
+                {
+                    return card2;
+                }
+            }
+            return null;
+        }
+
     }
 }

--- a/CauldronMods/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
@@ -126,7 +126,12 @@ namespace Cauldron.Gray
             return new int?(base.FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsHero && (c.IsOngoing || base.IsEquipment(c)) && CanBeDestroyedByGray(c)).Count());
         }
 
-        private int? FindNumberOHeroOngoingAndEquipmentInPlay()
+        private int? FindNumberOfIndestructibleHeroOngoingAndEquipmentInPlay()
+        {
+            return new int?(base.FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsHero && (c.IsOngoing || base.IsEquipment(c)) && !CanBeDestroyedByGray(c)).Count());
+        }
+
+        private int? FindNumberOfHeroOngoingAndEquipmentInPlay()
         {
             return new int?(base.FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsHero && (c.IsOngoing || base.IsEquipment(c))).Count());
         }
@@ -147,7 +152,7 @@ namespace Cauldron.Gray
         {
             //...destroy all but 2 hero ongoing or equipment cards. 
             IEnumerator coroutine;
-            while (this.FindNumberOfDestructibleHeroOngoingAndEquipmentInPlay() > 2)
+            while (FindNumberOfHeroOngoingAndEquipmentInPlay() > 2 && FindNumberOfHeroOngoingAndEquipmentInPlay() != this.FindNumberOfIndestructibleHeroOngoingAndEquipmentInPlay())
             {
                 coroutine = base.GameController.SelectAndDestroyCard(this.DecisionMaker, new LinqCardCriteria((Card c) => c.IsHero && (c.IsOngoing || base.IsEquipment(c))), false);
                 if (base.UseUnityCoroutines)
@@ -161,9 +166,9 @@ namespace Cauldron.Gray
             }
 
             //add message if ended because of indestructible
-            if(FindNumberOHeroOngoingAndEquipmentInPlay() > 2)
+            if(FindNumberOfHeroOngoingAndEquipmentInPlay() > 2)
             {
-                coroutine = GameController.SendMessageAction($"Some hero ongoing or equipment cards are indestructible, so there are more than 2 of them still in play.", Priority.Medium, GetCardSource(), showCardSource: true);
+                coroutine = GameController.SendMessageAction($"Some hero ongoing or equipment cards are indestructible.", Priority.Medium, GetCardSource(), showCardSource: true);
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);

--- a/Testing/CauldronBaseTest.cs
+++ b/Testing/CauldronBaseTest.cs
@@ -70,11 +70,18 @@ namespace CauldronTests
             this.RunCoroutine(this.GameController.AddStatusEffect(immuneToDamageStatusEffect, true, new CardSource(ttc.CharacterCardController)));
         }
 
-        protected void AddCannotDealDamageTrigger(TurnTakerController ttc, Card specificCard)
+        protected void AddCannotDealDamageTrigger(TurnTakerController ttc, Card specificCard, bool untilEnd = false)
         {
             CannotDealDamageStatusEffect cannotDealDamageEffect = new CannotDealDamageStatusEffect();
             cannotDealDamageEffect.SourceCriteria.IsSpecificCard = specificCard;
-            cannotDealDamageEffect.UntilStartOfNextTurn(ttc.TurnTaker);
+            if(!untilEnd)
+            {
+                cannotDealDamageEffect.UntilStartOfNextTurn(ttc.TurnTaker);
+            }
+            else
+            {
+                cannotDealDamageEffect.UntilEndOfNextTurn(ttc.TurnTaker);
+            }
             this.RunCoroutine(this.GameController.AddStatusEffect(cannotDealDamageEffect, true, new CardSource(ttc.CharacterCardController)));
         }
 
@@ -86,7 +93,7 @@ namespace CauldronTests
             this.RunCoroutine(this.GameController.AddStatusEffect(cannotDealDamageStatusEffect, true, new CardSource(ttc.CharacterCardController)));
         }
 
-        protected void AddCannotPlayCardsStatusEffect(TurnTakerController source, bool heroesCannotPlay, bool villainsCannotPlay, bool envCardsCannotPlay = false)
+        protected void AddCannotPlayCardsStatusEffect(TurnTakerController source, bool heroesCannotPlay, bool villainsCannotPlay, bool envCardsCannotPlay = false, bool untilEnd = false)
         {
             CannotPlayCardsStatusEffect effect = new CannotPlayCardsStatusEffect();
             if (heroesCannotPlay)
@@ -95,7 +102,15 @@ namespace CauldronTests
                 effect.CardCriteria.IsVillain = true;
             if (envCardsCannotPlay)
                 effect.CardCriteria.IsEnvironment = true;
-            effect.UntilStartOfNextTurn(source.TurnTaker);
+
+            if(!untilEnd)
+            {
+                effect.UntilStartOfNextTurn(source.TurnTaker);
+
+            } else
+            {
+                effect.UntilEndOfNextTurn(source.TurnTaker);
+            }
             this.RunCoroutine(this.GameController.AddStatusEffect(effect, true, new CardSource(source.CharacterCardController)));
         }
 

--- a/Testing/Villains/GrayTests.cs
+++ b/Testing/Villains/GrayTests.cs
@@ -5,6 +5,7 @@ using Cauldron.Gray;
 using System.Linq;
 using Handelabra.Sentinels.Engine.Model;
 using System.Collections.Generic;
+using System;
 
 namespace CauldronTests
 {
@@ -233,6 +234,35 @@ namespace CauldronTests
             AssertInTrash(trash);
             AssertIsInPlay(play);
             AssertIsInPlay(ali);
+        }
+
+        [Test()]
+        public void TestGrayBackStartOfTurn_FixedPoint()
+        {
+            SetupGameController("Cauldron.Gray", "Legacy", "Haka", "Ra", "TimeCataclysm");
+            StartGame();
+
+            PlayCards(GetCard("BlightTheLand", 0), GetCard("BlightTheLand", 1));
+            GoToEndOfTurn(env);
+            AddCannotDealDamageTrigger(gray, gray.CharacterCard, untilEnd: true);
+            AddCannotPlayCardsStatusEffect(gray, false, true, untilEnd: true);
+            IEnumerable<Card> trash = GetCards("Fortitude", "Mere");
+            IEnumerable<Card> play = GetCards("TaMoko", "BlazingTornado");
+            PlayCards(play);
+            PlayCards(trash);
+            Card fixedPoint = PlayCard("FixedPoint");
+            //At the start of the villain turn, destroy all but 2 hero ongoing or equipment cards. 
+            GoToStartOfTurn(gray);
+            //CardController fixedCC = FindCardController(fixedPoint);
+            //bool indestructible;
+            //foreach(Card c in trash.Concat(play))
+            //{
+            //    indestructible = fixedCC.AskIfCardIsIndestructible(c);
+            //    string not = indestructible ? "" : "not ";
+            //    Console.WriteLine($"{c.Title} is {not}indestructible.");
+            //}
+            AssertIsInPlay(trash);
+            AssertIsInPlay(play);
         }
 
         [Test()]


### PR DESCRIPTION
Gray's Start of Turn flipped effect was continuously trying to destroy all ongoing/equipment cards until there are 2 left. When everything is indestructible, that becomes impossible. Allowed a backdoor if everything is indestructible.

Closes #1303 