### PR TITLE
Improved Sig Quil's Sign Status Effect Messaging

### DIFF
--- a/CauldronMods/Controller/Environments/VaultFive/Cards/SigQuilsSignCardController.cs
+++ b/CauldronMods/Controller/Environments/VaultFive/Cards/SigQuilsSignCardController.cs
@@ -19,12 +19,16 @@ namespace Cauldron.VaultFive
             //increase damage dealt to and by targets from its deck by 1 until the start of their next turn
             IncreaseDamageStatusEffect effect1 = new IncreaseDamageStatusEffect(1);
             effect1.SourceCriteria.NativeDeck = Card.NativeDeck;
+            effect1.SourceCriteria.OutputString = $"targets from {Card.Owner.Name}'s deck";
             effect1.UntilStartOfNextTurn(Card.Owner);
             IEnumerator addEffect1 = AddStatusEffect(effect1);
+
             IncreaseDamageStatusEffect effect2 = new IncreaseDamageStatusEffect(1);
             effect2.TargetCriteria.NativeDeck = Card.NativeDeck;
+            effect2.TargetCriteria.OutputString = $"targets from {Card.Owner.Name}'s deck";
             effect2.UntilStartOfNextTurn(Card.Owner);
             IEnumerator addEffect2 = AddStatusEffect(effect2);
+
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(addEffect1);


### PR DESCRIPTION
Previously, this said "Increase damage dealt by 1" for both status effects.

Now it says "Increase damage dealt to targets from {owner}'s deck by 1" and "Increase damage dealt by targets from {owner}'s deck by 1"