### PR TITLE
ScreaMachine Band Members Can Be Affected by Sky Deck

### DIFF
--- a/CauldronMods/Controller/Villains/ScreaMachine/CardSubClasses/ScreaMachineBandCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/ScreaMachine/CardSubClasses/ScreaMachineBandCharacterCardController.cs
@@ -68,7 +68,7 @@ namespace Cauldron.ScreaMachine
             {
                 AddFlippedSideTriggers();
             }
-
+            AddSideTrigger(AddTrigger((DestroyCardAction destroyCard) => destroyCard.CardToDestroy == this, CannotBeMovedResponse, TriggerType.Hidden, TriggerTiming.Before));
             AddAfterLeavesPlayAction(ga => CheckForDefeat(ga), TriggerType.GameOver);
         }
 

--- a/CauldronMods/Controller/Villains/ScreaMachine/CharacterCards/TheSetListCardController.cs
+++ b/CauldronMods/Controller/Villains/ScreaMachine/CharacterCards/TheSetListCardController.cs
@@ -305,14 +305,20 @@ namespace Cauldron.ScreaMachine
                 base.GameController.ExhaustCoroutine(coroutine);
             }
 
-            coroutine = GameController.DealDamage(DecisionMaker, highest.First(), c => c.IsHeroCharacterCard && !c.IsIncapacitatedOrOutOfGame, 2, DamageType.Sonic, cardSource: GetCardSource());
-            if (base.UseUnityCoroutines)
+            // add check for targets just in case
+            // this should never matter since if there are no villain targets, the game should already be over
+            if (highest.Any())
             {
-                yield return base.GameController.StartCoroutine(coroutine);
-            }
-            else
-            {
-                base.GameController.ExhaustCoroutine(coroutine);
+
+                coroutine = GameController.DealDamage(DecisionMaker, highest.First(), c => c.IsHeroCharacterCard && !c.IsIncapacitatedOrOutOfGame, 2, DamageType.Sonic, cardSource: GetCardSource());
+                if (base.UseUnityCoroutines)
+                {
+                    yield return base.GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    base.GameController.ExhaustCoroutine(coroutine);
+                }
             }
 
             coroutine = GameController.PlayTopCardOfLocation(TurnTakerController, TurnTaker.Deck, cardSource: GetCardSource());
@@ -324,6 +330,7 @@ namespace Cauldron.ScreaMachine
             {
                 base.GameController.ExhaustCoroutine(coroutine);
             }
+            
         }
 
         private IEnumerator RemoveDecisionsFromMakeDecisionsResponse(MakeDecisionsAction md)

--- a/Testing/Villains/ScreaMachineTests.cs
+++ b/Testing/Villains/ScreaMachineTests.cs
@@ -347,6 +347,20 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestSetListCharacterRemovedFromGameDestroy_SkyDeck([Values(ScreaMachineBandmate.Value.Slice, ScreaMachineBandmate.Value.Bloodlace, ScreaMachineBandmate.Value.Valentine, ScreaMachineBandmate.Value.RickyG)] ScreaMachineBandmate.Value member)
+        {
+            SetupGameController(new[] { "Cauldron.ScreaMachine", "Legacy", "Ra", "Haka", "MobileDefensePlatform" }, advanced: false);
+            StartGame();
+
+            PlayCard("SkyDeck");
+            var memberCard = GetCard(member.GetIdentifier());
+
+            DestroyCard(memberCard);
+
+            AssertAtLocation(memberCard, scream.TurnTaker.OutOfGame);
+        }
+
+        [Test()]
         public void TestSetListCharacterRemovedFromGameDamage([Values(ScreaMachineBandmate.Value.Slice, ScreaMachineBandmate.Value.Bloodlace, ScreaMachineBandmate.Value.Valentine, ScreaMachineBandmate.Value.RickyG)] ScreaMachineBandmate.Value member)
         {
             SetupGameController(new[] { "Cauldron.ScreaMachine", "Legacy", "Ra", "Haka", "Megalopolis" }, advanced: false);
@@ -411,7 +425,7 @@ namespace CauldronTests
 
             QuickHPStorage(legacy.CharacterCard, ra.CharacterCard, haka.CharacterCard, bunker.CharacterCard, rickyg, bloodlace);
 
-            AssertNextMessage("Take Down prevented ScreaMachine from playing cards.");
+            AssertNextMessage("Take Down prevented a card from being played.");
             GoToEndOfTurn(scream);
             QuickHPCheck(-2, -2, -2, -2, 0, 0);
 


### PR DESCRIPTION
Closes #1499 

When a band member was destroyed with Sky Deck out, the band member would go under the villain deck. This fixes it so when the band member is destroyed they will always go straight to Removed From the Game