### PR TITLE
Dynamo Ultimate Interaction

### DIFF
--- a/CauldronMods/Controller/Villains/Dynamo/CharacterCards/DynamoTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/Dynamo/CharacterCards/DynamoTurnTakerController.cs
@@ -19,17 +19,23 @@ namespace Cauldron.Dynamo
             {
                 //At the start of the game, put Python and Copperhead into play.
 
-                IEnumerator copperhead = PutCardIntoPlay("Copperhead", shuffleDeckAfter: false);
-                IEnumerator python = PutCardIntoPlay("Python");
+                Card copperhead = TurnTaker.FindCard("Copperhead");
+                Card python = TurnTaker.FindCard("Python");
+                CardSource dynamoSource = new CardSource(CharacterCardController);
+                IEnumerator copperheadRoutine = GameController.PlayCard(this, copperhead, isPutIntoPlay: true, cardSource: dynamoSource);
+                IEnumerator pythonRoutine = GameController.PlayCard(this, python, isPutIntoPlay: true, cardSource: dynamoSource);
+                IEnumerator shuffleRoutine = GameController.ShuffleLocation(TurnTaker.Deck);
                 if (base.UseUnityCoroutines)
                 {
-                    yield return base.GameController.StartCoroutine(copperhead);
-                    yield return base.GameController.StartCoroutine(python);
+                    yield return base.GameController.StartCoroutine(copperheadRoutine);
+                    yield return base.GameController.StartCoroutine(pythonRoutine);
+                    yield return base.GameController.StartCoroutine(shuffleRoutine);
                 }
                 else
                 {
-                    base.GameController.ExhaustCoroutine(copperhead);
-                    base.GameController.ExhaustCoroutine(python);
+                    base.GameController.ExhaustCoroutine(copperheadRoutine);
+                    base.GameController.ExhaustCoroutine(pythonRoutine);
+                    base.GameController.ExhaustCoroutine(shuffleRoutine);
                 }
             }
             yield break;

--- a/Testing/Villains/DynamoTests.cs
+++ b/Testing/Villains/DynamoTests.cs
@@ -74,6 +74,17 @@ namespace CauldronTests
             AssertGameOver(EndingResult.VillainDestroyedVictory);
 
         }
+
+        [Test()]
+        public void TestDynamo_Ultimate_PythonCopperHeadStacked()
+        {
+            SetupGameController(new string[] { "Cauldron.Dynamo", "Haka", "Bunker", "TheScholar", "Megalopolis" }, advanced: true, challenge: true);
+            StackDeck("Copperhead", "Python");
+            StartGame();
+
+            AssertIsInPlay("Python", "Copperhead");
+
+        }
         [Test()]
         public void TestDynamo_ChallengeWhenNotLastDestroyed()
         {


### PR DESCRIPTION
Closes #1411 

There's a poor interaction between Dynamo Challenge and Advanced that can cause Python/Copperhead to not be put into play at the start of the game if they are both stacked next to each other in the deck. This changes the function call to be played from anywhere, not just from deck.