### PR TITLE
Night Under the Mountain's Buff on Destruction Stays Around for Too Long

### DIFF
--- a/CauldronMods/Controller/Villains/Celadroch/Cards/NightUnderTheMountainCardController.cs
+++ b/CauldronMods/Controller/Villains/Celadroch/Cards/NightUnderTheMountainCardController.cs
@@ -35,7 +35,8 @@ namespace Cauldron.Celadroch
             var effect = new IncreaseDamageStatusEffect(2);
             effect.SourceCriteria.IsVillain = true;
             effect.SourceCriteria.IsTarget = true;
-            effect.UntilEndOfNextTurn(TurnTaker);
+            effect.ToTurnPhaseExpiryCriteria.TurnTaker = TurnTaker;
+            effect.ToTurnPhaseExpiryCriteria.Phase = Phase.End;
             effect.CardSource = Card;
 
             return AddStatusEffect(effect);


### PR DESCRIPTION
If Night Under the Mountain is destroyed on Celadroch's turn, it's buff lasts through until the end of his next turn. This changes it just to be the end of his turn.

Closes #1609 