### PR TITLE
Mirror Wraith and Mission Cards

### DIFF
--- a/CauldronMods/Controller/Environments/BlackwoodForest/Cards/MirrorWraithCardController.cs
+++ b/CauldronMods/Controller/Environments/BlackwoodForest/Cards/MirrorWraithCardController.cs
@@ -68,8 +68,16 @@ namespace Cauldron.BlackwoodForest
         {
             var card = CopiedCard; //buffer the resolution
             string replacementTitle = "*" + Card.Title + "*";
-            var sa = card.Definition.Body.Select(b => b.Replace("{" + card.Title + "}", replacementTitle).Replace(card.Title, replacementTitle)).ToArray();
 
+            string[] sa;
+            if (!card.IsFlipped)
+            {
+                sa = card.Definition.Body.Select(b => b.Replace("{" + card.Title + "}", replacementTitle).Replace(card.Title, replacementTitle)).ToArray();
+            } else
+            {
+                sa = card.Definition.FlippedBody.Select(b => b.Replace("{" + card.Title + "}", replacementTitle).Replace(card.Title, replacementTitle)).ToArray();
+
+            }
             return "Copied card text: " + string.Join(System.Environment.NewLine, sa);
         }
 
@@ -165,7 +173,7 @@ namespace Cauldron.BlackwoodForest
 
                 // Set card text
                 CopyGameText(copiedCard);
-                ModifyDefinitionKeywords(BaseKeywords.Concat(copiedCard.Definition.Keywords));
+                ModifyDefinitionKeywords(BaseKeywords.Concat(copiedCard.IsFlipped ? copiedCard.Definition.FlippedKeywords : copiedCard.Definition.Keywords));
 
                 var messageRoutine = GameController.SendMessageAction($"{Card.Title} copies {copiedCard.Title}.", Priority.High, GetCardSource(), new[] { copiedCard });
                 if (base.UseUnityCoroutines)

--- a/Testing/Environments/BlackwoodForestTests.cs
+++ b/Testing/Environments/BlackwoodForestTests.cs
@@ -5,6 +5,7 @@ using Cauldron.BlackwoodForest;
 using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 using Handelabra.Sentinels.UnitTest;
+using Handelabra;
 
 using NUnit.Framework;
 
@@ -1163,6 +1164,40 @@ namespace CauldronTests
             QuickHandStorage(thriya);
             DestroyCard(mirror);
             QuickHandCheck(1);
+        }
+
+        [Test]
+        public void TestMirrorWraith_MissionCards()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Ra", "Legacy", "Haka", "Tachyon", "Luminary", DeckNamespace, "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            Card warTorn = MoveCard(oblivaeon, "AWarTornLandscape", oblivaeon.TurnTaker.FindSubDeck("MissionDeck"));
+
+            GoToBeforeStartOfTurn(ra);
+            RunActiveTurnPhase();
+
+            GoToEndOfTurn();
+            RunActiveTurnPhase();
+
+            GoToPlayCardPhase(legacy);
+            MoveCards(oblivaeon, FindCardsWhere(c => c.IsEnvironment && c.IsInPlay), c => c.NativeTrash, overrideIndestructible: true);
+
+            GoToEndOfTurn(legacy);
+
+            AssertFlipped(warTorn);
+            Log.Debug($"Owner of {warTorn.Title} is {warTorn.Owner.Name}");
+
+            GoToPlayCardPhase(ra);
+            Card mirror = PlayCard("MirrorWraith");
+            PrintSpecialStringsForCard(mirror);
+            Log.Debug($"Keywords on Mirror Wraith are: {mirror.GetKeywords().ToRecursiveString()}");
+            AssertCardHasKeyword(mirror, "reward", isAdditional: false);
+            DecisionSelectTargets = new Card[] { haka.CharacterCard, haka.CharacterCard, tachyon.CharacterCard, luminary.CharacterCard, legacy.CharacterCard, tachyon.CharacterCard, luminary.CharacterCard, legacy.CharacterCard };
+            QuickHPStorage(haka, legacy, tachyon, luminary);
+            UsePower(ra.CharacterCard);
+            UsePower(ra.CharacterCard);
+            QuickHPCheck(-4, -4, -4, -4);
         }
     }
 }


### PR DESCRIPTION
Closes #1406 

The effects when copying a mission work as intended, but the card text and keywords that were copied always copy the front side. Changed that to match whatever the state is, and added test to verify functionality