### PR TITLE
Beyond the Veil Discard Trigger Fix

### DIFF
--- a/CauldronMods/Controller/Environments/TheChasmOfAThousandNights/Cards/BeyondTheVeilCardController.cs
+++ b/CauldronMods/Controller/Environments/TheChasmOfAThousandNights/Cards/BeyondTheVeilCardController.cs
@@ -35,14 +35,14 @@ namespace Cauldron.TheChasmOfAThousandNights
         public override void AddTriggers()
         {
             //The first time a hero card is discarded each turn, that hero deals themselves 1 psychic damage.
-            AddTrigger((DiscardCardAction dca) => dca.WasCardDiscarded && !HasBeenSetToTrueThisTurn(FirstTimeDiscard) && dca.CardToDiscard != null && dca.CardToDiscard.IsHero, DealDamageResponse, TriggerType.DealDamage, TriggerTiming.After);
+            AddTrigger((MoveCardAction mca) => mca.IsDiscard && mca.IsSuccessful && !HasBeenSetToTrueThisTurn(FirstTimeDiscard) && mca.CardToMove != null && mca.CardToMove.IsHero, DealDamageResponse, TriggerType.DealDamage, TriggerTiming.After);
         }
 
-        private IEnumerator DealDamageResponse(DiscardCardAction dca)
+        private IEnumerator DealDamageResponse(MoveCardAction mca)
         {
             SetCardPropertyToTrueIfRealAction(FirstTimeDiscard);
             List<Card> storedCharacter = new List<Card>();
-            IEnumerator coroutine = FindCharacterCardToTakeDamage(dca.CardToDiscard.Owner.ToHero(), storedCharacter, base.CharacterCard, 1, DamageType.Psychic);
+            IEnumerator coroutine = FindCharacterCardToTakeDamage(mca.CardToMove.Owner.ToHero(), storedCharacter, base.CharacterCard, 1, DamageType.Psychic);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/Testing/Environments/TheChasmOfAThousandNightsTests.cs
+++ b/Testing/Environments/TheChasmOfAThousandNightsTests.cs
@@ -604,6 +604,30 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestBeyondTheVeil_DiscardTriggers()
+        {
+            SetupGameController(new string[] { "Omnitron", "LaComodora", "Legacy", "Ra", "Cauldron.TheChasmOfAThousandNights" });
+            Card veil = GetCard("BeyondTheVeil");
+            Card chron = GetCard("ChronologicalSweetspot");
+            Card combat = GetCard("CombatTiming");
+
+            StartGame();
+            PlayCard(combat);
+            PlayCard(chron);
+            PlayCard(veil);
+            MoveCard(comodora, "CannonPortal", comodora.TurnTaker.Deck);
+            MoveCard(legacy, "TheLegacyRing", legacy.TurnTaker.Deck);
+            MoveCard(ra, "BlazingTornado", ra.TurnTaker.Deck);
+            MoveCard(omnitron, "AdaptivePlatingSubroutine", omnitron.TurnTaker.Deck);
+            MoveCard(omnitron, "DisintegrationRay", omnitron.TurnTaker.Deck);
+            DecisionDestroyCard = combat;
+
+            QuickHPStorage(comodora);
+            GoToEndOfTurn(comodora);
+            QuickHPCheck(-1);
+        }
+
+        [Test()]
         public void TestBeyondTheVeil_FirstTimeDiscard()
         {
             SetupGameController(new string[] { "BaronBlade", "Ra", "Legacy", "Haka", "Tachyon", "Cauldron.TheChasmOfAThousandNights" });


### PR DESCRIPTION
Beyond the Veil was not triggering for all instances of discarded cards, such as Chronological Sweetspot.

This fixes it by using MoveCardAction and checking for isDiscard instead of a DiscardCardAction