### PR TITLE
Change Time Freeze to respect other turn-changers

### DIFF
--- a/CauldronMods/Controller/Environments/FSCContinuanceWanderer/Cards/TimeFreezeCardController.cs
+++ b/CauldronMods/Controller/Environments/FSCContinuanceWanderer/Cards/TimeFreezeCardController.cs
@@ -67,7 +67,10 @@ namespace Cauldron.FSCContinuanceWanderer
                 GameController,
                 new object[] {
                     CardControllerListType.ChangesTurnTakerOrder,
-                    (Func<CardController, TurnTaker>)(cc => cc == this ? null : cc.AskIfTurnTakerOrderShouldBeChanged(active, next)),
+                    (Func<CardController, TurnTaker>)(
+                        cc => cc == this || cc.AskPriority > AskPriority
+                                        ? null
+                                        : cc.AskIfTurnTakerOrderShouldBeChanged(active, next)),
                     false,
                     null
                 }

--- a/CauldronMods/Controller/Environments/FSCContinuanceWanderer/Cards/TimeFreezeCardController.cs
+++ b/CauldronMods/Controller/Environments/FSCContinuanceWanderer/Cards/TimeFreezeCardController.cs
@@ -5,12 +5,20 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Cauldron.FSCContinuanceWanderer
 {
     public class TimeFreezeCardController : CardController
     {
         //This card is very fragile, test changes carefully.
+
+        // We use reflection to call a private method on GameController. This is a cached handle to
+        // that method; this is just a performance optimisation, so it doesn't matter that this variable
+        // won't survive an undo or reload.
+        MethodInfo cachedAskAllCardControllersInList;
+        bool currentlyChangingTurnOrder = false;
+
         public TimeFreezeCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             AddThisCardControllerToList(CardControllerListType.ChangesTurnTakerOrder);
@@ -30,97 +38,77 @@ namespace Cauldron.FSCContinuanceWanderer
                 return null;
             }
         }
-        private bool AreTurnsReversed
+
+        // The algorithm here:
+        // - Ensure we are asked for the next turntaker before any other cardcontroller by setting our askpriority very high.
+        // - When we get asked, ask every other card controller who they think should go first
+        // - If they say the turntaker we've frozen is up next, go back and ask again as if the turn order has just moved on
+        // - Return the answer we get.
+        // - If we don't return null the engine won't go on to ask anyone else; we've taken full control
+        //   of the process while still respecting what other cards think.
+        // - This should seamlessly handle a lot of other turn-order-changing cards.
+        // - We include protection against recursive calls just in case someone else is doing something similar.
+
+        public override int AskPriority => 100;
+
+        private TurnTaker GetExpectedNextTurnTaker(TurnTaker active, TurnTaker next)
         {
-            get 
+            if (cachedAskAllCardControllersInList == null)
             {
-                return GameController.FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.Identifier == "PlayingDiceWithTheCosmos").Any();
+                var method = GameController.GetType().GetMethod(
+                    "AskAllCardControllersInList",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+
+                cachedAskAllCardControllersInList = method.MakeGenericMethod(typeof(TurnTaker));
             }
+
+            var result = (TurnTaker)cachedAskAllCardControllersInList.Invoke(
+                GameController,
+                new object[] {
+                    CardControllerListType.ChangesTurnTakerOrder,
+                    (Func<CardController, TurnTaker>)(cc => cc == this ? null : cc.AskIfTurnTakerOrderShouldBeChanged(active, next)),
+                    false,
+                    null
+                }
+            );
+
+            return result ?? next;
         }
+
         public override TurnTaker AskIfTurnTakerOrderShouldBeChanged(TurnTaker fromTurnTaker, TurnTaker toTurnTaker)
         {
-            var frozen = FrozenTurnTaker;
-            if (frozen != null && !AreTurnsReversed)
+            if (FrozenTurnTaker == null)
+                return null;
+
+            // We've recursed; this can only happen if another cardcontroller is doing something similar.
+            // We should return null just so everything bottoms out in an answer eventually.
+            if (currentlyChangingTurnOrder)
+                return null;
+
+            currentlyChangingTurnOrder = true;
+
+            var next = GetExpectedNextTurnTaker(Game.ActiveTurnTaker, Game.FindNextTurnTaker());
+            if (next == FrozenTurnTaker)
             {
-                if (toTurnTaker == frozen)
-                {
-                    var turnTakersInOrder = GameController.AllTurnTakers.ToList();
-                    int? frozenIndex = turnTakersInOrder.IndexOf(frozen);
-                    if(frozenIndex.HasValue)
-                    {
-                        return turnTakersInOrder[frozenIndex.Value + 1];
-                    }
-                }
+                var index = Game.TurnTakers.IndexOf(next) ?? 0;
+                index = (index + 1) % Game.TurnTakers.Count();
+                next = GetExpectedNextTurnTaker(next, Game.TurnTakers.ElementAt(index));
             }
-            return null;
+
+            currentlyChangingTurnOrder = false;
+
+            return next;
         }
 
         public override void AddTriggers()
