### PR TITLE
Impact innate power with prevent-next-damage effect

### DIFF
--- a/Testing/Heroes/ImpactTests.cs
+++ b/Testing/Heroes/ImpactTests.cs
@@ -127,9 +127,24 @@ namespace CauldronTests
             QuickHPStorage(shield);
 
             UsePower(impact);
-            AssertNumberOfStatusEffectsInPlay(0);
             DealDamage(impact, shield, 1, DamageType.Melee);
             QuickHPCheck(-1);
+        }
+        [Test]
+        public void TestImpactPowerNoDamagePossible()
+        {
+            SetupGameController("CitizensHammerAndAnvilTeam", "Cauldron.Impact", "TheWraith", "WagnerMarsBase");
+            StartGame();
+
+            DecisionSelectTarget = impact.CharacterCard;
+            PlayCard("ThroatJab");
+
+            Card shield = GetCardInPlay("HammerAndShield");
+            DecisionSelectTarget = shield;
+            QuickHPStorage(shield);
+
+            AssertNextMessageContains("from dealing damage");
+            UsePower(impact);
         }
         [Test]
         public void TestImpactIncap1()

--- a/Testing/Heroes/ImpactTests.cs
+++ b/Testing/Heroes/ImpactTests.cs
@@ -114,6 +114,24 @@ namespace CauldronTests
             QuickHPCheck(-1);
         }
         [Test]
+        public void TestImpactPowerNextDamagePrevented()
+        {
+            SetupGameController("CitizensHammerAndAnvilTeam", "Cauldron.Impact", "Megalopolis");
+            StartGame();
+
+            PlayCard("ScorchingSnap");
+            AssertNumberOfStatusEffectsInPlay(1);
+
+            Card shield = GetCardInPlay("HammerAndShield");
+            DecisionSelectTarget = shield;
+            QuickHPStorage(shield);
+
+            UsePower(impact);
+            AssertNumberOfStatusEffectsInPlay(0);
+            DealDamage(impact, shield, 1, DamageType.Melee);
+            QuickHPCheck(-1);
+        }
+        [Test]
         public void TestImpactIncap1()
         {
             SetupGameController("BaronBlade", "Cauldron.Impact", "Haka", "Bunker", "TheScholar", "Megalopolis");


### PR DESCRIPTION
Impact's innate power does nothing when he has a "prevent the next damage" effect on him, as from Citizen Hammer and Anvil's Scorching Snap, which it should be able to clear. This fixes that, as well as improving its messaging around complete inabilities to deal damage.

Also applies to Pyre's Particle Collider.