### PR TITLE
Fix crash if vanish incap reveals the bottom card of an empty deck.

### DIFF
--- a/CauldronMods/Controller/Heroes/Vanish/CharacterCards/VanishCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Vanish/CharacterCards/VanishCharacterCardController.cs
@@ -97,21 +97,24 @@ namespace Cauldron.Vanish
                                 base.GameController.ExhaustCoroutine(coroutine);
                             }
 
-                            var card = revealedCards.First();
-                            var locations = new[]
+                            if (revealedCards.Any())
                             {
-                                new MoveCardDestination(card.NativeDeck, true, false),
-                                new MoveCardDestination(card.NativeDeck, false, true)
-                            };
+                                var card = revealedCards.First();
+                                var locations = new[]
+                                {
+                                        new MoveCardDestination(card.NativeDeck, true, false),
+                                        new MoveCardDestination(card.NativeDeck, false, true)
+                                    };
 
-                            coroutine = GameController.SelectLocationAndMoveCard(this.DecisionMaker, card, locations, cardSource: GetCardSource());
-                            if (base.UseUnityCoroutines)
-                            {
-                                yield return base.GameController.StartCoroutine(coroutine);
-                            }
-                            else
-                            {
-                                base.GameController.ExhaustCoroutine(coroutine);
+                                coroutine = GameController.SelectLocationAndMoveCard(this.DecisionMaker, card, locations, cardSource: GetCardSource());
+                                if (base.UseUnityCoroutines)
+                                {
+                                    yield return base.GameController.StartCoroutine(coroutine);
+                                }
+                                else
+                                {
+                                    base.GameController.ExhaustCoroutine(coroutine);
+                                }
                             }
                         }
                         break;

--- a/Testing/Heroes/VanishTests.cs
+++ b/Testing/Heroes/VanishTests.cs
@@ -193,6 +193,31 @@ namespace CauldronTests
         }
 
         [Test]
+        public void VanishIncap2_Empty()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Vanish", "Haka", "Bunker", "TheScholar", "Megalopolis");
+            StartGame();
+
+            DestroyCard("MobileDefensePlatform");
+            SetupIncap(baron);
+            AssertIncapacitated(vanish);
+
+            GoToUseIncapacitatedAbilityPhase(vanish);
+
+            MoveAllCards(haka, haka.HeroTurnTaker.Deck, haka.HeroTurnTaker.Hand);
+
+            AssertNumberOfCardsInDeck(haka, 0);
+
+            DecisionSelectLocation = new LocationChoice(haka.TurnTaker.Deck);
+            DecisionMoveCardDestination = new MoveCardDestination(haka.TurnTaker.Deck, false);
+
+            UseIncapacitatedAbility(vanish, 1);
+
+            AssertNumberOfCardsInRevealed(haka, 0);
+            AssertNumberOfCardsInDeck(haka, 0);
+        }
+
+        [Test]
         public void VanishIncap3()
         {
             SetupGameController("BaronBlade", "Cauldron.Vanish", "Ra", "TheWraith", "Megalopolis");


### PR DESCRIPTION
If Vanish's incap reveals the bottom card of an empty deck it throws. Fix by checking that there's revealed cards.