### PR TITLE
Wand of Banishment and Mission Cards

### DIFF
--- a/CauldronMods/Controller/Heroes/MagnificentMara/Cards/WandOfBanishmentCardController.cs
+++ b/CauldronMods/Controller/Heroes/MagnificentMara/Cards/WandOfBanishmentCardController.cs
@@ -25,10 +25,11 @@ namespace Cauldron.MagnificentMara
         private IEnumerator MaybeMoveInsteadResponse(DestroyCardAction dc)
         {
             Card card = dc.CardToDestroy.Card;
+            Location destination = card.NativeDeck is null || card.NativeDeck.OwnerTurnTaker != card.Owner ? card.Owner.Deck : card.NativeDeck;
             var functions = new List<Function>
             {
-                new Function(DecisionMaker, $"Put {card.Title} on top of its deck", SelectionType.MoveCardOnDeck, () => CancelDestructionAndMoveCard(dc, card.NativeDeck)),
-                new Function(DecisionMaker, $"Put {card.Title} on the bottom of its deck", SelectionType.MoveCardOnBottomOfDeck, () => CancelDestructionAndMoveCard(dc, card.NativeDeck, true))
+                new Function(DecisionMaker, $"Put {card.Title} on top of its deck", SelectionType.MoveCardOnDeck, () => CancelDestructionAndMoveCard(dc, destination)),
+                new Function(DecisionMaker, $"Put {card.Title} on the bottom of its deck", SelectionType.MoveCardOnBottomOfDeck, () => CancelDestructionAndMoveCard(dc, destination, true))
             };
             var selectFunction = new SelectFunctionDecision(GameController, DecisionMaker, functions, optional: true, associatedCards: new Card[] { card }, cardSource: GetCardSource());
             IEnumerator coroutine = GameController.SelectAndPerformFunction(selectFunction);

--- a/Testing/Heroes/MagnificentMaraTests.cs
+++ b/Testing/Heroes/MagnificentMaraTests.cs
@@ -1223,6 +1223,36 @@ namespace CauldronTests
             AssertInTrash(crystal);
         }
 
+        [Test]
+        public void TestWandOfBanishment_TRexBot()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Legacy", "Cauldron.MagnificentMara", "Unity", "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            IEnumerable<Card> mechGolemsAndEquipment = FindCardsWhere(c => c.Owner == unity.TurnTaker && (IsEquipment(c) || c.IsMechanicalGolem));
+            MoveCards(unity, mechGolemsAndEquipment, unity.HeroTurnTaker.Hand);
+
+            Card trex = MoveCard(oblivaeon, "BuildingAKing", oblivaeon.TurnTaker.FindSubDeck("MissionDeck"));
+            GoToBeforeStartOfTurn(legacy);
+            RunActiveTurnPhase();
+
+            List<Card> decisionCards = mechGolemsAndEquipment.ToList();
+            decisionCards.Add(null);
+            DecisionSelectCards = decisionCards.ToArray();
+            DecisionSelectTurnTakers = new TurnTaker[] { unity.TurnTaker, null };
+
+            GoToEndOfTurn(legacy);
+
+
+            GoToPlayCardPhase(mara);
+            Card wandOfBanishment = PlayCard("WandOfBanishment");
+
+            DealDamage(oblivaeon, trex, 20, DamageType.Infernal);
+
+            AssertInTrash(wandOfBanishment);
+            AssertOnTopOfDeck(legacy, trex);
+        }
+
         [Test()]
         public void TestBootlegMesmerPendant_Oblivaeon_0Heroes()
         {


### PR DESCRIPTION
Improved interaction with cards that have a null NativeDeck, such as Mission Cards.

Copied this fix from Warp Bridge.

Closes #1461 