### PR TITLE
Reorder play area move card destinations

### DIFF
--- a/CauldronMods/Controller/Heroes/Cypher/Cards/RebuiltToSucceedCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cypher/Cards/RebuiltToSucceedCardController.cs
@@ -59,8 +59,8 @@ namespace Cauldron.Cypher
 
             MoveCardDestination[] destinations = 
             {
-                new MoveCardDestination(base.HeroTurnTaker.Hand),
-                new MoveCardDestination(base.TurnTaker.PlayArea)
+                new MoveCardDestination(base.TurnTaker.PlayArea),
+                new MoveCardDestination(base.HeroTurnTaker.Hand)
             };
 
             List<MoveCardAction> moveResult = new List<MoveCardAction>();

--- a/CauldronMods/Controller/Heroes/TheKnight/Cards/ArmYourselfCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/Cards/ArmYourselfCardController.cs
@@ -35,8 +35,8 @@ namespace Cauldron.TheKnight
                 var card = cards[0];
 
                 var destinations = new[] {
-                    new MoveCardDestination(base.HeroTurnTaker.Hand),
-                    new MoveCardDestination(base.TurnTaker.PlayArea)
+                    new MoveCardDestination(base.TurnTaker.PlayArea),
+                    new MoveCardDestination(base.HeroTurnTaker.Hand)
                 };
 
                 List<MoveCardAction> moveResult = new List<MoveCardAction>();


### PR DESCRIPTION
Closes #1376 

Per MigrantP, when selecting between locations, the Play Area should always be first.

Searched through the entire project and these were the only two that had play area + other locations with the play area not first