### PR TITLE
make tattoos under windcolor dendron not in play

### DIFF
--- a/CauldronMods/Controller/Villains/Dendron/CharacterCards/WindcolorDendronCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Dendron/CharacterCards/WindcolorDendronCharacterCardController.cs
@@ -55,6 +55,7 @@ namespace Cauldron.Dendron
                  * At the end of the villain turn, if there are no cards beneath this one, flip {Dendron}'s villain character cards.
                  * Otherwise, put 2 random cards from beneath this one into play
                  */
+                base.Card.UnderLocation.OverrideIsInPlay = false;
                 base.SideTriggers.Add(AddEndOfTurnTrigger(tt => tt == TurnTaker, FlipOrPlayFromBeneath, new[] { TriggerType.FlipCard, TriggerType.PutIntoPlay }));
             }
             // Flipped side (Colors of the Wind)
@@ -67,6 +68,7 @@ namespace Cauldron.Dendron
                  * Then, flip {Dendron}'s villain character cards.
                  * At the end of the villain turn, play the top card of the villain deck.
                  */
+                base.Card.UnderLocation.OverrideIsInPlay = null;
                 base.SideTriggers.Add(base.AddStartOfTurnTrigger(tt => tt == TurnTaker, DestroyOngoingToDealDamage, new[] { TriggerType.DestroyCard, TriggerType.DealDamage }));
                 base.SideTriggers.Add(base.AddTrigger<DestroyCardAction>(dca => dca.CardToDestroy != null && IsTattoo(dca.CardToDestroy.Card), MoveBeneathThisCard, TriggerType.MoveCard, TriggerTiming.Before));
                 base.SideTriggers.Add(base.AddStartOfTurnTrigger(tt => tt == TurnTaker && CharacterCard.UnderLocation.NumberOfCards >= 6, FlipBack, new[] { TriggerType.FlipCard, TriggerType.DealDamage }));

--- a/CauldronMods/Controller/Villains/Dendron/CharacterCards/WindcolorDendronCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Dendron/CharacterCards/WindcolorDendronCharacterCardController.cs
@@ -68,7 +68,7 @@ namespace Cauldron.Dendron
                  * Then, flip {Dendron}'s villain character cards.
                  * At the end of the villain turn, play the top card of the villain deck.
                  */
-                base.Card.UnderLocation.OverrideIsInPlay = null;
+                base.Card.UnderLocation.OverrideIsInPlay = false;
                 base.SideTriggers.Add(base.AddStartOfTurnTrigger(tt => tt == TurnTaker, DestroyOngoingToDealDamage, new[] { TriggerType.DestroyCard, TriggerType.DealDamage }));
                 base.SideTriggers.Add(base.AddTrigger<DestroyCardAction>(dca => dca.CardToDestroy != null && IsTattoo(dca.CardToDestroy.Card), MoveBeneathThisCard, TriggerType.MoveCard, TriggerTiming.Before));
                 base.SideTriggers.Add(base.AddStartOfTurnTrigger(tt => tt == TurnTaker && CharacterCard.UnderLocation.NumberOfCards >= 6, FlipBack, new[] { TriggerType.FlipCard, TriggerType.DealDamage }));

--- a/Testing/Villains/DendronVariantTests.cs
+++ b/Testing/Villains/DendronVariantTests.cs
@@ -11,6 +11,7 @@ using Handelabra.Sentinels.UnitTest;
 using Cauldron.Dendron;
 
 using NUnit.Framework;
+using Handelabra;
 
 namespace CauldronTests
 {
@@ -181,6 +182,32 @@ namespace CauldronTests
             var c2 = PlayCard("TintedStag");
             DealDamage(legacy, c2, 10, DamageType.Cold);
             AssertAtLocation(c2, dendron.CharacterCard.UnderLocation);
+       
+        }
+
+        [Test]
+        public void TestWindcolorFlippedDendronTattoosUnderAreNotInPlay()
+        {
+            // Arrange
+            SetupGameController(DeckNamespace, "Legacy", "Ra", "Haka", "Cauldron.TangoOne", "Megalopolis");
+            StartGame();
+
+
+            Card viper = dendron.CharacterCard.UnderLocation.Cards.First(c => c.Identifier == "PaintedViper");
+            Card owl = PlayCard("ShadedOwl");
+            Card ursa = PlayCard("UrsaMajor");
+            GoToPlayCardPhase(dendron);
+
+            MoveCards(tango, c => c.DoKeywordsContain("critical"), tango.HeroTurnTaker.Hand, numberOfCards: 2);
+            IEnumerable<Card> criticalCardsInHand = tango.HeroTurnTaker.Hand.Cards.Where(c => c.DoKeywordsContain("critical")).Take(2);
+            Card rifle = PlayCard("SniperRifle");
+
+            List<Card> decisionCards = new List<Card>();
+            decisionCards.AddRange(criticalCardsInHand);
+            decisionCards.Add(owl);
+            SkipDecisionsBeforeAssertion(1);
+            AssertNextDecisionChoices(notIncluded: new List<Card>(){ viper });
+            UsePower(rifle, 0);
         }
 
         [Test]


### PR DESCRIPTION
Closes #1617 

I've updated this under the literal assumption that cards under Windcolor Dendron are only not in play when Windcolor Dendron is on her front side. If this is not the case (pending tosx), this will need to be updated