### PR TITLE
Fix TestHeroPreservation_DualDrift test

### DIFF
--- a/Testing/Villains/TheMistressOfFateTests.cs
+++ b/Testing/Villains/TheMistressOfFateTests.cs
@@ -1528,8 +1528,11 @@ namespace CauldronTests
         public void TestHeroPreservation_DualDrift()
         {
             SetupGameController("Cauldron.TheMistressOfFate", "Legacy", "Cauldron.Drift/DualDriftCharacter", "Ra", "Megalopolis");
-            StartGame();
+            
             Card track = FindCardsWhere((Card c) => c.Identifier == $"DualShiftTrack1", false).FirstOrDefault();
+            DecisionSelectCards = new Card[] { track, futureDrift };
+            StartGame(false);
+            ResetDecisions();
 
             ResetDays();
             FlipCard(fate);


### PR DESCRIPTION
A Mistress of Fate vs Dual Drift test doesn't actually specify which Drift cards to put into play at the start, and either the default has changed or something else has happened, because the test fails for me now. This patch fixes that.