### PR TITLE
Pyre multi-damage test

### DIFF
--- a/Testing/Heroes/PyreTests.cs
+++ b/Testing/Heroes/PyreTests.cs
@@ -707,8 +707,7 @@ namespace CauldronTests
             GoToEndOfTurn(pyre);
             AssertIrradiated(grandReshiel);
 
-            //only the first instance of damage will trigger here, so battalion will be undamaged
-            QuickHPCheck(-2, 0);
+            QuickHPCheck(-2, -2);
         }
 
         [Test]
@@ -752,8 +751,7 @@ namespace CauldronTests
             GoToEndOfTurn(pyre);
             AssertNotIrradiated(highReshiel);
 
-            //only the first instance of damage will trigger here, so battalion will be undamaged
-            QuickHPCheck(-2, 0);
+            QuickHPCheck(-2, -2);
 
             AssertInTrash(highReshiel);
         }

--- a/Testing/Heroes/PyreTests.cs
+++ b/Testing/Heroes/PyreTests.cs
@@ -807,6 +807,28 @@ namespace CauldronTests
             QuickHandCheck(2);
             AssertInTrash(aux);
         }
+
+        [Test]
+        public void TestCherenkovDriveMultiHitPower()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Pyre", "Legacy", "ChronoRanger", "TheScholar", "Megalopolis");
+            StartGamePyre();
+            DestroyNonCharacterVillainCards();
+
+            Card bow = PutInHand("CompoundedBow");
+            DecisionSelectTurnTaker = chrono.TurnTaker;
+            DecisionSelectCard = bow;
+            DecisionYesNo = true;
+            DecisionSelectTarget = baron.CharacterCard;
+            DecisionSelectDamageType = DamageType.Energy;
+
+            QuickHPStorage(baron);
+            PlayCard("CherenkovDrive");
+            GoToEndOfTurn(pyre);
+
+            QuickHPCheck(-2);
+        }
+
         [Test]
         public void TestCherenkovDrivePowerSelfDestructAccountForBug()
         {

--- a/Testing/Heroes/PyreTests.cs
+++ b/Testing/Heroes/PyreTests.cs
@@ -830,6 +830,29 @@ namespace CauldronTests
         }
 
         [Test]
+        public void TestCherenkovDriveMultiTargetPower()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Pyre", "Legacy", "Stuntman", "TheScholar", "Megalopolis");
+            StartGamePyre();
+            DestroyNonCharacterVillainCards();
+
+            var goon = PlayCard("BladeBattalion");
+            var device = PlayCard("ElementalRedistributor");
+
+            Card gun = PutInHand("PistoletMitrailleur");
+            DecisionSelectTurnTaker = stunt.TurnTaker;
+            DecisionSelectCard = gun;
+            DecisionYesNo = true;
+            DecisionDoNotSelectCard = SelectionType.PlayCard;
+
+            QuickHPStorage(baron.CharacterCard, goon, device);
+            PlayCard("CherenkovDrive");
+            GoToEndOfTurn(pyre);
+
+            QuickHPCheck(-1, -1, -1);
+        }
+
+        [Test]
         public void TestCherenkovDrivePowerSelfDestructAccountForBug()
         {
             SetupGameController("BaronBlade", "Cauldron.Pyre", "Legacy", "Bunker", "TheScholar", "Megalopolis");


### PR DESCRIPTION
Sentinels 4.0.5 fixed one engine bug around out-of-play cards causing damage, which broke some Pyre tests that were accounting for that bug. Explicitly add two tests for powers that previously the engine would have handled weirdly.

Also: I've replicated the bug with Cherenkov Drive triggering draws with official content (completionist guise, my love), so hopefully that'll get fixed in a later update.