### PR TITLE
Celestials Triggers Can Be Interrupted for Joint Immunity

### DIFF
--- a/CauldronMods/Controller/Villains/Celadroch/CardSubClasses/CeladrochCelestialCardController.cs
+++ b/CauldronMods/Controller/Villains/Celadroch/CardSubClasses/CeladrochCelestialCardController.cs
@@ -39,15 +39,16 @@ namespace Cauldron.Celadroch
             //when my partner receives damage make them immune to damage.
             AddTrigger<DealDamageAction>(dda => dda.DidDealDamage && !dda.DidDestroyTarget && dda.Target == Partner && !dda.Target.IsLeavingPlay,
                 (dda) => { SetCardPropertyIfRealAction(Partner, _IsImmuneKey, true); return DoNothing(); },
-                TriggerType.MakeImmuneToDamage,
+                TriggerType.FirstTrigger,
                 TriggerTiming.After
             );
 
             //when I receive damage, clear my partner's immunity
             AddTrigger<DealDamageAction>(dda => dda.DidDealDamage && !dda.DidDestroyTarget && dda.Target == Card && !dda.Target.IsLeavingPlay,
                 (dda) => { SetCardPropertyIfRealAction(Partner, _IsImmuneKey, false); return DoNothing(); },
-                TriggerType.ImmuneToDamage,
-                TriggerTiming.After
+                TriggerType.Hidden,
+                TriggerTiming.After,
+                priority: TriggerPriority.High
             );
 
             //make my partner immune to damage

--- a/Testing/Villains/CeladrochTests.cs
+++ b/Testing/Villains/CeladrochTests.cs
@@ -938,6 +938,44 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestCelestials_TestImmunity_DamageInterrupt()
+        {
+            SetupGameController(new[] { "Cauldron.Celadroch", "Ra", "Haka", "Legacy", "Cauldron.BlackwoodForest" }, advanced: false);
+            AddTokensToPool(stormPool, 3);
+            DecisionYesNo = false;
+            StartGame(false);
+            SuppressCeladrochMinionPlay();
+
+            GoToPlayCardPhase(celadroch);
+
+            DestroyNonCharacterVillainCards();
+
+            var c1 = GetCard("HollowAngel");
+            var c2 = GetCard("TatteredDevil");
+            PlayCard(c1);
+            PlayCard(c2);
+
+            Card overgrownCathedral = PlayCard("OvergrownCathedral");
+            DecisionSelectCards = new Card[] { celadroch.CharacterCard, ra.CharacterCard, haka.CharacterCard, legacy.CharacterCard, c2 };
+            QuickHPStorage(c1, c2);
+            DealDamage(haka, c1, 2, DamageType.Cold);
+            DealDamage(legacy, c2, 2, DamageType.Cold);
+            DealDamage(legacy, c1, 2, DamageType.Cold);
+            DealDamage(ra, c1, 2, DamageType.Cold);
+            DealDamage(ra, c2, 2, DamageType.Cold);
+
+            // c1 -> haka (-2) + legacy (-2) + ra (0)
+            // c2 -> overgrown cathedral (-1) + legacy (0) + ra (-2)
+            QuickHPCheck(-4, -3);
+
+            QuickHPStorage(c1, c2);
+            DealDamage(ra, c1, 2, DamageType.Cold);
+            DealDamage(haka, c2, 2, DamageType.Cold);
+            DealDamage(legacy, c2, 2, DamageType.Cold);
+            QuickHPCheck(-2, -2);
+        }
+
+        [Test()]
         public void TestOngoings_PlayCard([Values("HoursTilDawn", "LingeringExhalation", "NightUnderTheMountain", "RattlingWind", "ScreamingGale")] string identifier)
         {
 


### PR DESCRIPTION
Closes #773 

If damage is dealt to one of Celadroch's celestials, other triggers based on that damage could occur before the immunity is switched / cleared, resulting in both of the celestials having immunity.