### PR TITLE
Malichae's Zephaeren's Compass Ignores Chasm's Djinns

### DIFF
--- a/CauldronMods/Controller/Heroes/Malichae/Cards/ZephaerensCompassCardController.cs
+++ b/CauldronMods/Controller/Heroes/Malichae/Cards/ZephaerensCompassCardController.cs
@@ -15,8 +15,8 @@ namespace Cauldron.Malichae
 
         public override IEnumerator UsePower(int index = 0)
         {
-            var scd = new SelectCardDecision(GameController, DecisionMaker, SelectionType.MoveCardToHand, DecisionMaker.HeroTurnTaker.PlayArea.Cards,
-                            additionalCriteria: c => c.IsTarget && c.IsInPlayAndHasGameText && IsDjinn(c),
+            IEnumerable<Card> choices = FindCardsWhere(c => c.IsTarget && c.IsInPlayAndHasGameText && IsDjinn(c), visibleToCard: GetCardSource());
+            var scd = new SelectCardDecision(GameController, DecisionMaker, SelectionType.MoveCardToHand, choices,
                             cardSource: GetCardSource());
             var coroutine = base.GameController.SelectCardAndDoAction(scd, CompassPowerResponse);
             if (base.UseUnityCoroutines)

--- a/Testing/Heroes/MalichaeTests.cs
+++ b/Testing/Heroes/MalichaeTests.cs
@@ -1414,6 +1414,38 @@ namespace CauldronTests
             AssertInTrash(envCard);
         }
 
+        [Test]
+        public void ZephaerensCompass_ChasmDjinn()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Malichae", "Ra", "Fanatic", "Cauldron.TheChasmOfAThousandNights");
+            StartGame();
+
+            var ongoing = PlayCard("BacklashField");
+
+            GoToPlayCardPhase(malichae);
+
+            var card = PlayCard("ZephaerensCompass");
+            AssertInPlayArea(malichae, card);
+
+            string djinn = "Axion";
+
+            var target = PlayCard(djinn);
+            DecisionMoveCard = target;
+
+            GoToUsePowerPhase(malichae);
+
+            QuickHandStorage(malichae, ra, fanatic);
+
+            DecisionMoveCard = target;
+            DecisionDestroyCards = new Card[] { ongoing, null };
+
+            UsePower(card);
+
+            QuickHandCheck(1, 0, 0);
+            AssertInHand(malichae, target);
+            AssertInTrash(ongoing);
+        }
+
 
         [Test]
         public void PrismaticVision()


### PR DESCRIPTION
Changed criteria to look for all djinns, not just the ones in Malichae's play area.
