### PR TITLE
Use GameController.FlipCard for Tiamat

### DIFF
--- a/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/HydraTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/HydraTiamatCharacterCardController.cs
@@ -46,8 +46,7 @@ namespace Cauldron.Tiamat
         //When a {Tiamat} head is destroyed, flip her.
         public override IEnumerator DestroyAttempted(DestroyCardAction destroyCard)
         {
-            FlipCardAction action = new FlipCardAction(base.GameController, this, false, false, destroyCard.ActionSource);
-            IEnumerator coroutine = base.DoAction(action);
+            IEnumerator coroutine = base.GameController.FlipCard(this, actionSource: destroyCard.ActionSource, cardSource: GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CardSubClasses/TiamatCharacterCardController.cs
@@ -72,8 +72,7 @@ namespace Cauldron.Tiamat
         //When a {Tiamat} head is destroyed, flip her.
         public override IEnumerator DestroyAttempted(DestroyCardAction destroyCard)
         {
-            FlipCardAction action = new FlipCardAction(base.GameController, this, false, false, destroyCard.ActionSource);
-            IEnumerator coroutine = base.DoAction(action);
+            IEnumerator coroutine = base.GameController.FlipCard(this, actionSource: destroyCard.ActionSource, cardSource: GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);


### PR DESCRIPTION
Tiamat's heads construct a FlipCardAction directly; they don't need to and should just call GameController.FlipCard. This is a contributing factor for the recent Tiamat-doesn't-flip bug; Handelabra changed the FlipCardAction constructor so we get an exception when we try to call the old one. Pushing a new release of the mod will fix that bug, but this fix seemed worthwhile to do as well.

Superstorm Akela changes properties of the FlipCardAction that the helper method doesn't expose, so that's left the same.

All Tiamat tests still pass.