### PR TITLE
Fix Leech Field.

### DIFF
--- a/CauldronMods/Controller/Heroes/Gargoyle/CardSubClasses/GargoyleUtilityCardController.cs
+++ b/CauldronMods/Controller/Heroes/Gargoyle/CardSubClasses/GargoyleUtilityCardController.cs
@@ -2,48 +2,114 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-
 using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 
 namespace Cauldron.Gargoyle
 {
+    [Serializable]
+    public class GargoyleDamageIncrease : OnDealDamageStatusEffect
+    {
+        public GargoyleDamageIncrease(CardController controller, int _amount, DealDamageAction _notThisDDA)
+            : base(
+                  controller.CardWithoutReplacements, 
+                  nameof(GargoyleUtilityCardController.GargoyleDamageIncreaseFunc),
+                  "Increase the next damage dealt by " + controller.CharacterCard.Title + " by " + _amount + ", excepting damage reduced by leech field.", 
+                  new TriggerType[] { TriggerType.IncreaseDamage },
+                  controller.TurnTaker,
+                  controller.Card
+            )
+        {
+            Amount = _amount;
+            NotThisDDA = _notThisDDA.InstanceIdentifier;
+        }
+
+        public int Amount;
+        public Guid NotThisDDA;
+    }
+
+
     public abstract class GargoyleUtilityCardController : CardController
     {
         protected GargoyleUtilityCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
         }
 
-        // Most of Gargoyle's cards increase his next damage dealt by a set amount.
-        protected IEnumerator IncreaseGargoyleNextDamage(int amount)
+        public IEnumerator GargoyleDamageIncreaseFunc(DealDamageAction dda, TurnTaker decisionMaker, OnDealDamageStatusEffect effect, int[] powerNumerals)
         {
-            IncreaseDamageStatusEffect increaseDamageStatusEffect;
+            var gdEffect = effect as GargoyleDamageIncrease;
+            if (gdEffect == null || gdEffect.NotThisDDA == dda.InstanceIdentifier)
+            {
+                ++effect.NumberOfUses;
+                yield break;
+            }
 
-            increaseDamageStatusEffect = new IncreaseDamageStatusEffect(amount);
-            increaseDamageStatusEffect.SourceCriteria.IsSpecificCard = base.CharacterCard;
-            increaseDamageStatusEffect.NumberOfUses = 1;
-            increaseDamageStatusEffect.UntilTargetLeavesPlay(base.CharacterCard);
+            var e = GameController.IncreaseDamage(dda, gdEffect.Amount, cardSource: GetCardSource());
+            if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
+            else { GameController.ExhaustCoroutine(e); }
+        }
 
-            return base.AddStatusEffect(increaseDamageStatusEffect);
+        // Most of Gargoyle's cards increase his next damage dealt by a set amount.
+        protected IEnumerator IncreaseGargoyleNextDamage(int amount, DealDamageAction ignoreThisDDA = null)
+        {
+            StatusEffect increaseDamageStatusEffect;
+            if (ignoreThisDDA == null)
+            {
+                var effect = new IncreaseDamageStatusEffect(amount);
+                effect.SourceCriteria.IsSpecificCard = CharacterCard;
+                increaseDamageStatusEffect = effect;
+                increaseDamageStatusEffect.NumberOfUses = 1;
+            }
+            else
+            {
+                var effect = new GargoyleDamageIncrease(this, amount, ignoreThisDDA);
+                effect.SourceCriteria.IsSpecificCard = CharacterCard;
+                increaseDamageStatusEffect = effect;
+            }
+
+            increaseDamageStatusEffect.UntilTargetLeavesPlay(CharacterCard);
+
+            return AddStatusEffect(increaseDamageStatusEffect);
         }
 
         protected string TotalNextDamageBoostString()
         {
-            var allDamageBoosts = GameController.StatusEffectManager.StatusEffectControllers.Where(sec => sec.StatusEffect is IncreaseDamageStatusEffect);
+            var allDamageBoosts = GameController.StatusEffectManager.StatusEffectControllers.Where(
+                sec => sec.StatusEffect is IncreaseDamageStatusEffect || sec.StatusEffect is GargoyleDamageIncrease
+            );
             int totalBoost = 0;
+            int conditionalBoost = 0;
             foreach(StatusEffectController sec in allDamageBoosts)
             {
-                var thisEffect = sec.StatusEffect as IncreaseDamageStatusEffect;
-                if(thisEffect.SourceCriteria.IsSpecificCard == CharacterCard && thisEffect.NumberOfUses == 1)
+                if (sec.StatusEffect is IncreaseDamageStatusEffect thisEffect)
                 {
-                    totalBoost += thisEffect.Amount;
+                    if (thisEffect.SourceCriteria.IsSpecificCard == CharacterCard && thisEffect.NumberOfUses > 0)
+                    {
+                        totalBoost += thisEffect.Amount;
+                    }
+                }
+
+                if (sec.StatusEffect is GargoyleDamageIncrease thisGargoyleEffect)
+                {
+                    if (thisGargoyleEffect.SourceCriteria.IsSpecificCard == CharacterCard && thisGargoyleEffect.NumberOfUses > 0)
+                    {
+                        totalBoost += thisGargoyleEffect.Amount;
+                        conditionalBoost += thisGargoyleEffect.Amount;
+                    }
                 }
             }
             if(totalBoost == 0)
             {
                 return $"{TurnTaker.Name} has no temporary damage boosts.";
             }
-            return $"{TurnTaker.Name}'s next damage will be increased by a total of {totalBoost}.";
+
+            var ret = $"{TurnTaker.Name}'s next damage will be increased by a total of {totalBoost}";
+            if (conditionalBoost > 0)
+            {
+                ret += $"; {conditionalBoost} of which is conditional";
+            }
+
+            return ret + ".";
         }
     }
 }

