### PR TITLE
Progeny and Titan/Drift

### DIFF
--- a/CauldronMods/Controller/Heroes/Drift/CardSubClasses/DriftSubCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/CardSubClasses/DriftSubCharacterCardController.cs
@@ -3,6 +3,7 @@ using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Cauldron.Drift
@@ -333,6 +334,39 @@ namespace Cauldron.Drift
                 }
             }
         }
-        
+
+        protected override IEnumerator RemoveCardsFromGame(IEnumerable<Card> cards)
+        {
+            if (!Card.IsInPlayAndHasGameText)
+            {
+                yield break;
+            }
+            IEnumerable<Card> enumerable = FindCardsWhere((Card c) => c != Card && c.SharedIdentifier != null && c.SharedIdentifier == Card.SharedIdentifier);
+            foreach (Card item in enumerable)
+            {
+                if (!item.IsIncapacitated)
+                {
+                    IEnumerator coroutine = base.GameController.FlipCard(FindCardController(item), cardSource: GetCardSource());
+                    if (base.UseUnityCoroutines)
+                    {
+                        yield return base.GameController.StartCoroutine(coroutine);
+                    }
+                    else
+                    {
+                        base.GameController.ExhaustCoroutine(coroutine);
+                    }
+                }
+            }
+            IEnumerator coroutine2 = base.RemoveCardsFromGame(cards);
+            if (base.UseUnityCoroutines)
+            {
+                yield return base.GameController.StartCoroutine(coroutine2);
+            }
+            else
+            {
+                base.GameController.ExhaustCoroutine(coroutine2);
+            }
+        }
+
     }
 }

--- a/CauldronMods/Controller/Heroes/Titan/SubCardClasses/TitanBaseCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Titan/SubCardClasses/TitanBaseCharacterCardController.cs
@@ -78,5 +78,38 @@ namespace Cauldron.Titan
                 }
             }
         }
+
+        protected override IEnumerator RemoveCardsFromGame(IEnumerable<Card> cards)
+        {
+            if (!Card.IsInPlayAndHasGameText)
+            {
+                yield break;
+            }
+            IEnumerable<Card> enumerable = FindCardsWhere((Card c) => c != Card && c.SharedIdentifier != null && c.SharedIdentifier == Card.SharedIdentifier);
+            foreach (Card item in enumerable)
+            {
+                if (!item.IsIncapacitated)
+                {
+                    IEnumerator coroutine = base.GameController.FlipCard(FindCardController(item), cardSource: GetCardSource());
+                    if (base.UseUnityCoroutines)
+                    {
+                        yield return base.GameController.StartCoroutine(coroutine);
+                    }
+                    else
+                    {
+                        base.GameController.ExhaustCoroutine(coroutine);
+                    }
+                }
+            }
+            IEnumerator coroutine2 = base.RemoveCardsFromGame(cards);
+            if (base.UseUnityCoroutines)
+            {
+                yield return base.GameController.StartCoroutine(coroutine2);
+            }
+            else
+            {
+                base.GameController.ExhaustCoroutine(coroutine2);
+            }
+        }
     }
 }

--- a/Testing/Heroes/DriftDualVariantTests.cs
+++ b/Testing/Heroes/DriftDualVariantTests.cs
@@ -301,5 +301,26 @@ namespace CauldronTests
             Assert.AreEqual(decision, CurrentShiftPosition());
             AssertIsInPlay(track);
         }
+
+        [Test()]
+        public void TestDualDriftAndProgeny()
+        {
+            SetupGameController("Progeny", "Cauldron.Drift/DualDriftCharacter", "Haka", "Bunker", "TheScholar", "Megalopolis");
+            StartGame();
+
+            Card blueFuture = GetCard("Blue" + FutureDriftCharacter);
+            AssertInPlayArea(drift,blueFuture);
+            SetHitPoints(blueFuture, 8);
+
+            GoToStartOfTurn(progeny);
+
+            DealDamage(progeny, blueFuture, 8, DamageType.Radiant);
+            AssertIncapacitated(drift);
+
+            GoToStartOfTurn(progeny);
+
+            AssertNotFlipped(progeny);
+
+        }
     }
 }

--- a/Testing/Heroes/DriftTests.cs
+++ b/Testing/Heroes/DriftTests.cs
@@ -1217,5 +1217,22 @@ namespace CauldronTests
             AssertMaxNumberOfDecisions(1);
             UsePower(lookingUp);
         }
+
+        [Test()]
+        public void TestDriftAndProgeny()
+        {
+            SetupGameController("Progeny", "Cauldron.Drift", "Haka", "Bunker", "TheScholar", "Megalopolis");
+            SetHitPoints(drift, 8);
+            StartGame();
+
+            GoToShiftPosition(4);
+            DealDamage(progeny, drift, 8, DamageType.Radiant);
+            AssertIncapacitated(drift);
+
+            GoToStartOfTurn(progeny);
+
+            AssertNotFlipped(progeny);
+
+        }
     }
 }

--- a/Testing/Heroes/TitanTests.cs
+++ b/Testing/Heroes/TitanTests.cs
@@ -1362,5 +1362,26 @@ namespace CauldronTests
             //+2 each for Bunker and Scholar's turns
             QuickHPCheck(4);
         }
+
+        [Test()]
+        public void TestTitanAndProgeny()
+        {
+            SetupGameController("Progeny", "Cauldron.Titan", "Haka", "Bunker", "TheScholar", "Megalopolis");
+            SetHitPoints(titan, 8);
+            Card tform = PlayCard("Titanform");
+            StartGame();
+
+            DecisionYesNo = true;
+            DealDamage(titan, progeny, 3, DamageType.Infernal);
+            DealDamage(progeny, titan, 8, DamageType.Radiant);
+            AssertIncapacitated(titan);
+
+            GoToStartOfTurn(progeny);
+
+            AssertNotFlipped(progeny);
+
+
+            
+        }
     }
 }


### PR DESCRIPTION
When Titan or Drift was in the game and become incapped with no other heroes below 10 HP, Progeny starts an infinite loop of flipping back and forth. Added more support for incapping the off to the side cards.

Closes #1308 