### PR TITLE
Doc Havoc's Immediate Evacuation and Sentinels

### DIFF
--- a/CauldronMods/Controller/Heroes/DocHavoc/Cards/ImmediateEvacCardController.cs
+++ b/CauldronMods/Controller/Heroes/DocHavoc/Cards/ImmediateEvacCardController.cs
@@ -37,7 +37,7 @@ namespace Cauldron.DocHavoc
                         new MoveCardDestination[] { new MoveCardDestination(h.HeroTurnTaker.Hand) }),
                     repeatDecisionText: ChoiceTextSelectTrashIntoHand),
 
-                new Function(h, ChoiceTextDiscardAndDraw, SelectionType.DiscardAndDrawCard, () => DiscardCardAndDrawCardsResponse(h.CharacterCard)),
+                new Function(h, ChoiceTextDiscardAndDraw, SelectionType.DiscardAndDrawCard, () => DiscardCardAndDrawCardsResponse(h)),
             };
 
             List<SelectFunctionDecision> choicesMade = new List<SelectFunctionDecision>();
@@ -73,19 +73,17 @@ namespace Cauldron.DocHavoc
         }
 
 
-        private IEnumerator DiscardCardAndDrawCardsResponse(Card card)
+        private IEnumerator DiscardCardAndDrawCardsResponse(HeroTurnTakerController httc)
         {
-            if (card == null)
+            if (httc is null)
             {
                 yield break;
             }
 
             //discard a card and draw 2 cards
-            CardController cc = base.FindCardController(card);
-
             List<DiscardCardAction> storedResults = new List<DiscardCardAction>();
 
-            IEnumerator discardCardRoutine = this.GameController.SelectAndDiscardCard(cc.HeroTurnTakerController, storedResults: storedResults, cardSource: GetCardSource());
+            IEnumerator discardCardRoutine = this.GameController.SelectAndDiscardCard(httc, storedResults: storedResults, cardSource: GetCardSource());
 
 
             if (this.UseUnityCoroutines)

--- a/Testing/Heroes/DocHavocTests.cs
+++ b/Testing/Heroes/DocHavocTests.cs
@@ -910,6 +910,50 @@ namespace CauldronTests
         }
 
         [Test]
+        public void TestImmediateEvac_Sentinels()
+        {
+            // Arrange
+            SetupGameController("BaronBlade", "Cauldron.DocHavoc", "Tempest", "Haka", "TheSentinels", "RuinsOfAtlantis");
+
+            MakeCustomHeroHand(doc, new List<string>()
+            {
+                ImmediateEvacCardController.Identifier, RecklessChargeCardController.Identifier,
+                RecklessChargeCardController.Identifier, GasMaskCardController.Identifier
+            });
+
+
+            StartGame();
+
+            SetHitPoints(baron.CharacterCard, 35);
+
+            PutInTrash(doc, new List<Card>() { GetCard(DocsFlaskCardController.Identifier), GetCard(BrawlerCardController.Identifier) });
+            PutInTrash(tempest, new List<Card>() { GetCard("ChainLightning"), GetCard("FlashFlood") });
+            PutInTrash(haka, new List<Card>() { GetCard("Mere"), GetCard("GroundPound") });
+            PutInTrash(sentinels, new List<Card>() { GetCard("HumanShield"), GetCard("PositiveEnergy") });
+
+            Card mdp = GetCardInPlay("MobileDefensePlatform");
+            SetHitPoints(mdp, 5);
+
+            QuickHPStorage(baron.CharacterCard, mdp, doc.CharacterCard, tempest.CharacterCard, haka.CharacterCard, medico,mainstay, idealist, writhe);
+            QuickHandStorage(doc, tempest, haka, sentinels);
+
+            DecisionSelectFunctions = new int?[] { 1, 0, 1, 1};
+
+            Card sentinelsDiscard = GetRandomCardFromHand(sentinels);
+
+            DecisionSelectCards = new[] { GetCardFromHand(doc, RecklessChargeCardController.Identifier), GetCardFromTrash(tempest, "FlashFlood"), GetCardFromHand(haka), sentinelsDiscard };
+
+            // Act
+            GoToPlayCardPhase(doc);
+            PlayCardFromHand(doc, ImmediateEvacCardController.Identifier);
+
+            // Assert
+            QuickHPCheck(2, 2, 0, 0, 0, 0, 0, 0, 0); // Villain HP gain check
+            QuickHandCheck(0, 1, 1, 1);
+
+        }
+
+        [Test]
         public void TestPainkillersAcceptSelfDamage()
         {
             SetupGameController("BaronBlade", "Cauldron.DocHavoc", "Tempest", "Haka", "RuinsOfAtlantis");


### PR DESCRIPTION
Closes #1594 

Immediate Evacuation was looking up the character card for the hero discarding cards, which ran into a null issue with the Sentinels. Reworked the functions to not require character card and instead use the Hero Turn Taker