### PR TITLE
Graven Shell Null Reference Issue

### DIFF
--- a/CauldronMods/Controller/Heroes/Terminus/Cards/GravenShellCardController.cs
+++ b/CauldronMods/Controller/Heroes/Terminus/Cards/GravenShellCardController.cs
@@ -23,8 +23,13 @@ namespace Cauldron.Terminus
 
         public override void AddTriggers()
         {
-            base.AddTrigger<DestroyCardAction>((dca) => dca.WasCardDestroyed && dca.WasDestroyedBy((card) => card.Owner.CharacterCard == base.CharacterCard), DestroyCardActionResponse, new TriggerType[] { TriggerType.AddTokensToPool, TriggerType.GainHP }, TriggerTiming.After);
+            base.AddTrigger<DestroyCardAction>(TriggerCriteria, DestroyCardActionResponse, new TriggerType[] { TriggerType.AddTokensToPool, TriggerType.GainHP }, TriggerTiming.After);
             base.AddTriggers();
+        }
+
+        private bool TriggerCriteria(DestroyCardAction dca)
+        {
+            return dca.WasCardDestroyed && dca.GetCardDestroyer() != null && dca.WasDestroyedBy((card) => card.Owner.CharacterCard == base.CharacterCard);
         }
 
         private IEnumerator DestroyCardActionResponse(DestroyCardAction destroyCardAction)

--- a/Testing/Heroes/TerminusTest.cs
+++ b/Testing/Heroes/TerminusTest.cs
@@ -696,6 +696,30 @@ namespace CauldronTests
             AssertOutOfGame(badge);
         }
 
+        [Test]
+        public void TestGravenShell_MarkOfDestructionBug()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Terminus", "Cauldron.TheStranger", "Legacy/YoungLegacyCharacter", "Cauldron.WindmillCity");
+            StartGame();
+
+            SetHitPoints(terminus, 10);
+
+            Card mdp = GetCardInPlay("MobileDefensePlatform");
+
+            Card gravenShell = PlayCard("GravenShell");
+            DecisionSelectCard = mdp;
+            DecisionAutoDecideIfAble = true;
+            Card markOfDestruction = PlayCard("MarkOfDestruction");
+
+            QuickHPStorage(terminus);
+            DealDamage(terminus, markOfDestruction, 10, DamageType.Infernal);
+            AssertInTrash(markOfDestruction);
+            AssertInTrash(mdp);
+            QuickHPCheck(1);
+            AssertTokensInWrathPool(2);
+
+        }
+
         #endregion
 
         #region Test Railway Spike


### PR DESCRIPTION
Graven Shell's on DestroyCardAction trigger was looking for the card that destroyed the other card without first doing a null check to make sure it existed in the first place.

Closes #1479
Closes #1478 