### PR TITLE
Renegade Quicksilver Incap 2 - Only when damage is dealt

### DIFF
--- a/CauldronMods/Controller/Heroes/Quicksilver/CharacterCards/RenegadeQuicksilverCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Quicksilver/CharacterCards/RenegadeQuicksilverCharacterCardController.cs
@@ -42,6 +42,7 @@ namespace Cauldron.Quicksilver
                         statusEffect.TargetCriteria.IsHeroCharacterCard = true;
                         statusEffect.NumberOfUses = 1;
                         statusEffect.BeforeOrAfter = BeforeOrAfter.After;
+                        statusEffect.DamageAmountCriteria.GreaterThan = 0;
                         statusEffect.CanEffectStack = true;
 
                         if (IsRealAction())

--- a/Testing/Heroes/QuicksilverVariantsTests.cs
+++ b/Testing/Heroes/QuicksilverVariantsTests.cs
@@ -193,6 +193,29 @@ namespace CauldronTests
         }
 
         [Test]
+        public void TestRenegadeQuicksilverIncap2_NoDamageDealt()
+        {
+            SetupGameController("Apostate", "Cauldron.Quicksilver/RenegadeQuicksilverCharacter", "Ra", "TheWraith", "Megalopolis");
+            StartGame();
+
+            SetupIncap(apostate, quicksilver.CharacterCard);
+            Card staff = PutInHand("TheStaffOfRa");
+            Card blaze = PutInHand("BlazingTornado");
+            DecisionYesNo = true;
+            DecisionSelectCards = new Card[] { staff, blaze };
+
+            //The next time a hero is dealt damage, they may play a card.
+            UseIncapacitatedAbility(quicksilver, 1);
+            AssertInHand(new Card[] { staff, blaze });
+
+            AddImmuneToNextDamageEffect(ra, false, true);
+            DealDamage(apostate, ra, 2, DamageType.Melee);
+            AssertInHand(new Card[] { staff, blaze });
+
+
+        }
+
+        [Test]
         public void TestRenegadeQuicksilverIncap2UsedTwice()
         {
             SetupGameController("Apostate", "Cauldron.Quicksilver/RenegadeQuicksilverCharacter", "Ra", "TheWraith", "Megalopolis");


### PR DESCRIPTION
Renegade Quicksilver's second incap was firing even if no damage was actually dealt to a hero. Added the criteria in the status effect for the damage to be greater than 0 to fire