--- a/CauldronMods/Controller/Heroes/Gargoyle/Cards/LeechFieldCardController.cs
+++ b/CauldronMods/Controller/Heroes/Gargoyle/Cards/LeechFieldCardController.cs
@@ -13,6 +13,14 @@ namespace Cauldron.Gargoyle
         // "Once per turn, when {Gargoyle} deals or is dealt damage, or when a non-hero target is dealt damage, 
         // you may reduce that damage by 1 and increase the next damage dealt by {Gargoyle} by 1."
         private const string FirstTimeWouldBeDealtDamage = "OncePerTurn";
+        
+        private struct PreventInfo
+        {
+            public bool preventDamage;
+            public Guid ddaGuid;
+        };
+
+        private PreventInfo? selectedReaction;
 
         public LeechFieldCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
@@ -30,71 +38,62 @@ namespace Cauldron.Gargoyle
 
         public override void AddTriggers()
         {
-            //ReduceDamageTrigger reduceDamageTrigger;
-
-            base.AddTrigger<DealDamageAction>(DealDamageCritera, DealDamageResponse, new TriggerType[] { TriggerType.ModifyDamageAmount }, TriggerTiming.Before, isActionOptional: true);
-
-            //reduceDamageTrigger = new ReduceDamageTrigger(base.GameController, DealDamageCritera, (card) => true, DealDamageResponse, true, false, base.GetCardSource());
-            //base.AddTrigger(reduceDamageTrigger);
-
+            AddTrigger<DealDamageAction>(DealDamageCritera, DealDamageResponse, new TriggerType[] { TriggerType.ModifyDamageAmount }, TriggerTiming.Before);
             AddAfterLeavesPlayAction((GameAction ga) => ResetFlagAfterLeavesPlay(FirstTimeWouldBeDealtDamage), TriggerType.Hidden);
         }
 
         private bool DealDamageCritera(DealDamageAction dealDamageAction)
         {
             // "Once per turn, when {Gargoyle} deals or is dealt damage, or when a non-hero target is dealt damage, 
-            return !base.HasBeenSetToTrueThisTurn(FirstTimeWouldBeDealtDamage) && dealDamageAction.Amount > 0 && !dealDamageAction.IsPretend && ((dealDamageAction.DamageSource != null && dealDamageAction.DamageSource.Card != null && dealDamageAction.DamageSource.Card == base.CharacterCard) || dealDamageAction.Target == base.CharacterCard || !IsHero(dealDamageAction.Target));
+            return !HasBeenSetToTrueThisTurn(FirstTimeWouldBeDealtDamage) &&
+                dealDamageAction.Amount > 0 && 
+                (
+                    dealDamageAction.DamageSource?.Card == CharacterCard ||
+                    dealDamageAction.Target == CharacterCard ||
+                    ! IsHeroTarget(dealDamageAction.Target)
+                );
         }
 
