### PR TITLE
Villain Start of Game Cards Should be Put into Play

### DIFF
--- a/CauldronMods/Controller/Villains/Gray/CharacterCards/GrayTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/Gray/CharacterCards/GrayTurnTakerController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.Gray
         public override IEnumerator StartGame()
         {
             //Search the villain deck for 1 copy of Chain Reaction and put it into play.
-            IEnumerator coroutine = base.GameController.PlayCard(this, base.TurnTaker.GetCardByIdentifier("ChainReaction"), cardSource: new CardSource(base.CharacterCardController));
+            IEnumerator coroutine = base.GameController.PlayCard(this, base.TurnTaker.GetCardByIdentifier("ChainReaction"), isPutIntoPlay: true, cardSource: new CardSource(base.CharacterCardController));
             //Shuffle the villain deck.
             IEnumerator coroutine2 = base.GameController.ShuffleLocation(base.TurnTaker.Deck, cardSource: new CardSource(base.CharacterCardController));
             if (base.UseUnityCoroutines)

--- a/CauldronMods/Controller/Villains/Menagerie/CharacterCards/MenagerieTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/Menagerie/CharacterCards/MenagerieTurnTakerController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.Menagerie
         public override IEnumerator StartGame()
         {
             //Search the villain deck for the card Prized Catch and put it into play.
-            IEnumerator coroutine = base.GameController.PlayCard(this, base.GameController.FindCard("PrizedCatch"));
+            IEnumerator coroutine = base.GameController.PlayCard(this, base.GameController.FindCard("PrizedCatch"), isPutIntoPlay: true, cardSource: CharacterCardController.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);
@@ -26,7 +26,7 @@ namespace Cauldron.Menagerie
             }
 
             //Shuffle the villain deck.
-            coroutine = base.GameController.ShuffleLocation(base.TurnTaker.Deck);
+            coroutine = base.GameController.ShuffleLocation(base.TurnTaker.Deck, cardSource: CharacterCardController.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/PhaseVillain/CharacterCards/PhaseVillainTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/CharacterCards/PhaseVillainTurnTakerController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.PhaseVillain
         public override IEnumerator StartGame()
         {
             //Search the villain deck for the card Reinforced Wall and put it into play.
-            IEnumerator coroutine = base.GameController.PlayCard(this, base.GameController.FindCard("ReinforcedWall"));
+            IEnumerator coroutine = base.GameController.PlayCard(this, base.GameController.FindCard("ReinforcedWall"), isPutIntoPlay: true, cardSource: CharacterCardController.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);
@@ -26,7 +26,7 @@ namespace Cauldron.PhaseVillain
             }
 
             //Shuffle the villain deck.
-            coroutine = base.GameController.ShuffleLocation(base.TurnTaker.Deck);
+            coroutine = base.GameController.ShuffleLocation(base.TurnTaker.Deck, cardSource: CharacterCardController.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/ScreaMachine/Cards/UpToElevenCardController.cs
+++ b/CauldronMods/Controller/Villains/ScreaMachine/Cards/UpToElevenCardController.cs
@@ -63,6 +63,9 @@ namespace Cauldron.ScreaMachine
                 GameController.ExhaustCoroutine(coroutine);
             }
 
+            if (TheSetListCardController is null)
+                yield break;
+
             coroutine = TheSetListCardController.RevealTopCardOfTheSetList();
             if (UseUnityCoroutines)
             {

--- a/CauldronMods/Controller/Villains/TheRam/CharacterCards/PastTheRamCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/TheRam/CharacterCards/PastTheRamCharacterCardController.cs
@@ -18,7 +18,8 @@ namespace Cauldron.TheRam
         public override void AddStartOfGameTriggers()
         {
             base.AddStartOfGameTriggers();
-            (TurnTakerController as TheRamTurnTakerController).HandleWintersEarly(false);
+            AddTrigger((GameAction ga) => TurnTakerController is TheRamTurnTakerController tttc && !tttc.IsAdmiralWintersHandled, ga => (TurnTakerController as TheRamTurnTakerController).HandleWintersEarly(false), TriggerType.Hidden, TriggerTiming.Before, priority: TriggerPriority.High);
+
         }
 
         public override void AddSideTriggers()

--- a/CauldronMods/Controller/Villains/TheRam/CharacterCards/TheRamCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/TheRam/CharacterCards/TheRamCharacterCardController.cs
@@ -22,7 +22,7 @@ namespace Cauldron.TheRam
         public override void AddStartOfGameTriggers()
         {
             base.AddStartOfGameTriggers();
-            (TurnTakerController as TheRamTurnTakerController).HandleWintersEarly(true);
+            AddTrigger((GameAction ga) => TurnTakerController is TheRamTurnTakerController tttc && !tttc.IsAdmiralWintersHandled, ga => (TurnTakerController as TheRamTurnTakerController).HandleWintersEarly(true), TriggerType.Hidden, TriggerTiming.Before, priority: TriggerPriority.High);
         }
 
         private readonly string ChallengeRetreatKey = "TheRamChallengeTacticalRetreatKey";

--- a/CauldronMods/Controller/Villains/TheRam/CharacterCards/TheRamTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/TheRam/CharacterCards/TheRamTurnTakerController.cs
@@ -34,7 +34,7 @@ namespace Cauldron.TheRam
                 }
 
                 //Put Grappling Claw into play. Shuffle the villain deck."
-                coroutine = GameController.PlayCard(this, FindCardsWhere((Card c) => c.Identifier == "GrapplingClaw").FirstOrDefault(), cardSource: new CardSource(CharacterCardController));
+                coroutine = GameController.PlayCard(this, FindCardsWhere((Card c) => c.Identifier == "GrapplingClaw").FirstOrDefault(), isPutIntoPlay: true, cardSource: new CardSource(CharacterCardController));
                 if (base.UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatCharacterCardController.cs
@@ -29,6 +29,12 @@ namespace Cauldron.Tiamat
         protected abstract ITrigger[] AddDecapitatedAdvancedTriggers();
         protected abstract ITrigger[] AddDecapitatedChallengeTriggers();
 
+        public override void AddStartOfGameTriggers()
+        {
+            base.AddStartOfGameTriggers();
+            AddTrigger((GameAction ga) => TurnTakerController is TiamatTurnTakerController tttc && !tttc.AreStartingCardsSetUp, (TurnTakerController as TiamatTurnTakerController).MoveStartingCards, TriggerType.Hidden, TriggerTiming.Before, priority: TriggerPriority.High);
+        }
+
         public override void AddSideTriggers()
         {
             //Win Condition

--- a/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatCharacterCardController.cs
@@ -29,12 +29,6 @@ namespace Cauldron.Tiamat
         protected abstract ITrigger[] AddDecapitatedAdvancedTriggers();
         protected abstract ITrigger[] AddDecapitatedChallengeTriggers();
 
-        public override void AddStartOfGameTriggers()
-        {
-            base.AddStartOfGameTriggers();
-            AddTrigger((GameAction ga) => TurnTakerController is TiamatTurnTakerController tttc && !tttc.AreStartingCardsSetUp, (TurnTakerController as TiamatTurnTakerController).MoveStartingCards, TriggerType.Hidden, TriggerTiming.Before, priority: TriggerPriority.High);
-        }
-
         public override void AddSideTriggers()
         {
             //Win Condition

--- a/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatSubCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatSubCharacterCardController.cs
@@ -14,6 +14,12 @@ namespace Cauldron.Tiamat
 
         }
 
+        public override void AddStartOfGameTriggers()
+        {
+            base.AddStartOfGameTriggers();
+            AddTrigger((GameAction ga) => TurnTakerController is TiamatTurnTakerController tttc && !tttc.AreStartingCardsSetUp, (TurnTakerController as TiamatTurnTakerController).MoveStartingCards, TriggerType.Hidden, TriggerTiming.Before, priority: TriggerPriority.High);
+        }
+
         public bool IsSpell(Card card)
         {
             return card != null && base.GameController.DoesCardContainKeyword(card, "spell");

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/2199/FutureTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/2199/FutureTiamatCharacterCardController.cs
@@ -16,12 +16,7 @@ namespace Cauldron.Tiamat
             base.SpecialStringMaker.ShowDamageDealt(new LinqCardCriteria((Card c) => c == base.Card, base.Card.Title, useCardsSuffix: false), thisTurn: true).Condition = () => Game.ActiveTurnTaker == base.TurnTaker && !base.Card.IsFlipped;
         }
 
-        public override void AddStartOfGameTriggers()
-        {
-            base.AddStartOfGameTriggers();
-            (TurnTakerController as TiamatTurnTakerController).MoveStartingCards();            
-        }
-
+    
         private IEnumerator Discard2Spells(PhaseChangeAction action)
         {
             IEnumerator coroutine = base.RevealCards_MoveMatching_ReturnNonMatchingCards(base.TurnTakerController, base.TurnTaker.Deck, false, false, false, new LinqCardCriteria((Card c) => this.IsSpell(c), "spell"), 2,

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/HydraWinterTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/HydraWinterTiamatCharacterCardController.cs
@@ -10,12 +10,6 @@ namespace Cauldron.Tiamat
             base.SpecialStringMaker.ShowSpecialString(() => base.Card.Title + " is immune to Cold damage.").Condition = () => !base.Card.IsFlipped;
         }
 
-        public override void AddStartOfGameTriggers()
-        {
-            base.AddStartOfGameTriggers();
-            (TurnTakerController as TiamatTurnTakerController).MoveStartingCards();
-        }
-
         protected override ITrigger[] AddFrontTriggers()
         {
             return new ITrigger[]

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/Regular/WinterTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/Regular/WinterTiamatCharacterCardController.cs
@@ -47,7 +47,6 @@ namespace Cauldron.Tiamat
         {
             base.AddStartOfGameTriggers();
             AddTrigger((GameAction ga) => TurnTakerController is TiamatTurnTakerController tttc && !tttc.ArePromosSetup, SetupPromos, TriggerType.Hidden, TriggerTiming.Before, priority: TriggerPriority.High);
-            (TurnTakerController as TiamatTurnTakerController).MoveStartingCards();
         }
 
         protected override ITrigger[] AddFrontAdvancedTriggers()

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
@@ -17,7 +17,7 @@ namespace Cauldron.Tiamat
 
         public bool ArePromosSetup { get; set; } = false;
 
-        public override IEnumerator StartGame()
+        public IEnumerator SupplementalSetup()
         {
 
             //Elemental Hydra
@@ -75,8 +75,11 @@ namespace Cauldron.Tiamat
             yield break;
         }
 
-        public void MoveStartingCards()
+        public bool AreStartingCardsSetUp { get; private set; } = false;
+
+        public IEnumerator MoveStartingCards(GameAction action)
         {
+            AreStartingCardsSetUp = true;
             //Winter is in all, just has promoIdentifier differentiating
             Card winter = base.TurnTaker.GetCardByIdentifier("WinterTiamatCharacter");
             
@@ -133,11 +136,23 @@ namespace Cauldron.Tiamat
                 throw new InvalidOperationException("Character Controller is not a Tiamat Character Card Controller");
             }
 
+            IEnumerator coroutine;
             foreach (Card c in inPlay)
             {
                 if (c.Location.IsOffToTheSide)
-                {
-                    TurnTaker.MoveCard(c, TurnTaker.PlayArea);
+                { 
+                    //TurnTaker.MoveCard(c, TurnTaker.PlayArea);
+                    coroutine = GameController.PlayCard(this, c, isPutIntoPlay: true, cardSource: FindCardController(c).GetCardSource());
+                    coroutine = GameController.PlayCard(this, c, isPutIntoPlay: true, cardSource: FindCardController(c).GetCardSource());
+                    if (base.UseUnityCoroutines)
+                    {
+                        yield return base.GameController.StartCoroutine(coroutine);
+                      
+                    }
+                    else
+                    {
+                        base.GameController.ExhaustCoroutine(coroutine);
+                    }
                 }
             }
             foreach (Card c in inBox)
@@ -145,7 +160,28 @@ namespace Cauldron.Tiamat
                 if (c.Location.IsOffToTheSide)
                 {
                     TurnTaker.MoveCard(c, TurnTaker.InTheBox);
+                    coroutine = GameController.MoveCard(this, c, TurnTaker.InTheBox, cardSource: FindCardController(c).GetCardSource());
+                    if (base.UseUnityCoroutines)
+                    {
+                        yield return base.GameController.StartCoroutine(coroutine);
+
+                    }
+                    else
+                    {
+                        base.GameController.ExhaustCoroutine(coroutine);
+                    }
                 }
+            }
+
+            coroutine = SupplementalSetup();
+            if (base.UseUnityCoroutines)
+            {
+                yield return base.GameController.StartCoroutine(coroutine);
+
+            }
+            else
+            {
+                base.GameController.ExhaustCoroutine(coroutine);
             }
         }
 

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/TiamatTurnTakerController.cs
@@ -141,8 +141,6 @@ namespace Cauldron.Tiamat
             {
                 if (c.Location.IsOffToTheSide)
                 { 
-                    //TurnTaker.MoveCard(c, TurnTaker.PlayArea);
-                    coroutine = GameController.PlayCard(this, c, isPutIntoPlay: true, cardSource: FindCardController(c).GetCardSource());
                     coroutine = GameController.PlayCard(this, c, isPutIntoPlay: true, cardSource: FindCardController(c).GetCardSource());
                     if (base.UseUnityCoroutines)
                     {

--- a/CauldronMods/DeckLists/Villain/ScreaMachineDeckList.json
+++ b/CauldronMods/DeckLists/Villain/ScreaMachineDeckList.json
@@ -35,7 +35,7 @@
 			],
 			"flippedBody": "The Main Event!",
 			"flippedGameplay": [
-				"Cards beneath this one are not considered in play. Guitarist, Vocalist, Bassist, and Drummer cards are indestructible. Destroyed villain characteres are removed from the game.",
+				"Cards beneath this one are not considered in play. Guitarist, Vocalist, Bassist, and Drummer cards are indestructible. Destroyed villain characters are removed from the game.",
 				"Whenever a card beneath this one is revealed, play it if it shares a keyword with a card in play. Otherwise, place it face down on the bottom of the stack and play the top card beneath this one.",
 				"At the start of the villain turn, reveal the top card beneath this one.",
 				"At the end of the villain turn, if {H - 2} or fewer villain characters remain in play, the villain target with the highest HP deals each hero 2 sonic damage and plays the top card of the villain deck."


### PR DESCRIPTION
origamiswami found an interaction with Boss Rush and some Cauldron bosses where Ram, Gray, Menagerie, and Phase all put a card into play at the start of the game, but in their code, the card is played instead of put into play. This normally doesn't matter, but in Boss Rush, Take Down could be in play while the villain is setting up. This prevents those setup cards from getting played.

This fixes that issue