### PR TITLE
Nightlore Armor + Redirection Fix

### DIFF
--- a/CauldronMods/Controller/Heroes/Starlight/Cards/NightloreArmorCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/Cards/NightloreArmorCardController.cs
@@ -14,6 +14,10 @@ namespace Cauldron.Starlight
             SpecialStringMaker.ShowNumberOfCardsInPlay(new LinqCardCriteria((Card c) => IsConstellation(c), "constellation"));
         }
 
+        public readonly string HasConstellationBeenDestroyed = "HasConstellationBeenDestroyed";
+        public readonly string HasSaidNoToNightloreArmor = "HasSaidNoToNightloreArmor";
+        public readonly string CurrentActionGUID = "CurrentActionGUID";
+
         public override void AddTriggers()
         {
             //"Whenever damage would be dealt to another hero target, you may destroy a constellation card in play to prevent that damage."
@@ -25,51 +29,84 @@ namespace Cauldron.Starlight
                         TriggerType.WouldBeDealtDamage,
                         TriggerType.CancelAction
                     },
-                isActionOptional: true,
                 timing: TriggerTiming.Before);
         }
 
         private IEnumerator DestroyConstellationToPreventDamage(DealDamageAction dd)
         {
-            var constellationsInPlay = FindCardsWhere(IsConstellationInPlay);
-            if (constellationsInPlay.Count() == 0)
+            if (IsPropertyTrue(HasSaidNoToNightloreArmor) && dd.InstanceIdentifier.GetHashCode() + dd.Target.GetHashCode() == GetCardPropertyJournalEntryInteger(CurrentActionGUID).Value)
             {
-                //don't bother player with trigger they can't do anything about
+                if(!dd.IsPretend)
+                {
+                    SetCardProperty(HasSaidNoToNightloreArmor, false);
+                    SetCardProperty(CurrentActionGUID, -1);
+                }
                 yield break;
             }
+            if (!IsPropertyTrue(HasConstellationBeenDestroyed))
+            {
+                var constellationsInPlay = FindCardsWhere(IsConstellationInPlay);
+                if (constellationsInPlay.Count() == 0)
+                {
+                    //don't bother player with trigger they can't do anything about
+                    yield break;
+                }
 
-            //"...you may..."
-            List<YesNoCardDecision> yesNoDecision = new List<YesNoCardDecision> { };
+                //"...you may..."
+                List<YesNoCardDecision> yesNoDecision = new List<YesNoCardDecision> { };
 
-            //What does the associatedCards argument actually do here? Should/should not be passing in the list of constellations?
-            //Looks like it puts a constellation on the other side of the decision. Probably a good idea.
-            IEnumerator askPrevent = GameController.MakeYesNoCardDecision(HeroTurnTakerController, SelectionType.PreventDamage, Card, dd, yesNoDecision, constellationsInPlay, GetCardSource());
-            if (UseUnityCoroutines)
-            {
-                yield return GameController.StartCoroutine(askPrevent);
-            }
-            else
-            {
-                GameController.ExhaustCoroutine(askPrevent);
-            }
-            if (!DidPlayerAnswerYes(yesNoDecision))
-            {
-                yield break;
-            }
+                //What does the associatedCards argument actually do here? Should/should not be passing in the list of constellations?
+                //Looks like it puts a constellation on the other side of the decision. Probably a good idea.
+                IEnumerator askPrevent = GameController.MakeYesNoCardDecision(HeroTurnTakerController, SelectionType.PreventDamage, Card, dd, yesNoDecision, constellationsInPlay, GetCardSource());
+                if (UseUnityCoroutines)
+                {
+                    yield return GameController.StartCoroutine(askPrevent);
+                }
+                else
+                {
+                    GameController.ExhaustCoroutine(askPrevent);
+                }
+                if (!DidPlayerAnswerYes(yesNoDecision))
+                {
+                    SetCardProperty(HasSaidNoToNightloreArmor, true);
+                    SetCardProperty(CurrentActionGUID, dd.InstanceIdentifier.GetHashCode() + dd.Target.GetHashCode());
+                    yield break;
+                }
 
-            //"...destroy a constellation in play..."
-            IEnumerator destroyConstellation = GameController.SelectAndDestroyCard(HeroTurnTakerController, new LinqCardCriteria(IsConstellationInPlay, "constellation"), optional: false, cardSource: GetCardSource());
-            //"...to prevent that damage."
-            IEnumerator preventDamage = CancelAction(dd, isPreventEffect: true);
-            if (UseUnityCoroutines)
-            {
-                yield return GameController.StartCoroutine(destroyConstellation);
-                yield return GameController.StartCoroutine(preventDamage);
+                //"...destroy a constellation in play..."
+                IEnumerator destroyConstellation = GameController.SelectAndDestroyCard(HeroTurnTakerController, new LinqCardCriteria(IsConstellationInPlay, "constellation"), optional: false, cardSource: GetCardSource());
+                if (UseUnityCoroutines)
+                {
+                    yield return GameController.StartCoroutine(destroyConstellation);
+                }
+                else
+                {
+                    GameController.ExhaustCoroutine(destroyConstellation);
+                }
+
+                SetCardProperty(HasConstellationBeenDestroyed, true);
             }
-            else
+            if (IsPropertyTrue(HasConstellationBeenDestroyed))
             {
-                GameController.ExhaustCoroutine(destroyConstellation);
-                GameController.ExhaustCoroutine(preventDamage);
+               
+                //"...to prevent that damage."
+                IEnumerator preventDamage = CancelAction(dd, isPreventEffect: true);
+                if (UseUnityCoroutines)
+                {
+                    yield return GameController.StartCoroutine(preventDamage);
+                }
+                else
+                {
+                    GameController.ExhaustCoroutine(preventDamage);
+                }
+
+                if (!dd.IsPretend)
+                {
+                    SetCardProperty(HasConstellationBeenDestroyed, false);
+                    SetCardProperty(CurrentActionGUID, -1);
+                    SetCardProperty(HasSaidNoToNightloreArmor, false);
+                }
+
             }
             yield break;
         }

--- a/Testing/Heroes/StarlightTests.cs
+++ b/Testing/Heroes/StarlightTests.cs
@@ -1071,9 +1071,8 @@ namespace CauldronTests
             AssertNumberOfCardsInPlay(starlight, 3);
         }
         [Test()]
