### PR TITLE
Improve Necro's cards to Accomodate IsVillainTarget

### DIFF
--- a/CauldronMods/Controller/Heroes/Necro/CardSubClasses/NecroCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/CardSubClasses/NecroCardController.cs
@@ -19,32 +19,50 @@ namespace Cauldron.Necro
 
         protected ITrigger AddUndeadDestroyedTrigger(Func<DestroyCardAction, IEnumerator> response, TriggerType triggerType)
         {
-            return base.AddTrigger<DestroyCardAction>(d => this.IsUndead(d.CardToDestroy.Card) && d.WasCardDestroyed, response, triggerType, TriggerTiming.After);
+            return AddTrigger<DestroyCardAction>(d => this.IsUndead(d.CardToDestroy.Card) && d.WasCardDestroyed, response, triggerType, TriggerTiming.After);
         }
 
         protected bool IsHeroConsidering1929(Card card)
         {
-            if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
+            if (GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) == true)
             {
                 return IsVillain(card);
             }
             return card.IsHero;
         }
 
+        protected bool IsHeroTargetConsidering1929(Card card)
+        {
+            if (GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) == true)
+            {
+                return IsVillainTarget(card);
+            }
+            return card.IsHero && card.IsTarget;
+        }
+
         protected bool IsVillianConsidering1929(Card card)
         {
-            if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
+            if (GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) == true)
             {
                 return card.IsHero;
             }
-            return base.IsVillain(card);
+            return IsVillain(card);
+        }
+
+        protected bool IsVillianTargetConsidering1929(Card card)
+        {
+            if (GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) == true)
+            {
+                return card.IsHero && card.IsTarget;
+            }
+            return IsVillainTarget(card);
         }
 
         protected string HeroStringConsidering1929
         {
             get
             {
-                if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
+                if (GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) == true)
                 {
                     return "villain";
                 }
@@ -56,7 +74,7 @@ namespace Cauldron.Necro
         {
             get
             {
-                if (GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(base.CharacterCard, PastNecroPowerKey) == true)
+                if (GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) != null && GameController.GetCardPropertyJournalEntryBoolean(CharacterCard, PastNecroPowerKey) == true)
                 {
                     return "hero";
                 }
@@ -71,7 +89,7 @@ namespace Cauldron.Necro
 
         protected int GetNumberOfRitualsInPlay()
         {
-            return base.FindCardsWhere(c => c.IsInPlayAndHasGameText && this.IsRitual(c)).Count();
+            return FindCardsWhere(c => c.IsInPlayAndHasGameText && this.IsRitual(c)).Count();
         }
 
         protected bool IsUndead(Card card)

--- a/CauldronMods/Controller/Heroes/Necro/Cards/AbominationCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/Cards/AbominationCardController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.Necro
         public override void AddTriggers()
         {
             //At the end of your turn, this card deals all non-Undead hero targets 2 toxic damage.        
-            base.AddEndOfTurnTrigger(tt => tt == base.TurnTaker, _ => base.DealDamage(this.Card, card => !IsUndead(card) && IsHeroConsidering1929(card), 2, DamageType.Toxic), TriggerType.DealDamage);
+            base.AddEndOfTurnTrigger(tt => tt == base.TurnTaker, _ => base.DealDamage(this.Card, card => !IsUndead(card) && IsHeroTargetConsidering1929(card), 2, DamageType.Toxic), TriggerType.DealDamage);
             //When this card is destroyed, all players draw a card.
             base.AddWhenDestroyedTrigger(OnDestroyResponse, new TriggerType[] { TriggerType.PlayCard });
         }

--- a/CauldronMods/Controller/Heroes/Necro/Cards/BloodRiteCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/Cards/BloodRiteCardController.cs
@@ -22,7 +22,7 @@ namespace Cauldron.Necro
         {
             //all non-undead hero targets regain 2 HP.
             int powerNumeral = base.GetPowerNumeral(0, 2);
-            IEnumerator coroutine = base.GameController.GainHP(base.HeroTurnTakerController, c => IsHeroConsidering1929(c) && !this.IsUndead(c), powerNumeral, cardSource: base.GetCardSource());
+            IEnumerator coroutine = base.GameController.GainHP(base.HeroTurnTakerController, c => IsHeroTargetConsidering1929(c) && !this.IsUndead(c), powerNumeral, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Necro/Cards/CorpseExplosionCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/Cards/CorpseExplosionCardController.cs
@@ -20,7 +20,7 @@ namespace Cauldron.Necro
         private IEnumerator DealDamageResponse(DestroyCardAction dca)
         {
             //Necro deals 2 toxic damage to all villain targets.
-            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card card) => IsVillianConsidering1929(card) && card.IsTarget, 2, DamageType.Toxic);
+            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card card) => IsVillianTargetConsidering1929(card), 2, DamageType.Toxic);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Necro/Cards/GhoulCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/Cards/GhoulCardController.cs
@@ -14,8 +14,8 @@ namespace Cauldron.Necro
 
         public override void AddTriggers()
         {
-            //At the end of your turn, this card deals the non-undead target with the second lowest HP 2 toxic damage.
-            base.AddEndOfTurnTrigger(tt => tt == TurnTaker, p => base.DealDamageToLowestHP(Card, 2, c => !this.IsUndead(c) && IsHeroConsidering1929(c), c => 2, DamageType.Toxic), TriggerType.DealDamage);
+            //At the end of your turn, this card deals the non-undead hero target with the second lowest HP 2 toxic damage.
+            base.AddEndOfTurnTrigger(tt => tt == TurnTaker, p => base.DealDamageToLowestHP(Card, 2, c => !this.IsUndead(c) && IsHeroTargetConsidering1929(c), c => 2, DamageType.Toxic), TriggerType.DealDamage);
         }
     }
 }

