### PR TITLE
Mental Link Improvement

### DIFF
--- a/CauldronMods/Controller/Villains/ScreaMachine/Cards/MentalLinkCardController.cs
+++ b/CauldronMods/Controller/Villains/ScreaMachine/Cards/MentalLinkCardController.cs
@@ -23,8 +23,22 @@ namespace Cauldron.ScreaMachine
             // This failed becuse those conditions for those is tied to GameContoller.AllowInhibitors and that prop
             // is never true, it's only set to true during certain trigger resolution.
             // AskIfActionCanBePerformed is the answer.
+            
 
             IEnumerator coroutine;
+
+            if (TurnTaker.Deck.Cards.Count() == 0)
+            {
+                coroutine = GameController.ShuffleTrashIntoDeck(TurnTakerController, necessaryToPlayCard: true, cardSource: GetCardSource());
+                if (UseUnityCoroutines)
+                {
+                    yield return GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    GameController.ExhaustCoroutine(coroutine);
+                }
+            }
             //stolen message action from PlayTopCard
             var cardToPlay = TurnTaker.Deck.TopCard;
             var cc = FindCardController(cardToPlay);

--- a/Testing/Villains/ScreaMachineTests.cs
+++ b/Testing/Villains/ScreaMachineTests.cs
@@ -903,6 +903,24 @@ namespace CauldronTests
             ActivateAbility(key, card);
             AssertNumberOfCardsInDeck(scream, deck - 3);
         }
+
+        [Test()]
+        public void TestMentalLink_PlayCardWhenVillainDeckIsEmpty()
+        {
+            SetupGameController(new[] { "Cauldron.ScreaMachine", "Legacy", "Ra", "Haka", "Bunker", "Megalopolis" }, advanced: false);
+            StartGame();
+            DestroyNonCharacterVillainCards();
+            MoveAllCards(scream, scream.TurnTaker.Deck, scream.TurnTaker.Trash);
+
+            var card = SetupBandCard("MentalLink");
+
+            string key = ScreaMachineBandmate.GetAbilityKey(ScreaMachineBandmate.Value.Valentine);
+            StackAfterShuffle(scream.TurnTaker.Deck, new string[] { "Biosurge" });
+            QuickShuffleStorage(scream.TurnTaker.Deck);
+            ActivateAbility(key, card);
+            QuickShuffleCheck(1);
+            AssertIsInPlay("Biosurge");
+        }
         [Test()]
         public void TestMentalLink_OtherVillainCardPlayDuringMentalLinkPlay()
         {


### PR DESCRIPTION
When the deck is empty, Mental Link should force a reshuffle and then play the top card, like the base game implementation of PlayTopCard