### PR TITLE
The Black Tree and OblivAeon

### DIFF
--- a/CauldronMods/Controller/Environments/BlackwoodForest/Cards/TheBlackTreeCardController.cs
+++ b/CauldronMods/Controller/Environments/BlackwoodForest/Cards/TheBlackTreeCardController.cs
@@ -52,7 +52,7 @@ namespace Cauldron.BlackwoodForest
 
         private IEnumerator DrawCardFromEachDeckResponse(TurnTakerController ttc)
         {
-            foreach (var deck in ttc.TurnTaker.Decks)
+            foreach (var deck in ttc.TurnTaker.Decks.Where(loc => loc.IsRealDeck && GameController.IsLocationVisibleToSource(loc, GetCardSource())))
             {
                 Card top = deck.TopCard;
                 if (top != null)

--- a/Testing/Environments/BlackwoodForestTests.cs
+++ b/Testing/Environments/BlackwoodForestTests.cs
@@ -1047,6 +1047,40 @@ namespace CauldronTests
         }
 
         [Test]
+        public void TestTheBlackTree_Oblivaeon()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Ra", "Legacy", "Haka", "Cauldron.BlackwoodForest", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            Dictionary<Location, Card> topCardsOfSubDecks = new Dictionary<Location, Card>();
+
+            SwitchBattleZone(haka);
+
+            PlayCard(oblivaeon, GetCard("AeonWarrior"), isPutIntoPlay: true, overridePlayLocation: scionOne.TurnTaker.PlayArea);
+
+            //When this card enters play, place the top card of each hero and villain deck face-down beneath it.
+            Card tree = PlayCard("TheBlackTree");
+
+            // Visible: OA, Ra, Legacy, Aeon Deck - 4
+            // Invisible: Haka, Scion Deck, Mission Deck
+            AssertNumberOfCardsUnderCard(tree, 4);
+
+            IEnumerable<Card> underCards = tree.UnderLocation.Cards;
+            foreach(Card c in underCards)
+            {
+                System.Console.WriteLine($"There is a card from the deck with name: {c.NativeDeck.GetFriendlyName()}");
+            }
+            Assert.That(underCards.Any(c => c.NativeDeck.GetFriendlyName() == "OblivAeon's deck"), () => "There was not an OblivAeon card under the Black Tree.");
+            Assert.That(underCards.Any(c => c.NativeDeck.GetFriendlyName() == "Ra's deck"), () => "There was not a Ra card under the Black Tree.");
+            Assert.That(underCards.Any(c => c.NativeDeck.GetFriendlyName() == "Legacy's deck"), () => "There was not a Legacy card under the Black Tree.");
+            Assert.That(underCards.Any(c => c.NativeDeck.GetFriendlyName() == "The Aeon Men Deck"), () => "There was not an Aeon Men card under the Black Tree.");
+            Assert.That(!underCards.Any(c => c.NativeDeck.GetFriendlyName() == "Haka's deck"), () => "There was a Haka card under the Black Tree.");
+            Assert.That(!underCards.Any(c => c.NativeDeck.GetFriendlyName() == "The Scion Deck"), () => "There was a Scion card under the Black Tree.");
+            Assert.That(!underCards.Any(c => c.NativeDeck.GetFriendlyName() == "The Mission Deck"), () => "There was a Mission card under the Black Tree.");
+
+        }
+
+        [Test]
         public void TestTheBlackTreeExhaustCardsUnderneath()
         {
             // Arrange


### PR DESCRIPTION
The Black Tree was coded to steal cards from every deck and subdeck, regardless of whether it was a real deck or not and whether that deck is visible to the environment.

Closes #1425 