--- a/CauldronMods/Controller/Heroes/Necro/Cards/HellfireCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/Cards/HellfireCardController.cs
@@ -21,7 +21,7 @@ namespace Cauldron.Necro
         {
             //Necro deals 1 non - hero target 3 infernal damage.
             IEnumerator coroutine = base.GameController.SelectTargetsAndDealDamage(this.DecisionMaker, new DamageSource(base.GameController, base.CharacterCard), 3, DamageType.Infernal, 1, false, 1,
-                additionalCriteria: c => !IsHeroConsidering1929(c),
+                additionalCriteria: c => !IsHeroTargetConsidering1929(c),
                 cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {

--- a/CauldronMods/Controller/Heroes/Necro/Cards/NecroZombieCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/Cards/NecroZombieCardController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.Necro
         public override void AddTriggers()
         {
             //At the end of your turn, this card deals the non-Undead hero target with the highest HP 2 toxic damage.
-            base.AddEndOfTurnTrigger(tt => tt == base.TurnTaker, p => base.DealDamageToHighestHP(base.Card, 1, c => !this.IsUndead(c) && IsHeroConsidering1929(c), c => 2, DamageType.Toxic), TriggerType.DealDamage);
+            base.AddEndOfTurnTrigger(tt => tt == base.TurnTaker, p => base.DealDamageToHighestHP(base.Card, 1, c => !this.IsUndead(c) && IsHeroTargetConsidering1929(c), c => 2, DamageType.Toxic), TriggerType.DealDamage);
         }
     }
 }

--- a/CauldronMods/Controller/Heroes/Necro/Cards/PossessedCorpseCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/Cards/PossessedCorpseCardController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.Necro
         public override void AddTriggers()
         {
             //At the end of your turn, this card deals the non-undead target with the lowest HP 2 toxic damage.
-            base.AddEndOfTurnTrigger(tt => tt == TurnTaker, p => base.DealDamageToLowestHP(Card, 1, c => !this.IsUndead(c) && IsHeroConsidering1929(c), c => 2, DamageType.Infernal), TriggerType.DealDamage);
+            base.AddEndOfTurnTrigger(tt => tt == TurnTaker, p => base.DealDamageToLowestHP(Card, 1, c => !this.IsUndead(c) && IsHeroTargetConsidering1929(c), c => 2, DamageType.Infernal), TriggerType.DealDamage);
         }
     }
 }