-        public void TestNightloreArmorDamageStillPreventedIfDestructionPrevented()
+        public void TestNightloreArmorDamageDoesNotPreventIfDestructionPrevented()
         {
-            Assert.Ignore("Not sure if this is correct behavior.");
             SetupGameController("BaronBlade", "Cauldron.Starlight", "Haka", "Ra", "TheVisionary", "TimeCataclysm");
             StartGame();
 
@@ -1084,10 +1083,10 @@ namespace CauldronTests
             DecisionYesNo = true;
             QuickHPStorage(haka);
             DealDamage(baron, haka, 5, DamageType.Melee);
-            QuickHPCheck(0);
+            QuickHPCheck(-5);
             AssertIsInPlay(constellation);
 
-            DecisionYesNo = false;
+            DecisionYesNo = true;
             DealDamage(baron, haka, 5, DamageType.Melee);
             QuickHPCheck(-5);
         }

--- a/Testing/Heroes/StarlightTests.cs
+++ b/Testing/Heroes/StarlightTests.cs
@@ -1073,6 +1073,7 @@ namespace CauldronTests
         [Test()]
         public void TestNightloreArmorDamageStillPreventedIfDestructionPrevented()
         {
+            Assert.Ignore("Not sure if this is correct behavior.");
             SetupGameController("BaronBlade", "Cauldron.Starlight", "Haka", "Ra", "TheVisionary", "TimeCataclysm");
             StartGame();
 


### PR DESCRIPTION
Closes #1117 

Nightlore Armor was double prompting when there is a live redirection trigger such as Lead From the Front. By doing self tracking we can make it so it only prompts once.

We do additionally tracking when we say no to the prompt to make sure it doesn't reprompt in future cases for that instance but does reprompt if its been redirected to a new target

This is a UI only change so there is no unit test case