### PR TITLE
Future Tiamat and Spell card Special Strings

### DIFF
--- a/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/SpellCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/SpellCardController.cs
@@ -9,7 +9,8 @@ namespace Cauldron.Tiamat
     {
         protected SpellCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-
+            base.SpecialStringMaker.ShowNumberOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => IsSpell(c), "spell")).Condition = () => base.CharacterCardController is FutureTiamatCharacterCardController;
+            base.SpecialStringMaker.ShowNumberOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => c.Identifier == Card.Identifier, Card.Title)).Condition = () => !(base.CharacterCardController is FutureTiamatCharacterCardController);
         }
 
         protected int PlusNumberOfThisCardInTrash(int value)

--- a/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfFireCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfFireCardController.cs
@@ -12,14 +12,6 @@ namespace Cauldron.Tiamat
         public ElementOfFireCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             base.SpecialStringMaker.ShowHeroWithMostCards(false);
-            if (base.CharacterCardController is FutureTiamatCharacterCardController)
-            {
-                base.SpecialStringMaker.ShowNumberOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => base.IsSpell(c), "spell"));
-            }
-            else
-            {
-                base.SpecialStringMaker.ShowNumberOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => c.Identifier == "ElementOfFire", "element of fire"));
-            }
         }
 
         public override IEnumerator Play()

--- a/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfIceCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfIceCardController.cs
@@ -13,14 +13,6 @@ namespace Cauldron.Tiamat
         public ElementOfIceCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             base.SpecialStringMaker.ShowHeroTargetWithHighestHP();
-            if (base.CharacterCardController is FutureTiamatCharacterCardController)
-            {
-                base.SpecialStringMaker.ShowNumberOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => base.IsSpell(c), "spell"));
-            }
-            else
-            {
-                base.SpecialStringMaker.ShowNumberOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => c.Identifier == "ElementOfIce", "element of ice"));
-            }
         }
 
         public override IEnumerator Play()

--- a/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfLightningCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfLightningCardController.cs
@@ -13,14 +13,6 @@ namespace Cauldron.Tiamat
         public ElementOfLightningCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             base.SpecialStringMaker.ShowHeroWithMostCards(true);
-            if (base.CharacterCardController is FutureTiamatCharacterCardController)
-            {
-                base.SpecialStringMaker.ShowNumberOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => base.IsSpell(c), "spell"));
-            }
-            else
-            {
-                base.SpecialStringMaker.ShowNumberOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => c.Identifier == "ElementOfLightning", "element of lightning"));
-            }
         }
 
         public static readonly string PreventDrawPropertyKey = "ElementOfLightningCannotDraw";

--- a/Testing/Villains/TiamatFutureTests.cs
+++ b/Testing/Villains/TiamatFutureTests.cs
@@ -188,14 +188,16 @@ namespace CauldronTests
             //{Tiamat} counts as The Jaws of Winter, The Mouth of the Inferno, and The Eye of the Storm.
             AddCannotDealNextDamageTrigger(tiamat, tiamat.CharacterCard);
             QuickHPStorage(legacy, bunker, haka, ra);
-            PlayCard("ElementOfIce");
+            Card ice = PlayCard("ElementOfIce");
+            PrintSpecialStringsForCard(ice);
             //Preventing damage by Tiamat once shows the damage is coming from her
             QuickHPCheck(0, -2, -2, -2);
 
             //Each spell card in the villain trash counts as Element of Ice, Element of Fire, and Element of Lightining.
             AddCannotDealNextDamageTrigger(tiamat, tiamat.CharacterCard);
             QuickHPStorage(legacy, bunker, haka, ra);
-            PlayCard("ElementOfFire");
+            Card fire = PlayCard("ElementOfFire");
+            PrintSpecialStringsForCard(fire);
             //Preventing damage by Tiamat once shows the damage is coming from her
             //Only card in trash is Element of Ice which means Ice increased Fire
             QuickHPCheck(0, -3, -3, -3);
@@ -203,7 +205,8 @@ namespace CauldronTests
 
             AddCannotDealNextDamageTrigger(tiamat, tiamat.CharacterCard);
             QuickHPStorage(legacy, bunker, haka, ra);
-            PlayCard("ElementOfLightning");
+            Card lightning = PlayCard("ElementOfLightning");
+            PrintSpecialStringsForCard(lightning);
             //Preventing damage by Tiamat once shows the damage is coming from her
             //Only card in trash is Element of Ice which means Ice increased Fire
             QuickHPCheck(0, -4, -4, -4);

--- a/Testing/Villains/TiamatTests.cs
+++ b/Testing/Villains/TiamatTests.cs
@@ -713,7 +713,7 @@ namespace CauldronTests
             StartGame();
 
             Card fire = GetCard("ElementOfFire");
-
+            PrintSpecialStringsForCard(fire);
             //put the other two copies of element of fire in the trash
             List<Card> spellCards = (tiamat.TurnTaker.Deck.Cards.Where(c => c.Identifier == "ElementOfFire" && c != fire).Take(2)).ToList();
             PutInTrash(spellCards);
@@ -784,7 +784,8 @@ namespace CauldronTests
             //winter is the one who should be dealing the damage
             AddCannotDealNextDamageTrigger(tiamat, storm);
             AddCannotDealNextDamageTrigger(tiamat, inferno);
-            PlayCard(tiamat, "ElementOfIce");
+            Card ice = PlayCard(tiamat, "ElementOfIce");
+            PrintSpecialStringsForCard(ice);
 
             QuickHPCheck(-2, -2, -2);
         }
@@ -882,7 +883,7 @@ namespace CauldronTests
             StartGame();
 
             Card lightning = GetCard("ElementOfLightning");
-
+            PrintSpecialStringsForCard(lightning);
             //put the other two copies of element of lightning in the trash
             List<Card> spellCards = (tiamat.TurnTaker.Deck.Cards.Where(c => c.Identifier == "ElementOfLightning" && c != lightning).Take(2)).ToList();
             PutInTrash(spellCards);


### PR DESCRIPTION
 the special string should include all the spell cards in the trash, not just the specified Element card. In this case, there are 4 spell cards in the trash, but the special string only considers Element of Ice cards.

In the constructor, CharacterCardController is still null, so the check previously never resolved correctly