--- a/Testing/Heroes/NecroTests.cs
+++ b/Testing/Heroes/NecroTests.cs
@@ -617,6 +617,27 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestCorpseExplosion_RedMenace()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Necro", "Legacy", "Haka", "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            Card red = MoveCard(oblivaeon, "TheRedMenace", oblivaeon.TurnTaker.FindSubDeck("MissionDeck"));
+            GoToBeforeStartOfTurn(necro);
+            RunActiveTurnPhase();
+
+            GoToPlayCardPhase(necro);
+
+            Card ghoul = PlayCard("Ghoul");
+            Card explosion = PlayCard("CorpseExplosion");
+
+            QuickHPStorage(red);
+            DestroyCard(ghoul, necro.CharacterCard);
+            QuickHPCheck(-2);
+
+        }
+
+        [Test()]
         public void TestFinalRitualSingleCard()
         {
             SetupGameController("BaronBlade", "Cauldron.Necro", "Ra", "Fanatic", "Megalopolis");

--- a/Testing/Heroes/NecroVariantTests.cs
+++ b/Testing/Heroes/NecroVariantTests.cs
@@ -151,6 +151,8 @@ namespace CauldronTests
 
         }
 
+
+
         [Test()]
         public void TestPastNecroInnatePowerCorpseExplosion()
         {
@@ -175,6 +177,31 @@ namespace CauldronTests
             QuickHPUpdate();
             DealDamage(necro, zombie, 50, DamageType.Infernal);
             QuickHPCheck(-2, -2, 0, 0, 0);
+        }
+
+        [Test()]
+        public void TestPastNecroInnatePowerCorpseExplosion_RedMenaceFlipped()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Necro/PastNecroCharacter", "Legacy", "Haka", "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            Card red = MoveCard(oblivaeon, "TheRedMenace", oblivaeon.TurnTaker.FindSubDeck("MissionDeck"));
+            GoToBeforeStartOfTurn(necro);
+            RunActiveTurnPhase();
+
+            GoToPlayCardPhase(necro);
+            SetHitPoints(red, 5);
+            Card ghoul = PlayCard("Ghoul");
+            Card explosion = PlayCard("CorpseExplosion");
+
+            DestroyCard(red);
+            SetHitPoints(red, 5);
+
+            GoToUsePowerPhase(necro);
+            UsePower(necro.CharacterCard);
+            QuickHPStorage(red);
+            DestroyCard(ghoul, necro.CharacterCard);
+            QuickHPCheck(-2);
         }
 
         [Test()]

--- a/Testing/Heroes/NecroVariantTests.cs
+++ b/Testing/Heroes/NecroVariantTests.cs
@@ -129,6 +129,29 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestPastNecroInnatePowerBloodRite_RedMenace()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Necro/PastNecroCharacter", "Legacy", "Haka", "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            Card red = MoveCard(oblivaeon, "TheRedMenace", oblivaeon.TurnTaker.FindSubDeck("MissionDeck"));
+            GoToBeforeStartOfTurn(necro);
+            RunActiveTurnPhase();
+
+            GoToPlayCardPhase(necro);
+            SetHitPoints(red, 5);
+            Card ghoul = PlayCard("Ghoul");
+            Card blood = PlayCard("BloodRite");
+
+            GoToUsePowerPhase(necro);
+            UsePower(necro.CharacterCard);
+            QuickHPStorage(red);
+            DestroyCard(ghoul, necro.CharacterCard);
+            QuickHPCheck(2);
+
+        }
+
+        [Test()]
         public void TestPastNecroInnatePowerCorpseExplosion()
         {
             SetupGameController("BaronBlade", "Cauldron.Necro/PastNecroCharacter", "Fanatic", "Haka", "Megalopolis");


### PR DESCRIPTION
There are some cards (notably "Red Menace" as an example) that are villain targets but not villain cards. The way Necro's cards were coded, it wouldn't hit these cards when they were supposed to.

Tested for both normal and 1929 flipped and "Red Menace" is affected in both situations appropriately.

Closes #1377 