### PR TITLE
added IsGameWinnable check to game actions

### DIFF
--- a/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/HydraTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/HydraTiamatCharacterCardController.cs
@@ -3,7 +3,6 @@ using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Cauldron.Tiamat

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
@@ -147,12 +147,10 @@ namespace Cauldron.Tiamat
 
         public override bool IsGameWinnable()
         {
-            
             if(GameController.FindCardController(TurnTaker.FindCard("WinterTiamatCharacter")) is HydraWinterTiamatCharacterCardController)
             {
-                return TurnTaker.GetCardsWhere((Card c) => c.IsCharacter && c.IsInGame).Count() == 6;
+                return TurnTaker.GetCardsWhere((Card c) => c.IsCharacter && c.IsInGame).Count() < 6;
             }
-            
             return true;
         }
     }


### PR DESCRIPTION
Modeled after Unforgiving Wasteland's approach. If some other card (likely outside of the base game or the Cauldron) attempt to move a head out of the game without checking if that's possible or if the game is winnable, then this controller declares the game over itself.

Closes #1124, kind of. We could not repro the original issue, and the repro we did get was fixed with a base game update. This is future-proofing in case someone plays alongside other mods.