-        private bool DealDamageTargetCriteria(Card card)
-        {
-            return card == base.CharacterCard || !IsHero(card);
-        }
         private IEnumerator DealDamageResponse(DealDamageAction dealDamageAction)
         {
-            IEnumerator coroutine;
-            ITrigger trigger = null;
-            YesNoDecision decision;
-           
-            decision = new YesNoDecision(base.GameController, DecisionMaker, SelectionType.ReduceDamageTaken, gameAction: dealDamageAction, cardSource: GetCardSource());
-            coroutine = base.GameController.MakeDecisionAction(decision);
-            if (base.UseUnityCoroutines)
+            if (!selectedReaction.HasValue || selectedReaction.Value.ddaGuid != dealDamageAction.InstanceIdentifier)
             {
-                yield return base.GameController.StartCoroutine(coroutine);
+                var storedResults = new List<YesNoCardDecision>();
+                var e = GameController.MakeYesNoCardDecision(
+                    DecisionMaker,
+                    SelectionType.ReduceDamageTaken,
+                    card: Card,
+                    action: dealDamageAction,
+                    storedResults: storedResults,
+                    cardSource: GetCardSource()
+                );
+
+                if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
+                else { GameController.ExhaustCoroutine(e); }
+
+                selectedReaction = new PreventInfo { preventDamage = DidPlayerAnswerYes(storedResults), ddaGuid = dealDamageAction.InstanceIdentifier };
             }
-            else
+
+            if (selectedReaction.HasValue && selectedReaction.Value.preventDamage)
             {
-                base.GameController.ExhaustCoroutine(coroutine);
-            }
+                SetCardPropertyToTrueIfRealAction(FirstTimeWouldBeDealtDamage, gameAction: dealDamageAction);
 
-            if (base.DidPlayerAnswerYes(decision))
-            { 
-                base.SetCardPropertyToTrueIfRealAction(FirstTimeWouldBeDealtDamage);
-                // you may reduce that damage by 1 
-                coroutine = base.GameController.ReduceDamage(dealDamageAction, 1, trigger, GetCardSource());
-                if (base.UseUnityCoroutines)
-                {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
-                }
+                var e = GameController.ReduceDamage(dealDamageAction, 1, null, GetCardSource());
+                if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
+                else { GameController.ExhaustCoroutine(e); }
 
-                // and increase the next damage dealt by {Gargoyle} by 1.
-                coroutine = base.IncreaseGargoyleNextDamage(1);
-                if (base.UseUnityCoroutines)
+                if (IsRealAction(dealDamageAction))
                 {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
+                    e = IncreaseGargoyleNextDamage(1, dealDamageAction);
+                    if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
+                    else { GameController.ExhaustCoroutine(e); }
                 }
             }
 
-
-            yield break;
+            if (IsRealAction(dealDamageAction))
+            {
+                selectedReaction = null;
+            }
         }
     }
 }

--- a/CauldronMods/Controller/Heroes/Gargoyle/Cards/LeechFieldCardController.cs
+++ b/CauldronMods/Controller/Heroes/Gargoyle/Cards/LeechFieldCardController.cs
@@ -84,7 +84,7 @@ namespace Cauldron.Gargoyle
 
                 if (IsRealAction(dealDamageAction))
                 {
-                    e = IncreaseGargoyleNextDamage(1, dealDamageAction);
+                    e = IncreaseGargoyleNextDamage(1, dealDamageAction.DamageSource.Card == CharacterCard ? dealDamageAction : null);
                     if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
                     else { GameController.ExhaustCoroutine(e); }
                 }

--- a/Testing/Heroes/GargoyleTests.cs
+++ b/Testing/Heroes/GargoyleTests.cs
@@ -1006,6 +1006,54 @@ namespace CauldronTests
         }
 
         [Test]
+        public void TestLeechFieldDamageInFlight()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Gargoyle", "VoidGuardMainstay", "InsulaPrimalis");
+            StartGame();
+
+            DestroyNonCharacterVillainCards();
+
+            PutIntoPlay("PreemptivePayback");
+
+            GoToPlayCardPhase(gargoyle);
+
+            var bladeBattalion = PutIntoPlay("BladeBattalion");
+            PutIntoPlay("LeechField");
+
+            DecisionSelectTarget = bladeBattalion;
+            DecisionsYesNo = new bool[] { false, true, true };
+            QuickHPStorage(bladeBattalion, voidMainstay.CharacterCard);
+            DealDamage(gargoyle.CharacterCard, voidMainstay.CharacterCard, 1, DamageType.Melee);
+            QuickHPCheck(-2, -2);
+        }
+
+        [Test]
+        public void TestLeechFieldAppliesToPreemptive()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Gargoyle/WastelandRoninGargoyleCharacter", "VoidGuardMainstay", "CaptainCosmic", "InsulaPrimalis");
+            StartGame();
+
+            DestroyNonCharacterVillainCards();
+
+            PutIntoPlay("PreemptivePayback");
+
+            GoToPlayCardPhase(gargoyle);
+
+            var bladeBattalion = PutIntoPlay("BladeBattalion");
+
+            DecisionSelectCard = gargoyle.CharacterCard;
+            var siphon = PutIntoPlay("DynamicSiphon");
+
+            PutIntoPlay("LeechField");
+
+            DecisionSelectTargets = new Card[] { siphon, bladeBattalion };
+            DecisionsYesNo = new bool[] { true, true };
+            QuickHPStorage(bladeBattalion, voidMainstay.CharacterCard);
+            DealDamage(gargoyle.CharacterCard, voidMainstay.CharacterCard, 2, DamageType.Melee);
+            QuickHPCheck(-3, -1);
+        }
+
+        [Test]
         public void TestLeechFieldOtherHeroDamaged()
         {
             Card bladeBattalion1;


### PR DESCRIPTION
In version 4.1, the SOTM engine now applies triggers created after a DealDamageAction is initiated but before it resolves to that DealDamageAction. One effect of this is that if Gargoyle has Leech Field in play, does damage to a target, and chooses to reduce his damage, the Leech Field increase is applied to the damage that was reduced.

This patch fixes that and adds a couple additional tests for interactions with Preemptive Payback raised with tosx on the Cauldron discord. It also cleans up the DDA flow a bit.

The workaround is to add an OnDealDamageStatusEffect that remembers the InstanceIdentifier of the DDA that triggered the Leech Field and does not act on that DDA.