-        {//base.GameController.Game.OverrideNextTurnPhase = lastTurnPhase;
-            //That hero skips their turns...
-            //mostly accomplished with AskIfTurnTakerOrderShouldBeChanged,
-            //this is here to handle conflicts with Wager Master's 'Playing Dice With The Cosmos'
-            AddPhaseChangeTrigger(tt => true, p => true, IsEnteringTurnReversedFrozenPhase, SkipToTurnReversedFollower, new TriggerType[] { TriggerType.SkipTurn, TriggerType.HiddenLast }, TriggerTiming.Before);
-
+        {
             //...and targets in their play are are immune to damage.
             base.AddImmuneToDamageTrigger((DealDamageAction action) => action.Target.Location.HighestRecursiveLocation == GetCardThisCardIsNextTo()?.Location.HighestRecursiveLocation);
             //At the start of the environment turn, destroy this card.
             base.AddStartOfTurnTrigger((TurnTaker turnTaker) => turnTaker == base.TurnTaker, base.DestroyThisCardResponse, TriggerType.DestroySelf);
         }
 
-        private bool IsEnteringTurnReversedFrozenPhase(PhaseChangeAction pca)
-        {
-            var frozen = FrozenTurnTaker;
-            if (pca.ToPhase.TurnTaker == frozen && pca.FromPhase.TurnTaker != frozen && AreTurnsReversed)
-            {
-                return true;
-            }
-            return false;
-        }
-
-        private IEnumerator SkipToTurnReversedFollower(PhaseChangeAction pca)
-        {
-            var frozen = FrozenTurnTaker;
-            if (frozen == null)
-            {
-                yield break;
-            }
-            var frozenIndex = GameController.AllTurnTakers.IndexOf(frozen);
-            var allHeroTurnTakers = GameController.AllTurnTakers.Where((TurnTaker tt) => tt.IsHero);
-
-            //previous hero in normal turn order, or environment if it is the first
-            var nextTurnTakerIndex = (frozenIndex ?? 0) - 1;
-            if (frozen == allHeroTurnTakers.FirstOrDefault())
-            {
-                nextTurnTakerIndex = (GameController.AllTurnTakers.IndexOf(FindEnvironment().TurnTaker) ?? -1);
-            }
-
-            if (nextTurnTakerIndex == -1)
-            {
-                Log.Warning("Failed to find next turn taker for Time Freeze");
-                yield break;
-            }
-            var nextTurnTaker = GameController.AllTurnTakers.ToList()[nextTurnTakerIndex];
-            //Log.Debug($"Should skip to TurnTaker at index {nextTurnTakerIndex}, which is {nextTurnTaker.Name}");
-
-            //make sure we skip to the right phase if the imp also has Breaking The Rules
-            var nextTTStart = nextTurnTaker.TurnPhases.First();
-            if(nextTurnTaker.IsHero && GameController.GetAllCards().Where((Card c) => c.IsInPlayAndHasGameText && c.Identifier == "BreakingTheRules").Any())
-            {
-                nextTTStart = nextTurnTaker.TurnPhases.Last();
-            }
-
-            IEnumerator coroutine = GameController.SkipToTurnPhase(nextTTStart, interruptActions: true, cardSource: GetCardSource());
-            if (base.UseUnityCoroutines)
-            {
-                yield return base.GameController.StartCoroutine(coroutine);
-            }
-            else
-            {
-                base.GameController.ExhaustCoroutine(coroutine);
-            }
-            yield break;
-        }
         public override IEnumerator DeterminePlayLocation(List<MoveCardDestination> storedResults, bool isPutIntoPlay, List<IDecision> decisionSources, Location overridePlayArea = null, LinqTurnTakerCriteria additionalTurnTakerCriteria = null)
         {
             //Play this card next to a hero.


### PR DESCRIPTION
Conveniently also makes the handling of Playing Dice with the Cosmos less special-cased.

Algorithm:
- Get asked before any other card; take full control of the process by never returning null.
- Ask every other card who they think should be the next turntaker (using reflection)
- If the answer we get out is the frozen turntaker, ask again as if they'd just taken their turn and the engine has moved on, then return that answer.

This means we can respect other turn-changer cards, without special-casing them, while still preventing the frozen turntaker taking a turn (unless another card says that the turntaker that should take a turn after the frozen turntaker is the frozen turntaker, in which case there's not really a great option and letting them have the turn is probably safest).