### PR TITLE
Make Drift's shift cards heroes again

### DIFF
--- a/CauldronMods/DeckLists/Hero/DriftDeckList.json
+++ b/CauldronMods/DeckLists/Hero/DriftDeckList.json
@@ -88,9 +88,7 @@
           }
         ],
         "flippedBody": "Shift Track",
-        "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero"
+        "isReal": false
       },
       {
         "identifier": "BaseShiftTrack2",
@@ -118,9 +116,7 @@
           }
         ],
         "flippedBody": "Shift Track",
-        "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero"
+        "isReal": false
       },
       {
         "identifier": "BaseShiftTrack3",
@@ -148,9 +144,7 @@
           }
         ],
         "flippedBody": "Shift Track",
-        "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero"
+        "isReal": false
       },
       {
         "identifier": "BaseShiftTrack4",
@@ -178,9 +172,7 @@
           }
         ],
         "flippedBody": "Shift Track",
-        "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero"
+        "isReal": false
       },
         {
             "identifier": "AttenuationField",
@@ -656,8 +648,6 @@
         "title": "Shift Track: Past",
         "character": true,
         "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero",
         "notsetup": [
           "At the start of the game, after drawing your cards, flip this card and place a token on 1 of the 4 spaces of the shift track.",
           "Then place 1 of your 2 character cards (1929 or 2199) into play active. Place your other character card next to current space, inactive.",
@@ -692,8 +682,6 @@
         "title": "Shift Track: Past",
         "character": true,
         "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero",
         "notsetup": [
           "At the start of the game, after drawing your cards, flip this card and place a token on 1 of the 4 spaces of the shift track.",
           "Then place 1 of your 2 character cards (1929 or 2199) next to that same space, inactive. Place your other character card into play, active.",
@@ -728,8 +716,6 @@
         "title": "Shift Track: Future",
         "character": true,
         "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero",
         "notsetup": [
           "At the start of the game, after drawing your cards, flip this card and place a token on 1 of the 4 spaces of the shift track.",
           "Then place 1 of your 2 character cards (1929 or 2199) next to that same space, inactive. Place your other character card into play, active.",
@@ -764,8 +750,6 @@
         "title": "Shift Track: Future",
         "character": true,
         "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero",
         "notsetup": [
           "At the start of the game, after drawing your cards, flip this card and place a token on 1 of the 4 spaces of the shift track.",
           "Then place 1 of your 2 character cards (1929 or 2199) next to that same space, inactive. Place your other character card into play, active.",
@@ -800,8 +784,6 @@
         "title": "Shift Track: Past",
         "character": true,
         "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero",
         "setup": [
           "At the start of the game, after drawing your cards, place a token on 1 of the 4 spaces of the shift track."
         ],
@@ -830,8 +812,6 @@
         "title": "Shift Track: Past",
         "character": true,
         "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero",
         "setup": [
           "At the start of the game, after drawing your cards, place a token on 1 of the 4 spaces of the shift track."
         ],
@@ -860,8 +840,6 @@
         "title": "Shift Track: Future",
         "character": true,
         "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero",
         "setup": [
           "At the start of the game, after drawing your cards, place a token on 1 of the 4 spaces of the shift track."
         ],
@@ -890,8 +868,6 @@
         "title": "Shift Track: Future",
         "character": true,
         "isReal": false,
-        "kind": "Villain",
-        "flippedKind": "Hero",
         "setup": [
           "At the start of the game, after drawing your cards, place a token on 1 of the 4 spaces of the shift track."
         ],


### PR DESCRIPTION
Sentinels 4.0.5 fixes the engine bug that Drift's shift cards were made hero cards to avoid. This patch undoes the workaround.