### PR TITLE
Convert isHero to isHeroTarget where appropriate

### DIFF
--- a/CauldronMods/Controller/Environments/CatchwaterHarbor/Cards/SmoothCriminalCardController.cs
+++ b/CauldronMods/Controller/Environments/CatchwaterHarbor/Cards/SmoothCriminalCardController.cs
@@ -27,7 +27,7 @@ namespace Cauldron.CatchwaterHarbor
         private IEnumerator DealDamageResponse(PhaseChangeAction pca)
         {
             //this card deals each hero target X projectile damage, where X is 1 plus the number of Transports in play.
-            IEnumerator coroutine = DealDamage(Card, (Card c) => IsHero(c), (Card c) => 1 + GetNumberOfTransportsInPlay(), DamageType.Projectile);
+            IEnumerator coroutine = DealDamage(Card, (Card c) => IsHeroTarget(c), (Card c) => 1 + GetNumberOfTransportsInPlay(), DamageType.Projectile);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/RovingSlimeCardController.cs
+++ b/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/RovingSlimeCardController.cs
@@ -45,7 +45,7 @@ namespace Cauldron.DungeonsOfTerror
             {
                 //If it is a fate card, this card deals the hero target with the highest HP {H-1} toxic damage
                 message = GameController.SendMessageAction($"The top card of the environment trash is a fate card!", Priority.High, GetCardSource(), associatedCards: cardToCheck.ToEnumerable(), showCardSource: true);
-                effect = DealDamageToHighestHP(Card, 1, (Card c) => IsHero(c), (Card c)=> Game.H -1, DamageType.Toxic);
+                effect = DealDamageToHighestHP(Card, 1, (Card c) => IsHeroTarget(c), (Card c)=> Game.H -1, DamageType.Toxic);
             }
             else if (storedResults.Any() && storedResults.First() == 0)
             {

--- a/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/StoneWardenCardController.cs
+++ b/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/StoneWardenCardController.cs
@@ -46,7 +46,7 @@ namespace Cauldron.DungeonsOfTerror
             {
                 //If it is a fate card, this card deals the hero target with the highest HP {H} melee damage.
                 message = GameController.SendMessageAction($"The top card of the environment trash is a fate card!", Priority.High, GetCardSource(), associatedCards: cardToCheck.ToEnumerable(), showCardSource: true);
-                effect = DealDamageToHighestHP(Card, 1, (Card c) => IsHero(c), (Card c) => Game.H, DamageType.Melee);
+                effect = DealDamageToHighestHP(Card, 1, (Card c) => IsHeroTarget(c), (Card c) => Game.H, DamageType.Melee);
             }
             else if (storedResults.Any() && storedResults.First() == 0)
             {

--- a/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/SuspiciousChestCardController.cs
+++ b/CauldronMods/Controller/Environments/DungeonsOfTerror/Cards/SuspiciousChestCardController.cs
@@ -45,7 +45,7 @@ namespace Cauldron.DungeonsOfTerror
             {
                 //If it is a fate card, this card deals the hero target with the highest HP {H-1} toxic damage
                 message = GameController.SendMessageAction($"The top card of the environment trash is a fate card!", Priority.High, GetCardSource(), associatedCards: cardToCheck.ToEnumerable(), showCardSource: true);
-                effect = DealDamageToHighestHP(Card, 1, (Card c) => IsHero(c), (Card c) => Game.H - 1, DamageType.Toxic);
+                effect = DealDamageToHighestHP(Card, 1, (Card c) => IsHeroTarget(c), (Card c) => Game.H - 1, DamageType.Toxic);
             }
             else if (storedResults.Any() && storedResults.First() == 0)
             {

--- a/CauldronMods/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdSirenCardController.cs
+++ b/CauldronMods/Controller/Environments/HalberdExperimentalResearchCenter/Cards/HalberdSirenCardController.cs
@@ -21,7 +21,7 @@ namespace Cauldron.HalberdExperimentalResearchCenter
         public override void AddTriggers()
         {
             //If there are no Chemical Triggers in play, the first time the hero target with the highest HP would be dealt damage each turn, redirect that damage to the villain target with the highest HP. 
-            base.AddFirstTimePerTurnRedirectTrigger((DealDamageAction dd) => !base.IsChemicalTriggerInPlay() && base.CanCardBeConsideredHighestHitPoints(dd.Target, (Card c) => c.IsTarget && IsHero(c) && c.IsInPlayAndHasGameText), FirstTimeHeroDamage, TargetType.HighestHP, (Card c) => IsVillainTarget(c));
+            base.AddFirstTimePerTurnRedirectTrigger((DealDamageAction dd) => !base.IsChemicalTriggerInPlay() && base.CanCardBeConsideredHighestHitPoints(dd.Target, (Card c) => IsHeroTarget(c) && c.IsInPlayAndHasGameText), FirstTimeHeroDamage, TargetType.HighestHP, (Card c) => IsVillainTarget(c));
 
             //Otherwise, the first time a non-hero target would be dealt damage each turn, redirect that damage to the hero target with the highest HP.
             base.AddFirstTimePerTurnRedirectTrigger((DealDamageAction dd) => base.IsChemicalTriggerInPlay() && !IsHeroTarget(dd.Target), FirstTimeNonHeroDamage, TargetType.HighestHP, (Card c) => IsHeroTarget(c) && c.IsInPlayAndHasGameText);

--- a/CauldronMods/Controller/Environments/NightloreCitadel/Cards/StarlightOfOrosCardController.cs
+++ b/CauldronMods/Controller/Environments/NightloreCitadel/Cards/StarlightOfOrosCardController.cs
@@ -17,7 +17,7 @@ namespace Cauldron.NightloreCitadel
         public override void AddTriggers()
         {
             //At the end of the environment turn, this card deals each hero target 2 infernal damage and each other environment target 2 psychic damage.
-            AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, (Card c) => GameController.IsCardVisibleToCardSource(c, GetCardSource()) && c.IsTarget && IsHero(c), TargetType.All, 2, DamageType.Infernal);
+            AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, (Card c) => GameController.IsCardVisibleToCardSource(c, GetCardSource()) && IsHeroTarget(c), TargetType.All, 2, DamageType.Infernal);
             AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, (Card c) => GameController.IsCardVisibleToCardSource(c, GetCardSource()) && c.IsEnvironmentTarget && c != Card, TargetType.All, 2, DamageType.Psychic);
             //Then, each villain target next to a Constellation regains {H} HP.
             AddEndOfTurnTrigger((TurnTaker tt) => tt == TurnTaker, VillainGainHPResponse, TriggerType.GainHP);

--- a/CauldronMods/Controller/Environments/StSimeonsCatacombs/Cards/CoalKidCardController.cs
+++ b/CauldronMods/Controller/Environments/StSimeonsCatacombs/Cards/CoalKidCardController.cs
@@ -17,7 +17,7 @@ namespace Cauldron.StSimeonsCatacombs
         public override void AddTriggers()
         {
             //At the end of the environment turn, this card deals each hero target 2 fire damage.
-            IEnumerator dealDamage = base.DealDamage(base.Card, (Card c) => c.IsTarget && IsHero(c), 2, DamageType.Fire);
+            IEnumerator dealDamage = base.DealDamage(base.Card, (Card c) => IsHeroTarget(c), 2, DamageType.Fire);
             base.AddEndOfTurnTrigger((TurnTaker tt) => tt == base.TurnTaker, (PhaseChangeAction pca) => dealDamage, TriggerType.DealDamage);
 
             //add unaffected triggers from GhostCardControllers

--- a/CauldronMods/Controller/Environments/TheChasmOfAThousandNights/Cards/IreOfTheDjinnCardController.cs
+++ b/CauldronMods/Controller/Environments/TheChasmOfAThousandNights/Cards/IreOfTheDjinnCardController.cs
@@ -26,7 +26,7 @@ namespace Cauldron.TheChasmOfAThousandNights
 
         private IEnumerator RedirectDamageResponse(DealDamageAction dealDamage)
         {
-            IEnumerator coroutine = RedirectDamage(dealDamage, TargetType.HighestHP, (Card c) => IsHero(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource()));
+            IEnumerator coroutine = RedirectDamage(dealDamage, TargetType.HighestHP, (Card c) => IsHeroTarget(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource()));
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Environments/TheChasmOfAThousandNights/Cards/MalevolentCardController.cs
+++ b/CauldronMods/Controller/Environments/TheChasmOfAThousandNights/Cards/MalevolentCardController.cs
@@ -28,7 +28,7 @@ namespace Cauldron.TheChasmOfAThousandNights
 
         private IEnumerator RedirectDamageResponse(DealDamageAction dealDamage)
         {
-            IEnumerator coroutine = RedirectDamage(dealDamage, TargetType.HighestHP, (Card c) => IsHero(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource()));
+            IEnumerator coroutine = RedirectDamage(dealDamage, TargetType.HighestHP, (Card c) => IsHeroTarget(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource()));
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Environments/TheWanderingIsle/Cards/TimedDetonatorCardController.cs
+++ b/CauldronMods/Controller/Environments/TheWanderingIsle/Cards/TimedDetonatorCardController.cs
@@ -40,7 +40,7 @@ namespace Cauldron.TheWanderingIsle
             }
 
             //deals each hero target {H - 2} fire damage
-            IEnumerator heroDamage = base.DealDamage(base.Card, (Card c) => c.IsTarget && IsHero(c) && c.IsInPlayAndHasGameText, base.H - 2, DamageType.Fire);
+            IEnumerator heroDamage = base.DealDamage(base.Card, (Card c) => IsHeroTarget(c) && c.IsInPlayAndHasGameText, base.H - 2, DamageType.Fire);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(heroDamage);

--- a/CauldronMods/Controller/Environments/WindmillCity/Cards/FramejobCardController.cs
+++ b/CauldronMods/Controller/Environments/WindmillCity/Cards/FramejobCardController.cs
@@ -43,7 +43,7 @@ namespace Cauldron.WindmillCity
         private IEnumerator RedirectResponderResponse(DealDamageAction dd)
         {
             List<Card> storedResults = new List<Card>();
-            IEnumerator coroutine = GameController.FindTargetWithHighestHitPoints(1, (Card c) => IsHero(c), storedResults, cardSource: GetCardSource());
+            IEnumerator coroutine = GameController.FindTargetWithHighestHitPoints(1, (Card c) => IsHeroTarget(c), storedResults, cardSource: GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Environments/WindmillCity/Cards/IronWaspCardController.cs
+++ b/CauldronMods/Controller/Environments/WindmillCity/Cards/IronWaspCardController.cs
@@ -23,7 +23,7 @@ namespace Cauldron.WindmillCity
         private IEnumerator DealDamageResponse(PhaseChangeAction pca)
         {
             //this card deals each hero target X melee damage, where X is the current HP of this card.
-            IEnumerator coroutine = DealDamage(Card, (Card c) => c.IsTarget && IsHero(c), (Card c) => Card.HitPoints, DamageType.Melee);
+            IEnumerator coroutine = DealDamage(Card, (Card c) => IsHeroTarget(c), (Card c) => Card.HitPoints, DamageType.Melee);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Baccarat/Cards/AceOfSaintsCardController.cs
+++ b/CauldronMods/Controller/Heroes/Baccarat/Cards/AceOfSaintsCardController.cs
@@ -18,7 +18,7 @@ namespace Cauldron.Baccarat
         protected override ITrigger EffectTrigger()
         {
             //Reduce damage dealt to hero targets by 1.
-            return base.AddReduceDamageTrigger((Card c) => IsHero(c), 1);
+            return base.AddReduceDamageTrigger((Card c) => IsHeroTarget(c), 1);
         }
     }
 }

--- a/CauldronMods/Controller/Heroes/Baccarat/Cards/AllInCardController.cs
+++ b/CauldronMods/Controller/Heroes/Baccarat/Cards/AllInCardController.cs
@@ -41,7 +41,7 @@ namespace Cauldron.Baccarat
 
                     //...and 1 radiant damage.
                     new DealDamageAction(base.GetCardSource(), new DamageSource(base.GameController, base.CharacterCard), null, 1, DamageType.Radiant)
-                }, (Card c) => !IsHero(c));
+                }, (Card c) => !IsHeroTarget(c));
             }
             else
             {

--- a/CauldronMods/Controller/Heroes/Cricket/Cards/AcousticDistortionCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cricket/Cards/AcousticDistortionCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.Cricket
         {
             //Once per turn when a hero target would be dealt damage, you may redirect that damage to another hero target.
             List<SelectCardDecision> storedResults = new List<SelectCardDecision>();
-            IEnumerator coroutine = base.GameController.SelectTargetAndRedirectDamage(base.HeroTurnTakerController, (Card c) => IsHero(c) && c != action.Target, action, true, storedResults, base.GetCardSource());
+            IEnumerator coroutine = base.GameController.SelectTargetAndRedirectDamage(base.HeroTurnTakerController, (Card c) => IsHeroTarget(c) && c != action.Target, action, true, storedResults, base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Cricket/Cards/InfrasonicCollapseCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cricket/Cards/InfrasonicCollapseCardController.cs
@@ -48,7 +48,7 @@ namespace Cauldron.Cricket
                 if (destroyedCard.IsEnvironment)
                 {
                     //If you destroyed an environment card this way, {Cricket} deals each non-hero target 1 sonic damage.
-                    coroutine = base.DealDamage(base.CharacterCard, (Card c) => !IsHero(c), 1, DamageType.Sonic);
+                    coroutine = base.DealDamage(base.CharacterCard, (Card c) => !IsHeroTarget(c), 1, DamageType.Sonic);
                     if (base.UseUnityCoroutines)
                     {
                         yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Cricket/Cards/ReturnPulseCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cricket/Cards/ReturnPulseCardController.cs
@@ -18,7 +18,7 @@ namespace Cauldron.Cricket
         {
             List<DealDamageAction> targets = new List<DealDamageAction>();
             //{Cricket} deals up to 3 non-hero targets 1 sonic damage each.
-            IEnumerator coroutine = base.GameController.SelectTargetsAndDealDamage(base.HeroTurnTakerController, new DamageSource(base.GameController, base.CharacterCard), 1, DamageType.Sonic, 3, false, 0, additionalCriteria: (Card c) => !IsHero(c), storedResultsDamage: targets, cardSource: base.GetCardSource());
+            IEnumerator coroutine = base.GameController.SelectTargetsAndDealDamage(base.HeroTurnTakerController, new DamageSource(base.GameController, base.CharacterCard), 1, DamageType.Sonic, 3, false, 0, additionalCriteria: (Card c) => !IsHeroTarget(c), storedResultsDamage: targets, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Cypher/Cards/CyberdefenseCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cypher/Cards/CyberdefenseCardController.cs
@@ -41,7 +41,7 @@ namespace Cauldron.Cypher
 
             // Cypher deals each non-hero target X lightning damage, where X equals the number of cards destroyed this way.
             int damageAmount = storedResults.Count((DestroyCardAction dc) => dc.WasCardDestroyed);
-            routine = base.GameController.DealDamage(this.HeroTurnTakerController, this.CharacterCard, c => !IsHero(c),
+            routine = base.GameController.DealDamage(this.HeroTurnTakerController, this.CharacterCard, c => !IsHeroTarget(c),
                 damageAmount, DamageType.Lightning, cardSource: base.GetCardSource());
 
             if (base.UseUnityCoroutines)

--- a/CauldronMods/Controller/Heroes/DocHavoc/Cards/BrawlerCardController.cs
+++ b/CauldronMods/Controller/Heroes/DocHavoc/Cards/BrawlerCardController.cs
@@ -29,7 +29,7 @@ namespace Cauldron.DocHavoc
             List<SelectCardDecision> storedResults = new List<SelectCardDecision>();
 
             IEnumerator selectCardRoutine = base.GameController.SelectCardAndStoreResults(base.HeroTurnTakerController, SelectionType.SelectTargetNoDamage,
-                new LinqCardCriteria((Card c) => c.IsTarget && !IsHero(c) && c.IsInPlayAndHasGameText, "non-hero targets in play"),
+                new LinqCardCriteria((Card c) => c.IsTarget && !IsHeroTarget(c) && c.IsInPlayAndHasGameText, "non-hero targets in play"),
                 storedResults, false, cardSource: base.GetCardSource());
 
             if (base.UseUnityCoroutines)

--- a/CauldronMods/Controller/Heroes/DocHavoc/CharacterCards/DocHavocCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/DocHavoc/CharacterCards/DocHavocCharacterCardController.cs
@@ -127,7 +127,7 @@ namespace Cauldron.DocHavoc
             // Up to 3 hero targets regain 1 HP each.
             //==============================================================
 
-            return this.GameController.SelectAndGainHP(this.DecisionMaker, 1, additionalCriteria: ((Func<Card, bool>)(c => IsHero(c))),
+            return this.GameController.SelectAndGainHP(this.DecisionMaker, 1, additionalCriteria: ((Func<Card, bool>)(c => IsHeroTarget(c))),
                 numberOfTargets: 3, requiredDecisions: new int?(0), cardSource: this.GetCardSource());
         }
 

--- a/CauldronMods/Controller/Heroes/Drift/Cards/ThrowingShardCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/Cards/ThrowingShardCardController.cs
@@ -72,7 +72,7 @@ namespace Cauldron.Drift
 						{
 							int damageNumeral = base.GetPowerNumeral(2, 1);
 							//{Drift} deals each non-hero target 1 radiant damage. 
-							coroutine = base.DealDamage(base.GetActiveCharacterCard(), (Card c) => !IsHero(c), damageNumeral, DamageType.Radiant);
+							coroutine = base.DealDamage(base.GetActiveCharacterCard(), (Card c) => !IsHeroTarget(c), damageNumeral, DamageType.Radiant);
 							if (base.UseUnityCoroutines)
 							{
 								yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Echelon/Cards/AdvanceAndRegroupCardController.cs
+++ b/CauldronMods/Controller/Heroes/Echelon/Cards/AdvanceAndRegroupCardController.cs
@@ -27,7 +27,7 @@ namespace Cauldron.Echelon
         protected override void AddTacticEffectTrigger()
         {
             // Whenever a non-hero target is destroyed, 1 hero target regains 2HP.
-            base.AddTrigger<DestroyCardAction>(dca => dca.WasCardDestroyed && !IsHero(dca.CardToDestroy.Card) 
+            base.AddTrigger<DestroyCardAction>(dca => dca.WasCardDestroyed && !IsHeroTarget(dca.CardToDestroy.Card) 
                             && dca.CardToDestroy.Card.IsTarget && base.GameController.IsCardVisibleToCardSource(dca.CardToDestroy.Card, GetCardSource()),
                 this.DestroyNonHeroTargetResponse,
                 new[]

--- a/CauldronMods/Controller/Heroes/Echelon/Cards/RuthlessIntimidationCardController.cs
+++ b/CauldronMods/Controller/Heroes/Echelon/Cards/RuthlessIntimidationCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.Echelon
         protected override void AddTacticEffectTrigger()
         {
             //Increase damage dealt to the non-hero target with the lowest HP by 1.
-            AddTrigger((DealDamageAction dd) => !IsHero(dd.Target) && CanCardBeConsideredLowestHitPoints(dd.Target, (Card c) => !IsHero(c)), MaybeIncreaseDamageResponse, TriggerType.IncreaseDamage, TriggerTiming.Before);
+            AddTrigger((DealDamageAction dd) => !IsHeroTarget(dd.Target) && CanCardBeConsideredLowestHitPoints(dd.Target, (Card c) => !IsHero(c)), MaybeIncreaseDamageResponse, TriggerType.IncreaseDamage, TriggerTiming.Before);
         }
 
         private IEnumerator MaybeIncreaseDamageResponse(DealDamageAction dd)

--- a/CauldronMods/Controller/Heroes/Echelon/Cards/TeslaKnucklesCardController.cs
+++ b/CauldronMods/Controller/Heroes/Echelon/Cards/TeslaKnucklesCardController.cs
@@ -38,7 +38,7 @@ namespace Cauldron.Echelon
             int numDamage = GetPowerNumeral(0, 1);
 
             //Power: "{Echelon} deals each non-hero target 1 lightning damage."
-            IEnumerator coroutine = DealDamage(CharacterCard, (Card c) => !IsHero(c), numDamage, DamageType.Lightning);
+            IEnumerator coroutine = DealDamage(CharacterCard, (Card c) => !IsHeroTarget(c), numDamage, DamageType.Lightning);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Gyrosaur/Cards/IndiscriminatePassCardController.cs
+++ b/CauldronMods/Controller/Heroes/Gyrosaur/Cards/IndiscriminatePassCardController.cs
@@ -32,7 +32,7 @@ namespace Cauldron.Gyrosaur
             if(TrueCrashInHand + crashMod > 0)
             {
                 //...{Gyrosaur} deals another hero target 2 melee damage.
-                coroutine = GameController.SelectTargetsAndDealDamage(DecisionMaker, new DamageSource(GameController, CharacterCard), 2, DamageType.Melee, 1, false, 1, additionalCriteria: (Card c) => IsHero(c) && c != CharacterCard, cardSource: GetCardSource());
+                coroutine = GameController.SelectTargetsAndDealDamage(DecisionMaker, new DamageSource(GameController, CharacterCard), 2, DamageType.Melee, 1, false, 1, additionalCriteria: (Card c) => IsHeroTarget(c) && c != CharacterCard, cardSource: GetCardSource());
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);
@@ -44,7 +44,7 @@ namespace Cauldron.Gyrosaur
             }
 
             //"{Gyrosaur} deals 1 non-hero target 4 melee damage."
-            coroutine = GameController.SelectTargetsAndDealDamage(DecisionMaker, new DamageSource(GameController, CharacterCard), 4, DamageType.Melee, 1, false, 1, additionalCriteria: (Card c) => !IsHero(c), cardSource: GetCardSource());
+            coroutine = GameController.SelectTargetsAndDealDamage(DecisionMaker, new DamageSource(GameController, CharacterCard), 4, DamageType.Melee, 1, false, 1, additionalCriteria: (Card c) => !IsHeroTarget(c), cardSource: GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Gyrosaur/Cards/OnARollCardController.cs
+++ b/CauldronMods/Controller/Heroes/Gyrosaur/Cards/OnARollCardController.cs
@@ -56,7 +56,7 @@ namespace Cauldron.Gyrosaur
                 }
 
                 //...{Gyrosaur} deals each non-hero target 1 melee damage...
-                coroutine = DealDamage(CharacterCard, (Card c) => !IsHero(c), 1, DamageType.Melee);
+                coroutine = DealDamage(CharacterCard, (Card c) => !IsHeroTarget(c), 1, DamageType.Melee);
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Gyrosaur/Cards/TerrifyingMomentumCardController.cs
+++ b/CauldronMods/Controller/Heroes/Gyrosaur/Cards/TerrifyingMomentumCardController.cs
@@ -34,7 +34,7 @@ namespace Cauldron.Gyrosaur
             //"If X is more than 4, redirect this damage to the non-hero target with the lowest HP.",
             if(TrueCrashInHand + crashMod > 4)
             {
-                AddToTemporaryTriggerList(AddTrigger((DealDamageAction dd) => dd.CardSource.Card == Card, dd => RedirectDamage(dd, TargetType.LowestHP, (Card c) => !IsHero(c)), TriggerType.RedirectDamage, TriggerTiming.Before));
+                AddToTemporaryTriggerList(AddTrigger((DealDamageAction dd) => dd.CardSource.Card == Card, dd => RedirectDamage(dd, TargetType.LowestHP, (Card c) => !IsHeroTarget(c)), TriggerType.RedirectDamage, TriggerTiming.Before));
             }
 
             //"{Gyrosaur} deals 1 target X+2 melee damage",

--- a/CauldronMods/Controller/Heroes/Impact/Cards/RepulsionFieldCardController.cs
+++ b/CauldronMods/Controller/Heroes/Impact/Cards/RepulsionFieldCardController.cs
@@ -16,7 +16,7 @@ namespace Cauldron.Impact
         public override IEnumerator Play()
         {
             //"When this card enters play, {Impact} deals each non-hero target 1 energy damage.",
-            IEnumerator coroutine = DealDamage(this.CharacterCard, (Card c) => !IsHero(c), 1, DamageType.Energy);
+            IEnumerator coroutine = DealDamage(this.CharacterCard, (Card c) => !IsHeroTarget(c), 1, DamageType.Energy);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Impact/CharacterCards/ImpactCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Impact/CharacterCards/ImpactCharacterCardController.cs
@@ -186,7 +186,7 @@ namespace Cauldron.Impact
                     {
                         //"Select a hero target. That target deals 1 other target 1 projectile damage.",
                         var storedTarget = new List<SelectCardDecision> { };
-                        coroutine = GameController.SelectCardAndStoreResults(DecisionMaker, SelectionType.CardToDealDamage, new LinqCardCriteria(c => c.IsInPlayAndHasGameText && c.IsTarget && IsHero(c)), storedTarget, false, cardSource: GetCardSource());
+                        coroutine = GameController.SelectCardAndStoreResults(DecisionMaker, SelectionType.CardToDealDamage, new LinqCardCriteria(c => c.IsInPlayAndHasGameText && IsHeroTarget(c)), storedTarget, false, cardSource: GetCardSource());
                         if (base.UseUnityCoroutines)
                         {
                             yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/MagnificentMara/CardSubClasses/MaraUtilityCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/MagnificentMara/CardSubClasses/MaraUtilityCharacterCardController.cs
@@ -99,7 +99,7 @@ namespace Cauldron.MagnificentMara
 
                     //"one hero target (may deal damage...)"
                     var storedDamageSource = new List<SelectTargetDecision> { };
-                    var heroTargets = GameController.FindCardsWhere(new LinqCardCriteria((Card c) => c != null && c.IsTarget && IsHero(c) && c.IsInPlayAndHasGameText), visibleToCard: crystalSource);
+                    var heroTargets = GameController.FindCardsWhere(new LinqCardCriteria((Card c) => c != null && IsHeroTarget(c) && c.IsInPlayAndHasGameText), visibleToCard: crystalSource);
                     coroutine = GameController.SelectTargetAndStoreResults(DecisionMaker, heroTargets, storedDamageSource, damageAmount: (Card c) => numDamage, selectionType: SelectionType.HeroToDealDamage, cardSource: crystalSource);
                     if (base.UseUnityCoroutines)
                     {
@@ -138,7 +138,7 @@ namespace Cauldron.MagnificentMara
 
                         //"deal a non-hero target 2 damage"
 
-                        coroutine = GameController.SelectTargetsAndDealDamage(DecisionMaker, new DamageSource(GameController, damageSource), numDamage, selectedDamage, 1, false, 1, additionalCriteria:((Card c) => !IsHero(c)), cardSource: crystalSource);
+                        coroutine = GameController.SelectTargetsAndDealDamage(DecisionMaker, new DamageSource(GameController, damageSource), numDamage, selectedDamage, 1, false, 1, additionalCriteria:((Card c) => !IsHeroTarget(c)), cardSource: crystalSource);
                         if (UseUnityCoroutines)
                         {
                             yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Malichae/Cards/GrandEzaelCardController.cs
+++ b/CauldronMods/Controller/Heroes/Malichae/Cards/GrandEzaelCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.Malichae
             CardSource cs = GetCardSourceForGrantedPower();
             var card = cs.Card;
 
-            var coroutine = base.GameController.GainHP(DecisionMaker, c => c.IsTarget && IsHero(c) && c.IsInPlayAndHasGameText, hp, cardSource: cs);
+            var coroutine = base.GameController.GainHP(DecisionMaker, c => IsHeroTarget(c) && c.IsInPlayAndHasGameText, hp, cardSource: cs);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Malichae/Cards/GrandReshielCardController.cs
+++ b/CauldronMods/Controller/Heroes/Malichae/Cards/GrandReshielCardController.cs
@@ -53,7 +53,7 @@ namespace Cauldron.Malichae
             }
             var coroutine = GameController.SelectTargetsAndDealDamage(DecisionMaker, new DamageSource(GameController, dmgSource), damages, DamageType.Sonic, null, false, null,
                 allowAutoDecide: true,
-                additionalCriteria: c => c.IsInPlay && !IsHero(c),
+                additionalCriteria: c => c.IsInPlay && !IsHeroTarget(c),
                 cardSource: cs);
             if (base.UseUnityCoroutines)
             {

--- a/CauldronMods/Controller/Heroes/Malichae/Cards/HighEzaelCardController.cs
+++ b/CauldronMods/Controller/Heroes/Malichae/Cards/HighEzaelCardController.cs
@@ -46,7 +46,7 @@ namespace Cauldron.Malichae
             CardSource cs = GetCardSourceForGrantedPower();
             var card = cs.Card;
 
-            var coroutine = base.GameController.GainHP(DecisionMaker, c => c.IsTarget && c.IsInPlayAndHasGameText && (IsHero(c) || IsDjinn(c)), c => IsDjinn(c) ? djinnHP : otherHP, cardSource: cs);
+            var coroutine = base.GameController.GainHP(DecisionMaker, c => c.IsTarget && c.IsInPlayAndHasGameText && (IsHeroTarget(c) || IsDjinn(c)), c => IsDjinn(c) ? djinnHP : otherHP, cardSource: cs);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Necro/CharacterCards/PastNecroCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Necro/CharacterCards/PastNecroCharacterCardController.cs
@@ -64,7 +64,7 @@ namespace Cauldron.Necro
                 case 0:
                     {
                         //One hero target deals itself 3 toxic damage.
-                        IEnumerable<Card> choices = FindCardsWhere((Card c) => c.IsInPlayAndNotUnderCard && c.IsTarget && IsHero(c));
+                        IEnumerable<Card> choices = FindCardsWhere((Card c) => c.IsInPlayAndNotUnderCard && IsHeroTarget(c));
                         List<SelectCardDecision> storedResults = new List<SelectCardDecision>();
                         var damageInfo = new DealDamageAction(GetCardSource(), new DamageSource(GameController, TurnTaker), null, 3, DamageType.Toxic);
                         IEnumerator coroutine = base.GameController.SelectCardAndStoreResults(DecisionMaker, SelectionType.DealDamageSelf, choices, storedResults,

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/ContainmentBreachCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/ContainmentBreachCardController.cs
@@ -126,7 +126,7 @@ namespace Cauldron.Pyre
                 GameController.ExhaustCoroutine(coroutine);
             }
 
-            coroutine = DealDamage(CharacterCard, (Card c) => !IsHero(c), numDamage, DamageType.Energy);
+            coroutine = DealDamage(CharacterCard, (Card c) => !IsHeroTarget(c), numDamage, DamageType.Energy);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/GammaBurstCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/GammaBurstCardController.cs
@@ -45,7 +45,7 @@ namespace Cauldron.Pyre
                     GameController.ExhaustCoroutine(coroutine);
                 }
 
-                coroutine = DealDamage(CharacterCard, (Card c) => !IsHero(c), numCardsIrradiated, DamageType.Energy);
+                coroutine = DealDamage(CharacterCard, (Card c) => !IsHeroTarget(c), numCardsIrradiated, DamageType.Energy);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/HalfLifeCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/HalfLifeCardController.cs
@@ -62,7 +62,7 @@ namespace Cauldron.Pyre
                 GameController.ExhaustCoroutine(coroutine);
             }
             //"{Pyre} deals each non-hero target 0 energy damage."
-            coroutine = DealDamage(CharacterCard, (Card c) => !IsHero(c), 0, DamageType.Energy);
+            coroutine = DealDamage(CharacterCard, (Card c) => !IsHeroTarget(c), 0, DamageType.Energy);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/IonTraceCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/IonTraceCardController.cs
@@ -29,7 +29,7 @@ namespace Cauldron.Pyre
                 GameController.ExhaustCoroutine(coroutine);
             }
             //"{Pyre} deals each non-hero target 0 energy damage."
-            coroutine = DealDamage(CharacterCard, (Card c) => !IsHero(c), 0, DamageType.Energy);
+            coroutine = DealDamage(CharacterCard, (Card c) => !IsHeroTarget(c), 0, DamageType.Energy);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/NeutronForcefieldCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/NeutronForcefieldCardController.cs
@@ -46,7 +46,7 @@ namespace Cauldron.Pyre
         public override IEnumerator UsePower(int index = 0)
         {
             //"Select a hero target. Until the start of your next turn, that target is immune to damage. Destroy this card."
-            var decision = new SelectCardDecision(GameController, DecisionMaker, SelectionType.PreventDamage, GameController.GetAllCards().Where((Card c) => c.IsInPlayAndHasGameText && c.IsTarget && IsHero(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource())), cardSource: GetCardSource());
+            var decision = new SelectCardDecision(GameController, DecisionMaker, SelectionType.PreventDamage, GameController.GetAllCards().Where((Card c) => c.IsInPlayAndHasGameText && IsHeroTarget(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource())), cardSource: GetCardSource());
             IEnumerator coroutine = GameController.SelectCardAndDoAction(decision, AddDamageImmunityEffect);
             if (UseUnityCoroutines)
             {

--- a/CauldronMods/Controller/Heroes/Pyre/CharacterCards/PyreCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CharacterCards/PyreCharacterCardController.cs
@@ -119,7 +119,7 @@ namespace Cauldron.Pyre
                 case 1:
                     {
                         //"One hero target deals each target 1 energy damage.",
-                        var heroTargets = GameController.GetAllCards().Where((Card c) => c.IsInPlayAndHasGameText && c.IsTarget && IsHero(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource()));
+                        var heroTargets = GameController.GetAllCards().Where((Card c) => c.IsInPlayAndHasGameText && IsHeroTarget(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource()));
                         var storedTarget = new List<SelectTargetDecision>();
                         coroutine = GameController.SelectTargetAndStoreResults(DecisionMaker, heroTargets, storedTarget, damageAmount: c => 1, damageType: DamageType.Energy, selectionType: SelectionType.CardToDealDamage, cardSource: GetCardSource());
                         if (UseUnityCoroutines)

--- a/CauldronMods/Controller/Heroes/Quicksilver/Cards/AlloyStormCardController.cs
+++ b/CauldronMods/Controller/Heroes/Quicksilver/Cards/AlloyStormCardController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.Quicksilver
         public override IEnumerator Play()
         {
             //{Quicksilver} deals each non-hero target 1 projectile damage.
-            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card c) => !IsHero(c), 1, DamageType.Projectile);
+            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card c) => !IsHeroTarget(c), 1, DamageType.Projectile);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Starlight/Cards/CelestialAuraCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/Cards/CelestialAuraCardController.cs
@@ -11,7 +11,7 @@ namespace Cauldron.Starlight
     {
         public CelestialAuraCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => c.IsTarget && IsHero(c) && IsNextToConstellation(c), useCardsSuffix: false, singular: "hero target next to a constellation", plural:"hero targets next to a constellation"));
+            SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => IsHeroTarget(c) && IsNextToConstellation(c), useCardsSuffix: false, singular: "hero target next to a constellation", plural:"hero targets next to a constellation"));
         }
 
         public override void AddTriggers()

--- a/CauldronMods/Controller/Heroes/Starlight/Cards/WarpHaloCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/Cards/WarpHaloCardController.cs
@@ -9,8 +9,8 @@ namespace Cauldron.Starlight
     {
         public WarpHaloCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => c.IsTarget && IsHero(c) && IsNextToConstellation(c), useCardsSuffix: false, singular: "hero target next to a constellation", plural: "hero targets next to a constellation"));
-            SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => c.IsTarget && !IsHero(c) && IsNextToConstellation(c), useCardsSuffix: false, singular: "non-hero target next to a constellation", plural: "non-hero targets next to a constellation"));
+            SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => IsHeroTarget(c) && IsNextToConstellation(c), useCardsSuffix: false, singular: "hero target next to a constellation", plural: "hero targets next to a constellation"));
+            SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => c.IsTarget && !IsHeroTarget(c) && IsNextToConstellation(c), useCardsSuffix: false, singular: "non-hero target next to a constellation", plural: "non-hero targets next to a constellation"));
         }
 
         public override void AddTriggers()

--- a/CauldronMods/Controller/Heroes/Starlight/CharacterCards/GenesisStarlightCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/CharacterCards/GenesisStarlightCharacterCardController.cs
@@ -18,7 +18,7 @@ namespace Cauldron.Starlight
         {
             int damageNumeral = base.GetPowerNumeral(0, 1);
             //"Starlight deals each hero target 1 energy damage."
-            IEnumerator damageHeroes = DealDamage(this.Card, (Card c) => c.IsInPlayAndHasGameText && IsHero(c), damageNumeral, DamageType.Energy);
+            IEnumerator damageHeroes = DealDamage(this.Card, (Card c) => c.IsInPlayAndHasGameText && IsHeroTarget(c), damageNumeral, DamageType.Energy);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(damageHeroes);

--- a/CauldronMods/Controller/Heroes/TheStranger/CharacterCards/WastelandRoninTheStrangerCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheStranger/CharacterCards/WastelandRoninTheStrangerCharacterCardController.cs
@@ -65,7 +65,7 @@ namespace Cauldron.TheStranger
                     {
                         //One hero target deals 1 target 1 infernal damage.
                         List<SelectCardDecision> storedResults = new List<SelectCardDecision>();
-                        IEnumerator coroutine2 = base.GameController.SelectCardAndStoreResults(DecisionMaker, SelectionType.CardToDealDamage, new LinqCardCriteria((Card c) => c.IsInPlay && c.IsTarget && IsHero(c), "hero target"), storedResults, optional: false, cardSource: GetCardSource());
+                        IEnumerator coroutine2 = base.GameController.SelectCardAndStoreResults(DecisionMaker, SelectionType.CardToDealDamage, new LinqCardCriteria((Card c) => c.IsInPlay && IsHeroTarget(c), "hero target"), storedResults, optional: false, cardSource: GetCardSource());
                         if (base.UseUnityCoroutines)
                         {
                             yield return base.GameController.StartCoroutine(coroutine2);

--- a/CauldronMods/Controller/Heroes/Titan/Cards/HaplessShieldCardController.cs
+++ b/CauldronMods/Controller/Heroes/Titan/Cards/HaplessShieldCardController.cs
@@ -16,7 +16,7 @@ namespace Cauldron.Titan
 
         public override IEnumerator Play()
         {
-            IEnumerable<Card> choices = base.FindCardsWhere(new LinqCardCriteria((Card c) => c.IsInPlay && !IsHero(c) && c.IsTarget && GameController.IsCardVisibleToCardSource(c, GetCardSource()), "", false, singular: "non-hero target", plural:"non-hero targets"));
+            IEnumerable<Card> choices = base.FindCardsWhere(new LinqCardCriteria((Card c) => c.IsInPlay && !IsHeroTarget(c) && c.IsTarget && GameController.IsCardVisibleToCardSource(c, GetCardSource()), "", false, singular: "non-hero target", plural:"non-hero targets"));
             List<SelectTargetDecision> storedResults = new List<SelectTargetDecision>();
             //Select a non-hero target. 
             IEnumerator coroutine = base.GameController.SelectTargetAndStoreResults(base.HeroTurnTakerController, choices, storedResults, selectionType: SelectionType.None, cardSource: base.GetCardSource());
@@ -32,7 +32,7 @@ namespace Cauldron.Titan
             {
                 Card selectedTarget = storedResults.FirstOrDefault().SelectedCard;
                 //...Each other non-hero target deals that target 1 melee damage.
-                coroutine = base.DealDamage((Card c) => c != selectedTarget && c.IsInPlay && c.IsTarget && !IsHero(c), (Card c) => c == selectedTarget, (Card c) => new int?(1), DamageType.Melee);
+                coroutine = base.DealDamage((Card c) => c != selectedTarget && c.IsInPlay && c.IsTarget && !IsHeroTarget(c), (Card c) => c == selectedTarget, (Card c) => new int?(1), DamageType.Melee);
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Titan/Cards/PaybackTimeCardController.cs
+++ b/CauldronMods/Controller/Heroes/Titan/Cards/PaybackTimeCardController.cs
@@ -11,7 +11,7 @@ namespace Cauldron.Titan
     {
         public PaybackTimeCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            base.SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => !IsHero(c) && this.HasTargetDealtDamageToTitanSinceHisLastTurn(c), "non-hero targets who have dealt damge to Titan since the end of his last turn"));
+            base.SpecialStringMaker.ShowListOfCards(new LinqCardCriteria((Card c) => !IsHeroTarget(c) && this.HasTargetDealtDamageToTitanSinceHisLastTurn(c), "non-hero targets who have dealt damge to Titan since the end of his last turn"));
         }
 
         public override void AddTriggers()

--- a/CauldronMods/Controller/Heroes/Titan/Cards/StubbornGoliathCardController.cs
+++ b/CauldronMods/Controller/Heroes/Titan/Cards/StubbornGoliathCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.Titan
             int damageNumeral = base.GetPowerNumeral(1, 2);
 
             //{Titan} deals up to 2 non-hero targets 2 infernal damage each.
-            IEnumerator coroutine = base.GameController.SelectTargetsAndDealDamage(base.HeroTurnTakerController, new DamageSource(base.GameController, base.CharacterCard), damageNumeral, DamageType.Infernal, targetNumeral, false, 0, additionalCriteria: (Card c) => !IsHero(c), addStatusEffect: AddRedirectToSelfEffect, selectTargetsEvenIfCannotDealDamage: true, cardSource: base.GetCardSource());
+            IEnumerator coroutine = base.GameController.SelectTargetsAndDealDamage(base.HeroTurnTakerController, new DamageSource(base.GameController, base.CharacterCard), damageNumeral, DamageType.Infernal, targetNumeral, false, 0, additionalCriteria: (Card c) => !IsHeroTarget(c), addStatusEffect: AddRedirectToSelfEffect, selectTargetsEvenIfCannotDealDamage: true, cardSource: base.GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Vanish/Cards/TranslocationAcceleratorController.cs
+++ b/CauldronMods/Controller/Heroes/Vanish/Cards/TranslocationAcceleratorController.cs
@@ -20,7 +20,7 @@ namespace Cauldron.Vanish
         private IEnumerator UsePowerResponse(UsePowerAction action)
         {
             var coroutine = GameController.SelectTargetsAndDealDamage(DecisionMaker, new DamageSource(GameController, CharacterCard), 1, DamageType.Energy, 1, false, 0,
-                                additionalCriteria: c => !IsHero(c) && c.IsTarget && c.IsInPlayAndHasGameText,
+                                additionalCriteria: c => !IsHeroTarget(c) && c.IsTarget && c.IsInPlayAndHasGameText,
                                 cardSource: GetCardSource());
             if (this.UseUnityCoroutines)
             {

--- a/CauldronMods/Controller/Heroes/Vanish/CharacterCards/VanishCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Vanish/CharacterCards/VanishCharacterCardController.cs
@@ -124,7 +124,7 @@ namespace Cauldron.Vanish
                     {
                         //Select a hero target. Reduce damage dealt to that target by 1 till the start of your next turn"
                         List<SelectCardDecision> storedResults = new List<SelectCardDecision>();
-                        var coroutine = base.GameController.SelectCardAndStoreResults(this.DecisionMaker, SelectionType.SelectTargetFriendly, new LinqCardCriteria(c => c.IsInPlayAndHasGameText && c.IsTarget && IsHero(c), "hero target", false), storedResults, false, cardSource: base.GetCardSource());
+                        var coroutine = base.GameController.SelectCardAndStoreResults(this.DecisionMaker, SelectionType.SelectTargetFriendly, new LinqCardCriteria(c => c.IsInPlayAndHasGameText && IsHeroTarget(c), "hero target", false), storedResults, false, cardSource: base.GetCardSource());
                         if (base.UseUnityCoroutines)
                         {
                             yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Anathema/Cards/BiofeedbackCardController.cs
+++ b/CauldronMods/Controller/Villains/Anathema/Cards/BiofeedbackCardController.cs
@@ -22,7 +22,7 @@ namespace Cauldron.Anathema
             base.AddTrigger<DealDamageAction>(damageCriteria, this.DealDamageResponse, TriggerType.GainHP, TriggerTiming.After);
 
             //Whenever an arm, body, or head is destroyed by a Hero target, Anathema deals himself 2 psychic damage.
-            Func<DestroyCardAction, bool> destroyCriteria = (DestroyCardAction dca) => dca.CardToDestroy != null && base.IsArmHeadOrBody(dca.CardToDestroy.Card) && dca.WasDestroyedBy(c => c.IsTarget && IsHero(c));
+            Func<DestroyCardAction, bool> destroyCriteria = (DestroyCardAction dca) => dca.CardToDestroy != null && base.IsArmHeadOrBody(dca.CardToDestroy.Card) && dca.WasDestroyedBy(c => IsHeroTarget(c));
             base.AddTrigger<DestroyCardAction>(destroyCriteria, this.DestroyCardResponse, TriggerType.DealDamage, TriggerTiming.After);
         }
 

--- a/CauldronMods/Controller/Villains/Dendron/Cards/PaintedViperCardController.cs
+++ b/CauldronMods/Controller/Villains/Dendron/Cards/PaintedViperCardController.cs
@@ -32,7 +32,7 @@ namespace Cauldron.Dendron
         {
             //  At the end of the villain turn, this card deals the hero target with the lowest HP {H - 2} toxic damage.
             int damageToDeal = Game.H - 2;
-            IEnumerator dealDamageRoutine = DealDamageToLowestHP(Card, 1, (Card c) => IsHero(c), (Card c) => damageToDeal, DamageType.Toxic);
+            IEnumerator dealDamageRoutine = DealDamageToLowestHP(Card, 1, (Card c) => IsHeroTarget(c), (Card c) => damageToDeal, DamageType.Toxic);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(dealDamageRoutine);

--- a/CauldronMods/Controller/Villains/Dendron/Cards/StainedWolfCardController.cs
+++ b/CauldronMods/Controller/Villains/Dendron/Cards/StainedWolfCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.Dendron
 
             //  At the end of the villain turn,  this card deals the hero target with the highest HP {H - 1} melee damage.
             int damageToDeal = Game.H - 1;
-            IEnumerator dealDamageRoutine = DealDamageToHighestHP(Card, 1, (Card c) => IsHero(c), (Card c) => damageToDeal, DamageType.Melee);
+            IEnumerator dealDamageRoutine = DealDamageToHighestHP(Card, 1, (Card c) => IsHeroTarget(c), (Card c) => damageToDeal, DamageType.Melee);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(dealDamageRoutine);

--- a/CauldronMods/Controller/Villains/Dendron/Cards/UrsaMajorCardController.cs
+++ b/CauldronMods/Controller/Villains/Dendron/Cards/UrsaMajorCardController.cs
@@ -35,7 +35,7 @@ namespace Cauldron.Dendron
         private IEnumerator DealDamageResponse(PhaseChangeAction pca)
         {
            
-            IEnumerator dealDamageRoutine = DealDamageToHighestHP(Card, 1, (Card c) => IsHero(c), (Card c) => new int?(DamageToDeal), DamageType.Melee);
+            IEnumerator dealDamageRoutine = DealDamageToHighestHP(Card, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(DamageToDeal), DamageType.Melee);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(dealDamageRoutine);

--- a/CauldronMods/Controller/Villains/Dynamo/CharacterCards/DynamoCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Dynamo/CharacterCards/DynamoCharacterCardController.cs
@@ -131,7 +131,7 @@ namespace Cauldron.Dynamo
             }
 
             //...and {Dynamo} deals the hero target with the highest HP {H} energy damage.
-            coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => base.Game.H, DamageType.Energy);
+            coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => base.Game.H, DamageType.Energy);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Gray/Cards/ChainReactionCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/Cards/ChainReactionCardController.cs
@@ -12,7 +12,7 @@ namespace Cauldron.Gray
         public ChainReactionCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             base.SpecialStringMaker.ShowNumberOfCardsInPlay(new LinqCardCriteria((Card c) => c.DoKeywordsContain("radiation"), "radiation"));
-            base.SpecialStringMaker.ShowLowestHP(1, () => base.FindNumberOfRadiationCardsInPlay().Value, new LinqCardCriteria((Card c) => IsHero(c), "hero", true, false, "target", "targets"));
+            base.SpecialStringMaker.ShowLowestHP(1, () => base.FindNumberOfRadiationCardsInPlay().Value, new LinqCardCriteria((Card c) => IsHeroTarget(c), "hero", true, false, "target", "targets"));
             base.SpecialStringMaker.ShowListOfCardsAtLocation(base.TurnTaker.Trash, new LinqCardCriteria((Card c) => c.DoKeywordsContain("radiation"), "radiation"));
         }
 
@@ -22,7 +22,7 @@ namespace Cauldron.Gray
         {
             //At the start of the villain turn, this card deals the X hero targets with the lowest HP 1 energy damage each, where X is the number of Radiation cards in play.
             //This does not affect a dynamic number of targets because the DealDamageToLowestHP does not accept a dynamic number of targets
-            base.AddStartOfTurnTrigger((TurnTaker turnTaker) => turnTaker == base.TurnTaker, (PhaseChangeAction action) => this.DealDamageToLowestHP(this.Card, 1, (Card c) => IsHero(c), (Card c) => new int?(1), DamageType.Energy, numberOfTargets: this.FindNumberOfRadiationCardsInPlay() ?? default), TriggerType.DealDamage);
+            base.AddStartOfTurnTrigger((TurnTaker turnTaker) => turnTaker == base.TurnTaker, (PhaseChangeAction action) => this.DealDamageToLowestHP(this.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(1), DamageType.Energy, numberOfTargets: this.FindNumberOfRadiationCardsInPlay() ?? default), TriggerType.DealDamage);
 
             //At the end of the villain turn, put a random Radiation card from the villain trash into play.
             base.AddEndOfTurnTrigger((TurnTaker turnTaker) => turnTaker == base.TurnTaker, new Func<PhaseChangeAction, IEnumerator>(this.BringRadiationBackResponse), TriggerType.PutIntoPlay);

--- a/CauldronMods/Controller/Villains/Gray/Cards/IrradiatedTouchCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/Cards/IrradiatedTouchCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.Gray
             //At the end of the villain turn, {Gray} deals the hero target with the second highest HP {H - 2} melee and {H - 2} energy damage.
             base.AddEndOfTurnTrigger((TurnTaker turnTaker) => turnTaker == base.TurnTaker, DealDamageResponse, new TriggerType[] { TriggerType.DealDamage });
             //When this card is destroyed, {Gray} deals the hero target with the highest HP 2 energy damage.
-            base.AddWhenDestroyedTrigger((DestroyCardAction action) => base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => new int?(2), DamageType.Energy), TriggerType.DealDamage);
+            base.AddWhenDestroyedTrigger((DestroyCardAction action) => base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(2), DamageType.Energy), TriggerType.DealDamage);
         }
 
         private IEnumerator DealDamageResponse(PhaseChangeAction action)
@@ -29,7 +29,7 @@ namespace Cauldron.Gray
             {
                 new DealDamageAction(base.GetCardSource(),new DamageSource(base.GameController,base.CharacterCard),null,Game.H -2,DamageType.Melee),
                 new DealDamageAction(base.GetCardSource(),new DamageSource(base.GameController,base.CharacterCard),null,Game.H -2,DamageType.Energy)
-            }, (Card c) => IsHero(c), HighestLowestHP.HighestHP, 2);
+            }, (Card c) => IsHeroTarget(c), HighestLowestHP.HighestHP, 2);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Gray/Cards/MutatedWildlifeCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/Cards/MutatedWildlifeCardController.cs
@@ -27,7 +27,7 @@ namespace Cauldron.Gray
         private IEnumerator RedirectResponse(DealDamageAction action)
         {
             List<Card> storedResults = new List<Card>();
-            IEnumerator coroutine = base.GameController.FindTargetWithHighestHitPoints(1, (Card c) => IsHero(c), storedResults, cardSource: base.GetCardSource());
+            IEnumerator coroutine = base.GameController.FindTargetWithHighestHitPoints(1, (Card c) => IsHeroTarget(c), storedResults, cardSource: base.GetCardSource());
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Gray/Cards/NuclearFireCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/Cards/NuclearFireCardController.cs
@@ -16,9 +16,9 @@ namespace Cauldron.Gray
         public override IEnumerator Play()
         {
             //{Gray} deals the 2 hero targets with the highest HP {H - 1} energy damage each.
-            IEnumerator coroutine = DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => new int?(Game.H - 1), DamageType.Energy, numberOfTargets: () => 2);
+            IEnumerator coroutine = DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(Game.H - 1), DamageType.Energy, numberOfTargets: () => 2);
             //{Gray} deals the 2 hero targets with the lowest HP {H - 2} fire damage each.
-            IEnumerator coroutine2 = DealDamageToLowestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => new int?(Game.H - 2), DamageType.Fire, numberOfTargets: 2);
+            IEnumerator coroutine2 = DealDamageToLowestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(Game.H - 2), DamageType.Fire, numberOfTargets: 2);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Gray/Cards/UnwittingHenchmenCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/Cards/UnwittingHenchmenCardController.cs
@@ -44,7 +44,7 @@ namespace Cauldron.Gray
             else
             {
                 //...Otherwise this card deals the hero target with the highest HP 1 melee damage.
-                coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHero(c), (Card c) => 1, DamageType.Melee);
+                coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => 1, DamageType.Melee);
             }
             if (base.UseUnityCoroutines)
             {

--- a/CauldronMods/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Gray/CharacterCards/GrayCharacterCardController.cs
@@ -22,7 +22,7 @@ namespace Cauldron.Gray
                 //At the end of the villain turn, if there are 3 or more radiation cards in play, flip {Gray}'s villain character cards and destroy 1 environment card.
                 base.AddSideTrigger(base.AddEndOfTurnTrigger((TurnTaker turnTaker) => turnTaker == base.TurnTaker, FlipCardResponse, TriggerType.FlipCard, additionalCriteria: (PhaseChangeAction action) => this.FindNumberOfRadiationCardsInPlay() >= 3));
                 //At the end of the villain turn, {Gray} deals the hero target with the highest HP {H - 1} energy damage.
-                base.AddSideTrigger(base.AddDealDamageAtEndOfTurnTrigger(base.TurnTaker, base.Card, (Card c) => IsHero(c), TargetType.HighestHP, Game.H - 1, DamageType.Energy));
+                base.AddSideTrigger(base.AddDealDamageAtEndOfTurnTrigger(base.TurnTaker, base.Card, (Card c) => IsHeroTarget(c), TargetType.HighestHP, Game.H - 1, DamageType.Energy));
                 //Whenever a radiation card is destroyed, destroy 1 hero ongoing or equipment card and gray deals each non-villain target {H - 1} energy damage.
                 //Advanced - Whenever a radiation card is destroyed, destroy a second hero ongoing or equipment card.
                 base.AddSideTrigger(base.AddTrigger<DestroyCardAction>((DestroyCardAction action) => action.WasCardDestroyed && action.CardToDestroy.Card.DoKeywordsContain("radiation"), this.DestroyRadiationFrontResponse, new TriggerType[] { TriggerType.DestroyCard, TriggerType.DealDamage }, TriggerTiming.After));
@@ -180,7 +180,7 @@ namespace Cauldron.Gray
             }
 
             //...{Gray} deals each hero target {H x 2} energy damage.
-            coroutine = base.GameController.DealDamage(this.DecisionMaker, base.Card, (Card c) => IsHero(c), Game.H * 2, DamageType.Energy, cardSource: base.GetCardSource());
+            coroutine = base.GameController.DealDamage(this.DecisionMaker, base.Card, (Card c) => IsHeroTarget(c), Game.H * 2, DamageType.Energy, cardSource: base.GetCardSource());
             //...Play the top card of the villain deck.
             IEnumerator coroutine2 = base.GameController.PlayTopCardOfLocation(base.TurnTakerController, base.TurnTaker.Deck);
             if (base.UseUnityCoroutines)

--- a/CauldronMods/Controller/Villains/Menagerie/Cards/HalberdHiveCardController.cs
+++ b/CauldronMods/Controller/Villains/Menagerie/Cards/HalberdHiveCardController.cs
@@ -27,7 +27,7 @@ namespace Cauldron.Menagerie
         private IEnumerator DealDamageAndInsectResponse(PhaseChangeAction action)
         {
             //...this card deals the hero target with the lowest HP 2 toxic damage. 
-            IEnumerator coroutine = base.DealDamageToLowestHP(base.Card, 1, (Card c) => IsHero(c), (Card c) => 2, DamageType.Toxic);
+            IEnumerator coroutine = base.DealDamageToLowestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => 2, DamageType.Toxic);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Menagerie/Cards/HiredKeeperCardController.cs
+++ b/CauldronMods/Controller/Villains/Menagerie/Cards/HiredKeeperCardController.cs
@@ -9,7 +9,7 @@ namespace Cauldron.Menagerie
     {
         public HiredKeeperCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            SpecialStringMaker.ShowHighestHP(1, () => 2, new LinqCardCriteria(c => IsHero(c) && !IsCaptured(c.Owner), "non-captured hero targets", false));
+            SpecialStringMaker.ShowHighestHP(1, () => 2, new LinqCardCriteria(c => IsHeroTarget(c) && !IsCaptured(c.Owner), "non-captured hero targets", false));
         }
 
         public override void AddTriggers()
@@ -25,7 +25,7 @@ namespace Cauldron.Menagerie
         private IEnumerator DealDamageResponse(PhaseChangeAction action)
         {
             //...this card deals the 2 non-Captured hero targets with the highest HP 2 sonic damage each.
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => !base.IsCaptured(c.Owner) && IsHero(c), (Card c) => 2, DamageType.Sonic, numberOfTargets: () => 2);
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => !base.IsCaptured(c.Owner) && IsHeroTarget(c), (Card c) => 2, DamageType.Sonic, numberOfTargets: () => 2);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Menagerie/Cards/LumobatFlockCardController.cs
+++ b/CauldronMods/Controller/Villains/Menagerie/Cards/LumobatFlockCardController.cs
@@ -50,7 +50,7 @@ namespace Cauldron.Menagerie
             {
                 new DealDamageAction(base.GetCardSource(), new DamageSource(base.GameController, base.Card), null, 2, DamageType.Projectile),
                 new DealDamageAction(base.GetCardSource(), new DamageSource(base.GameController, base.Card), null, 2, DamageType.Radiant)
-            }, (Card c) => IsHero(c), HighestLowestHP.HighestHP);
+            }, (Card c) => IsHeroTarget(c), HighestLowestHP.HighestHP);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Menagerie/Cards/TakIshmaelCardController.cs
+++ b/CauldronMods/Controller/Villains/Menagerie/Cards/TakIshmaelCardController.cs
@@ -39,7 +39,7 @@ namespace Cauldron.Menagerie
             }
 
             //Then, this card deals the hero target with the highest HP X projectile damage, where X is the number of Specimens in play.
-            coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHero(c), (Card c) => base.FindCardsWhere(new LinqCardCriteria((Card spec) => base.IsSpecimen(spec) && spec.IsInPlayAndHasGameText)).Count(), DamageType.Projectile);
+            coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => base.FindCardsWhere(new LinqCardCriteria((Card spec) => base.IsSpecimen(spec) && spec.IsInPlayAndHasGameText)).Count(), DamageType.Projectile);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Menagerie/Cards/TheMonBeskmaHydricCardController.cs
+++ b/CauldronMods/Controller/Villains/Menagerie/Cards/TheMonBeskmaHydricCardController.cs
@@ -35,7 +35,7 @@ namespace Cauldron.Menagerie
             }
 
             //...and the hero target with the highest HP 2 melee damage.
-            coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHero(c), (Card c) => 2, DamageType.Melee);
+            coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => 2, DamageType.Melee);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Menagerie/Cards/ViewingAperturesCardController.cs
+++ b/CauldronMods/Controller/Villains/Menagerie/Cards/ViewingAperturesCardController.cs
@@ -48,7 +48,7 @@ namespace Cauldron.Menagerie
             }
 
             //{Menagerie} deals each hero, environment, and Specimen target 1 psychic damage.
-            coroutine = base.DealDamage(base.CharacterCard, (Card c) => IsHero(c) || c.IsEnvironmentTarget || base.IsSpecimen(c), 1, DamageType.Psychic);
+            coroutine = base.DealDamage(base.CharacterCard, (Card c) => IsHeroTarget(c) || c.IsEnvironmentTarget || base.IsSpecimen(c), 1, DamageType.Psychic);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Mythos/Cards/AclastyphWhoPeersCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/Cards/AclastyphWhoPeersCardController.cs
@@ -35,7 +35,7 @@ namespace Cauldron.Mythos
             if (base.IsTopCardMatching(MythosDangerDeckIdentifier))
             {
                 //{MythosDanger} This card deals the hero target with the highest HP 2 melee damage. 
-                coroutine = base.DealDamageToHighestHP(this.Card, 1, (Card c) => IsHero(c) && c.IsInPlayAndHasGameText, (Card c) => 2, DamageType.Melee);
+                coroutine = base.DealDamageToHighestHP(this.Card, 1, (Card c) => IsHeroTarget(c) && c.IsInPlayAndHasGameText, (Card c) => 2, DamageType.Melee);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Mythos/Cards/ClockworkRevenantCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/Cards/ClockworkRevenantCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.Mythos
         private IEnumerator DealDamageResponse(PhaseChangeAction action)
         {
             //...this card deals the hero target with the highest HP 2 melee damage.
-            IEnumerator coroutine = base.DealDamageToHighestHP(this.Card, 1, (Card c) => IsHero(c) && c.IsInPlayAndHasGameText, (Card c) => 2, DamageType.Melee);
+            IEnumerator coroutine = base.DealDamageToHighestHP(this.Card, 1, (Card c) => IsHeroTarget(c) && c.IsInPlayAndHasGameText, (Card c) => 2, DamageType.Melee);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Mythos/Cards/DangerousInvestigationCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/Cards/DangerousInvestigationCardController.cs
@@ -129,7 +129,7 @@ namespace Cauldron.Mythos
         private IEnumerator DealDamageResponse(PhaseChangeAction action)
         {
             //...{Mythos} deals the X hero targets with the highest HP 3 infernal damage each, where X is {H} minus the number of villain cards the players chose to play this turn.
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHero(c) && c.IsInPlayAndHasGameText, (Card c) => 3, DamageType.Infernal, numberOfTargets: () => base.Game.H - this.NumberOfCardsChosenThisTurn());
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c) && c.IsInPlayAndHasGameText, (Card c) => 3, DamageType.Infernal, numberOfTargets: () => base.Game.H - this.NumberOfCardsChosenThisTurn());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Mythos/Cards/FaithfulProselyteCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/Cards/FaithfulProselyteCardController.cs
@@ -40,7 +40,7 @@ namespace Cauldron.Mythos
         public override void AddTriggers()
         {
             //At the end of the villain turn, this card deals the hero target with the second highest HP {H - 1} lightning damage.
-            base.AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, (Card c) => IsHero(c), TargetType.HighestHP, Game.H - 1, DamageType.Lightning, highestLowestRanking: 2);
+            base.AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, (Card c) => IsHeroTarget(c), TargetType.HighestHP, Game.H - 1, DamageType.Lightning, highestLowestRanking: 2);
         }
 
     }

--- a/CauldronMods/Controller/Villains/Mythos/Cards/HallucinatedHorrorCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/Cards/HallucinatedHorrorCardController.cs
@@ -35,7 +35,7 @@ namespace Cauldron.Mythos
         public override void AddTriggers()
         {
             //At the end of the villain turn, this card deals each hero target 2 sonic damage.
-            base.AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, (Card c) => IsHero(c), TargetType.All, 2, DamageType.Sonic);
+            base.AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, (Card c) => IsHeroTarget(c), TargetType.All, 2, DamageType.Sonic);
             //Destroy this card when a hero is dealt damage by another hero target.
             base.AddTrigger<DealDamageAction>((DealDamageAction action) => action.DidDealDamage && IsHero(action.Target) && action.DamageSource != null && action.DamageSource.Card != null && action.DamageSource.IsHero && action.Target != action.DamageSource.Card, base.DestroyThisCardResponse, TriggerType.DestroySelf, TriggerTiming.After);
         }

--- a/CauldronMods/Controller/Villains/Mythos/Cards/OtherworldlyAlignmentCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/Cards/OtherworldlyAlignmentCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.Mythos
             if (base.IsTopCardMatching(MythosDangerDeckIdentifier))
             {
                 //{MythosDanger} {Mythos} deals the hero target with the highest HP {H} infernal damage.
-                coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => base.Game.H, DamageType.Infernal);
+                coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => base.Game.H, DamageType.Infernal);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);
@@ -57,7 +57,7 @@ namespace Cauldron.Mythos
             if (base.IsTopCardMatching(MythosClueDeckIdentifier))
             {
                 //{MythosClue} {Mythos} deals the hero target with the lowest HP {H} psychic damage
-                coroutine = base.DealDamageToLowestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => base.Game.H, DamageType.Psychic);
+                coroutine = base.DealDamageToLowestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => base.Game.H, DamageType.Psychic);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Mythos/Cards/RitualSiteCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/Cards/RitualSiteCardController.cs
@@ -27,7 +27,7 @@ namespace Cauldron.Mythos
         private IEnumerator MadnessDealDamageResponse(PhaseChangeAction action)
         {
             //...this card deals each hero target 1 psychic damage.
-            IEnumerator coroutine = base.DealDamage(this.Card, (Card c) => IsHero(c), 1, DamageType.Psychic);
+            IEnumerator coroutine = base.DealDamage(this.Card, (Card c) => IsHeroTarget(c), 1, DamageType.Psychic);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Mythos/Cards/WhispersAndLiesCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/Cards/WhispersAndLiesCardController.cs
@@ -50,7 +50,7 @@ namespace Cauldron.Mythos
                     damageSource = cardDecisions.FirstOrDefault().SelectedCard;
                 }
 
-                coroutine = base.DealDamageToHighestHP(damageSource, 1, (Card c) => IsHero(c), (Card c) => 2, DamageType.Sonic);
+                coroutine = base.DealDamageToHighestHP(damageSource, 1, (Card c) => IsHeroTarget(c), (Card c) => 2, DamageType.Sonic);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Mythos/CharacterCards/MythosCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Mythos/CharacterCards/MythosCharacterCardController.cs
@@ -138,7 +138,7 @@ namespace Cauldron.Mythos
             if (this.IsTopCardMatching((MythosMadnessDeckIdentifier)))
             {
                 //{MythosMadness} {Mythos} deals each hero target {H} infernal damage.
-                coroutine = base.DealDamage(this.Card, (Card c) => IsHero(c), base.Game.H, DamageType.Infernal);
+                coroutine = base.DealDamage(this.Card, (Card c) => IsHeroTarget(c), base.Game.H, DamageType.Infernal);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Oriphel/Cards/GrandOriphelCardController.cs
+++ b/CauldronMods/Controller/Villains/Oriphel/Cards/GrandOriphelCardController.cs
@@ -33,7 +33,7 @@ namespace Cauldron.Oriphel
                 new DealDamageAction(GetCardSource(), new DamageSource(GameController, oriphelIfInPlay), null, 1, DamageType.Projectile)
 
             };
-            IEnumerator coroutine = DealMultipleInstancesOfDamage(damageDetails, (Card c) => c.IsTarget && IsHero(c) && oriphelIfInPlay != null);
+            IEnumerator coroutine = DealMultipleInstancesOfDamage(damageDetails, (Card c) => IsHeroTarget(c) && oriphelIfInPlay != null);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Oriphel/Cards/HighDjarilCardController.cs
+++ b/CauldronMods/Controller/Villains/Oriphel/Cards/HighDjarilCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.Oriphel
             base.AddTriggers();
 
             //"At the end of the villain turn, this card deals the hero target with the highest HP {H} lightning damage.",
-            AddDealDamageAtEndOfTurnTrigger(TurnTaker, this.Card, (Card c) => IsHero(c), TargetType.HighestHP, H, DamageType.Lightning);
+            AddDealDamageAtEndOfTurnTrigger(TurnTaker, this.Card, (Card c) => IsHeroTarget(c), TargetType.HighestHP, H, DamageType.Lightning);
         }
     }
 }

--- a/CauldronMods/Controller/Villains/Oriphel/Cards/MejiNomadCardController.cs
+++ b/CauldronMods/Controller/Villains/Oriphel/Cards/MejiNomadCardController.cs
@@ -17,7 +17,7 @@ namespace Cauldron.Oriphel
         public override void AddTriggers()
         {
             //"At the end of the villain turn, this card deals the hero target with the highest HP X projectile damage, where X is the number of Guardians in play plus 2.",
-            AddDealDamageAtEndOfTurnTrigger(TurnTaker, this.Card, (Card c) => IsHero(c), TargetType.HighestHP, 2, DamageType.Projectile, dynamicAmount: NumberOfGuardiansPlusTwo);
+            AddDealDamageAtEndOfTurnTrigger(TurnTaker, this.Card, (Card c) => IsHeroTarget(c), TargetType.HighestHP, 2, DamageType.Projectile, dynamicAmount: NumberOfGuardiansPlusTwo);
         }
 
         private int? NumberOfGuardiansPlusTwo(Card irrelevant)

--- a/CauldronMods/Controller/Villains/Oriphel/Cards/MoonShardkeyCardController.cs
+++ b/CauldronMods/Controller/Villains/Oriphel/Cards/MoonShardkeyCardController.cs
@@ -25,7 +25,7 @@ namespace Cauldron.Oriphel
 
         private IEnumerator HighestDamagesHighestResponse(PhaseChangeAction pca)
         {
-            IEnumerator coroutine = DealDamageToHighestHP(null, 1, (Card c) => IsHero(c), (c) => 2, DamageType.Energy, damageSourceInfo: new TargetInfo(HighestLowestHP.HighestHP, 1, 1, new LinqCardCriteria((Card c) => IsVillainTarget(c), "The villain target with the highest HP")));
+            IEnumerator coroutine = DealDamageToHighestHP(null, 1, (Card c) => IsHeroTarget(c), (c) => 2, DamageType.Energy, damageSourceInfo: new TargetInfo(HighestLowestHP.HighestHP, 1, 1, new LinqCardCriteria((Card c) => IsVillainTarget(c), "The villain target with the highest HP")));
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Oriphel/Cards/ScrollsOfZephaerenCardController.cs
+++ b/CauldronMods/Controller/Villains/Oriphel/Cards/ScrollsOfZephaerenCardController.cs
@@ -50,7 +50,7 @@ namespace Cauldron.Oriphel
             //"If {Oriphel} is in play, he deals the hero target with the second lowest HP 3 melee damage."
             if (oriphelIfInPlay != null)
             {
-                coroutine = DealDamageToLowestHP(oriphelIfInPlay, 2, (Card c) => IsHero(c), (c) => 3, DamageType.Melee);
+                coroutine = DealDamageToLowestHP(oriphelIfInPlay, 2, (Card c) => IsHeroTarget(c), (c) => 3, DamageType.Melee);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Oriphel/Cards/ShardwalkersAwakeningCardController.cs
+++ b/CauldronMods/Controller/Villains/Oriphel/Cards/ShardwalkersAwakeningCardController.cs
@@ -53,7 +53,7 @@ namespace Cauldron.Oriphel
                 new DealDamageAction(GetCardSource(), new DamageSource(GameController, oriphelIfInPlay), null, 1, DamageType.Projectile)
 
             };
-            IEnumerator coroutine = DealMultipleInstancesOfDamage(damageDetails, (Card c) => c.IsTarget && IsHero(c) && oriphelIfInPlay != null);
+            IEnumerator coroutine = DealMultipleInstancesOfDamage(damageDetails, (Card c) => IsHeroTarget(c) && oriphelIfInPlay != null);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Oriphel/Cards/WorldShardkeyCardController.cs
+++ b/CauldronMods/Controller/Villains/Oriphel/Cards/WorldShardkeyCardController.cs
@@ -25,7 +25,7 @@ namespace Cauldron.Oriphel
 
         private IEnumerator HighestDamagesLowestResponse(PhaseChangeAction pca)
         {
-            IEnumerator coroutine = DealDamageToLowestHP(null, 1, (Card c) => IsHero(c), (c) => 2, DamageType.Melee, damageSourceInfo: new TargetInfo(HighestLowestHP.HighestHP, 1, 1, new LinqCardCriteria((Card c) => IsVillainTarget(c), "The villain target with the highest HP")));
+            IEnumerator coroutine = DealDamageToLowestHP(null, 1, (Card c) => IsHeroTarget(c), (c) => 2, DamageType.Melee, damageSourceInfo: new TargetInfo(HighestLowestHP.HighestHP, 1, 1, new LinqCardCriteria((Card c) => IsVillainTarget(c), "The villain target with the highest HP")));
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Oriphel/CharacterCards/OriphelCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Oriphel/CharacterCards/OriphelCharacterCardController.cs
@@ -50,7 +50,7 @@ namespace Cauldron.Oriphel
                 }
 
                 //"At the end of the villain turn, {Oriphel} deals the 2 hero targets with the highest HP {H - 1} infernal damage each.",
-                AddSideTrigger(AddDealDamageAtEndOfTurnTrigger(this.TurnTaker, this.Card, (Card c) => IsHero(c), TargetType.HighestHP, H - 1, DamageType.Infernal, numberOfTargets: 2));
+                AddSideTrigger(AddDealDamageAtEndOfTurnTrigger(this.TurnTaker, this.Card, (Card c) => IsHeroTarget(c), TargetType.HighestHP, H - 1, DamageType.Infernal, numberOfTargets: 2));
 
                 //"When there are 2 villain relics in the villain trash, flip {Oriphel}'s villain character cards."
                 AddSideTrigger(AddTrigger<GameAction>(CheckCardsInTrashCriteria, FlipThisCharacterCardResponse, TriggerType.FlipCard, TriggerTiming.After));

--- a/CauldronMods/Controller/Villains/Outlander/Cards/AnchoredFragmentCardController.cs
+++ b/CauldronMods/Controller/Villains/Outlander/Cards/AnchoredFragmentCardController.cs
@@ -21,7 +21,7 @@ namespace Cauldron.Outlander
         public override IEnumerator Play()
         {
             //When this card enters play, {Outlander} deals the hero target with the highest HP 1 melee damage.
-            IEnumerator coroutine = DealDamageToHighestHP(CharacterCard, 1, (Card c) => IsHero(c), (Card c) => 1, DamageType.Melee);
+            IEnumerator coroutine = DealDamageToHighestHP(CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => 1, DamageType.Melee);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/PhaseVillain/Cards/AroundTheCornerCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/Cards/AroundTheCornerCardController.cs
@@ -29,7 +29,7 @@ namespace Cauldron.PhaseVillain
         {
             //The first time an Obstacle is destroyed each turn, {Phase} deals each hero target 2 radiant damage.
             base.SetCardPropertyToTrueIfRealAction(FirstTimeDestroyed);
-            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card c) => IsHero(c), 2, DamageType.Radiant);
+            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card c) => IsHeroTarget(c), 2, DamageType.Radiant);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/PhaseVillain/Cards/BlockedSightlineCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/Cards/BlockedSightlineCardController.cs
@@ -23,7 +23,7 @@ namespace Cauldron.PhaseVillain
         private IEnumerator DealDamageResponse(DestroyCardAction action)
         {
             //...{Phase} deals the 2 hero targets with the highest HP {H} irreducible radiant damage each.
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => new int?(Game.H), DamageType.Radiant, true, numberOfTargets: () => 2);
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(Game.H), DamageType.Radiant, true, numberOfTargets: () => 2);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/PhaseVillain/Cards/DensityRegulatorCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/Cards/DensityRegulatorCardController.cs
@@ -23,7 +23,7 @@ namespace Cauldron.PhaseVillain
         private IEnumerator DealDamageResponse(PhaseChangeAction action)
         {
             //...{Phase} deals each hero target except the hero target with the lowest HP 2 radiant damage.
-            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card card) => IsHero(card), 2, DamageType.Radiant,
+            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card card) => IsHeroTarget(card), 2, DamageType.Radiant,
                 exceptFor: new TargetInfo(HighestLowestHP.LowestHP, 1, 1, new LinqCardCriteria((Card c) => IsHero(c), "the hero target with the lowest HP")));
             if (base.UseUnityCoroutines)
             {

--- a/CauldronMods/Controller/Villains/PhaseVillain/Cards/DistortionGrenadeCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/Cards/DistortionGrenadeCardController.cs
@@ -20,7 +20,7 @@ namespace Cauldron.PhaseVillain
         public override IEnumerator Play()
         {
             //When this card enters play, it deals the {H}-1 hero targets with the lowest HP 2 lightning damage each.
-            IEnumerator coroutine = base.DealDamageToLowestHP(base.Card, 1, (Card c) => IsHero(c), (Card c) => 2, DamageType.Lightning, numberOfTargets: Game.H - 1);
+            IEnumerator coroutine = base.DealDamageToLowestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => 2, DamageType.Lightning, numberOfTargets: Game.H - 1);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/PhaseVillain/Cards/FrequencyShiftCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/Cards/FrequencyShiftCardController.cs
@@ -30,7 +30,7 @@ namespace Cauldron.PhaseVillain
 
             //{Phase} deals the hero target with the highest HP {H} irreducible radiant damage and...
             List<DealDamageAction> targetedHero = new List<DealDamageAction>();
-            coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => Game.H, DamageType.Radiant, true,
+            coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => Game.H, DamageType.Radiant, true,
                             selectTargetEvenIfCannotDealDamage: true,
                             storedResults: targetedHero);
             if (base.UseUnityCoroutines)

--- a/CauldronMods/Controller/Villains/PhaseVillain/Cards/InsubstantialMatadorCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/Cards/InsubstantialMatadorCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.PhaseVillain
         public override IEnumerator Play()
         {
             //When this card enters play, {Phase} deals the hero target with the second lowest HP {H - 1} radiant damage.
-            IEnumerator coroutine = base.DealDamageToLowestHP(base.CharacterCard, 2, (Card c) => IsHero(c), (Card c) => Game.H - 1, DamageType.Radiant);
+            IEnumerator coroutine = base.DealDamageToLowestHP(base.CharacterCard, 2, (Card c) => IsHeroTarget(c), (Card c) => Game.H - 1, DamageType.Radiant);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/PhaseVillain/Cards/PrecariousRubbleCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/Cards/PrecariousRubbleCardController.cs
@@ -15,7 +15,7 @@ namespace Cauldron.PhaseVillain
         public override IEnumerator Play()
         {
             //When this card enters play, it deals the hero target with the lowest HP {H - 1} projectile damage. 
-            IEnumerator coroutine = base.DealDamageToLowestHP(base.Card, 1, (Card c) => IsHero(c), (Card c) => Game.H - 1, DamageType.Projectile);
+            IEnumerator coroutine = base.DealDamageToLowestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => Game.H - 1, DamageType.Projectile);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/PhaseVillain/CharacterCards/PhaseVillainCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/PhaseVillain/CharacterCards/PhaseVillainCharacterCardController.cs
@@ -166,7 +166,7 @@ namespace Cauldron.PhaseVillain
         private IEnumerator DealDamageResponse(PhaseChangeAction action)
         {
             //{Phase} deals each hero target {H} radiant damage. 
-            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card c) => IsHero(c), Game.H, DamageType.Radiant);
+            IEnumerator coroutine = base.DealDamage(base.CharacterCard, (Card c) => IsHeroTarget(c), Game.H, DamageType.Radiant);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/ScreaMachine/Cards/ShredZoneCardController.cs
+++ b/CauldronMods/Controller/Villains/ScreaMachine/Cards/ShredZoneCardController.cs
@@ -17,7 +17,7 @@ namespace Cauldron.ScreaMachine
 
         protected override IEnumerator ActivateBandAbility()
         {
-            var coroutine = DealDamageToLowestHP(GetBandmate(), 1, c => IsHero(c), c => 1, DamageType.Sonic, isIrreducible: true,
+            var coroutine = DealDamageToLowestHP(GetBandmate(), 1, c => IsHeroTarget(c), c => 1, DamageType.Sonic, isIrreducible: true,
                                 numberOfTargets: 2);
             if (UseUnityCoroutines)
             {

--- a/CauldronMods/Controller/Villains/SwarmEater/Cards/BladeAugCardController.cs
+++ b/CauldronMods/Controller/Villains/SwarmEater/Cards/BladeAugCardController.cs
@@ -28,7 +28,7 @@ namespace Cauldron.SwarmEater
         private IEnumerator DealDamageResponse(PhaseChangeAction action)
         {
             //...this card deals the hero target with the highest HP 2 lightning damage.
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHero(c), (Card c) => new int?(2), DamageType.Lightning);
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(2), DamageType.Lightning);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/SwarmEater/Cards/FollowTheScreamsCardController.cs
+++ b/CauldronMods/Controller/Villains/SwarmEater/Cards/FollowTheScreamsCardController.cs
@@ -26,7 +26,7 @@ namespace Cauldron.SwarmEater
                 base.GameController.ExhaustCoroutine(coroutine);
             }
             //{SwarmEater} deals the hero target with the highest HP {H} melee damage.
-            coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHero(c), (Card c) => Game.H, DamageType.Melee);
+            coroutine = base.DealDamageToHighestHP(base.CharacterCard, 1, (Card c) => IsHeroTarget(c), (Card c) => Game.H, DamageType.Melee);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/SwarmEater/Cards/StalkerAugCardController.cs
+++ b/CauldronMods/Controller/Villains/SwarmEater/Cards/StalkerAugCardController.cs
@@ -26,7 +26,7 @@ namespace Cauldron.SwarmEater
 
         private IEnumerator DealDamageExceptLowestResponse(PhaseChangeAction action)
         {
-            IEnumerator coroutine = base.DealDamage(base.Card, (Card card) => IsHero(card), Game.H - 2, DamageType.Energy, true, exceptFor: new TargetInfo(HighestLowestHP.LowestHP, 1, 1, new LinqCardCriteria((Card c) => IsHero(c), "the hero target with the lowest HP")));
+            IEnumerator coroutine = base.DealDamage(base.Card, (Card card) => IsHero(card), Game.H - 2, DamageType.Energy, true, exceptFor: new TargetInfo(HighestLowestHP.LowestHP, 1, 1, new LinqCardCriteria((Card c) => IsHeroTarget(c), "the hero target with the lowest HP")));
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/SwarmEater/Cards/VenomAugCardController.cs
+++ b/CauldronMods/Controller/Villains/SwarmEater/Cards/VenomAugCardController.cs
@@ -28,7 +28,7 @@ namespace Cauldron.SwarmEater
         {
             //...this card deals the hero target with the highest HP {H} projectile damage.
             List<DealDamageAction> storedResults = new List<DealDamageAction>();
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, c => IsHero(c), c => Game.H, DamageType.Projectile, storedResults: storedResults, numberOfTargets: () => 1);
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, c => IsHeroTarget(c), c => Game.H, DamageType.Projectile, storedResults: storedResults, numberOfTargets: () => 1);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/SwarmEater/CharacterCards/DistributedHivemindSwarmEaterCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/SwarmEater/CharacterCards/DistributedHivemindSwarmEaterCharacterCardController.cs
@@ -61,7 +61,7 @@ namespace Cauldron.SwarmEater
         private IEnumerator RedirectDamageResponse(DealDamageAction action)
         {
             //Whenever a villain target would deal damage to another villain target, redirect that damage to the hero target with the highest HP.
-            IEnumerator coroutine = base.RedirectDamage(action, TargetType.HighestHP, (Card c) => IsHero(c));
+            IEnumerator coroutine = base.RedirectDamage(action, TargetType.HighestHP, (Card c) => IsHeroTarget(c));
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/SwarmEater/CharacterCards/SwarmEaterCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/SwarmEater/CharacterCards/SwarmEaterCharacterCardController.cs
@@ -106,7 +106,7 @@ namespace Cauldron.SwarmEater
         private IEnumerator DealDamageResponse(PlayCardAction action)
         {
             //...{SwarmEater} deals the non-hero target other than itself with the lowest HP 3 melee damage.
-            IEnumerator coroutine = base.DealDamageToLowestHP(base.Card, 1, (Card c) => c != base.Card && !IsHero(c), (Card c) => 3, DamageType.Melee);
+            IEnumerator coroutine = base.DealDamageToLowestHP(base.Card, 1, (Card c) => c != base.Card && !IsHeroTarget(c), (Card c) => 3, DamageType.Melee);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/BaneOfEmbersCardController.cs
+++ b/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/BaneOfEmbersCardController.cs
@@ -25,7 +25,7 @@ namespace Cauldron.TheInfernalChoir
             AddTrigger<DealDamageAction>(dda => dda.Target == Card && dda.DidDealDamage && dda.Amount > 0 && !HasBeenSetToTrueThisTurn(FirstTimeDealtDamage), dda => SetFirstTimeDealtDamageFlag(), TriggerType.ImmuneToDamage, TriggerTiming.After);
             AddImmuneToDamageTrigger(dda => dda.Target == Card && HasBeenSetToTrueThisTurn(FirstTimeDealtDamage));
 
-            AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, c => IsHero(c), TargetType.HighestHP, 0, DamageType.Cold,
+            AddDealDamageAtEndOfTurnTrigger(TurnTaker, Card, c => IsHeroTarget(c), TargetType.HighestHP, 0, DamageType.Cold,
                     numberOfTargets: H,
                     dynamicAmount: c => Card.HitPoints.Value);
         }

--- a/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/KataMichiCardController.cs
+++ b/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/KataMichiCardController.cs
@@ -86,7 +86,7 @@ namespace Cauldron.TheInfernalChoir
 
             var coroutine = GameController.SelectTargetsToDealDamageToSelf(httc, damage, DamageType.Cold, null, false, null,
                                 allowAutoDecide: true,
-                                additionalCriteria: c => IsHero(c) || IsGhost(c),
+                                additionalCriteria: c => IsHeroTarget(c) || IsGhost(c),
                                 //stopDealingDamage: () => !source.IsInPlay || source.IsIncapacitatedOrOutOfGame || httc.IsIncapacitatedOrOutOfGame,
                                 cardSource: cs);
             if (base.UseUnityCoroutines)

--- a/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/RedSunXuCardController.cs
+++ b/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/RedSunXuCardController.cs
@@ -61,7 +61,7 @@ namespace Cauldron.TheInfernalChoir
 
         private IEnumerator EndOfTurnDamage()
         {
-            return GameController.SelectTargetsToDealDamageToSelf(DecisionMaker, 3, DamageType.Psychic, H - 1, false, H - 1, additionalCriteria: c => IsHero(c), allowAutoDecide: true, cardSource: GetCardSource());
+            return GameController.SelectTargetsToDealDamageToSelf(DecisionMaker, 3, DamageType.Psychic, H - 1, false, H - 1, additionalCriteria: c => IsHeroTarget(c), allowAutoDecide: true, cardSource: GetCardSource());
         }
     }
 }

--- a/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/TheVoicesGatherCardController.cs
+++ b/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/TheVoicesGatherCardController.cs
@@ -41,7 +41,7 @@ namespace Cauldron.TheInfernalChoir
 
             if (target != null)
             {
-                coroutine = base.DealDamageToHighestHP(target, 1, c => IsHero(c), c => H - 1, DamageType.Psychic, numberOfTargets: () => 1);
+                coroutine = base.DealDamageToHighestHP(target, 1, c => IsHeroTarget(c), c => H - 1, DamageType.Psychic, numberOfTargets: () => 1);
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/TrueColorsCardController.cs
+++ b/CauldronMods/Controller/Villains/TheInfernalChoir/Cards/TrueColorsCardController.cs
@@ -18,7 +18,7 @@ namespace Cauldron.TheInfernalChoir
 
         public override IEnumerator Play()
         {
-            var coroutine = base.DealDamageToHighestHP(CharacterCard, 1, c => IsHero(c), c => 6, DamageType.Infernal, numberOfTargets: () => 1);
+            var coroutine = base.DealDamageToHighestHP(CharacterCard, 1, c => IsHeroTarget(c), c => 6, DamageType.Infernal, numberOfTargets: () => 1);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);
@@ -30,7 +30,7 @@ namespace Cauldron.TheInfernalChoir
 
             if (IsVagrantHeartSoulRevealedInPlay())
             {
-                coroutine = base.DealDamageToHighestHP(CharacterCard, 1, c => IsHero(c), c => 6, DamageType.Cold, numberOfTargets: () => 1);
+                coroutine = base.DealDamageToHighestHP(CharacterCard, 1, c => IsHeroTarget(c), c => 6, DamageType.Cold, numberOfTargets: () => 1);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/TheMistressOfFate/Cards/ChaosButterflyCardController.cs
+++ b/CauldronMods/Controller/Villains/TheMistressOfFate/Cards/ChaosButterflyCardController.cs
@@ -32,7 +32,7 @@ namespace Cauldron.TheMistressOfFate
                 new DealDamageAction(GetCardSource(), new DamageSource(GameController, this.Card), null, 3, DamageType.Projectile),
                 new DealDamageAction(GetCardSource(), new DamageSource(GameController, this.Card), null, 3, DamageType.Cold)
             };
-            IEnumerator coroutine = DealMultipleInstancesOfDamage(damages, (Card c) => IsHero(c));
+            IEnumerator coroutine = DealMultipleInstancesOfDamage(damages, (Card c) => IsHeroTarget(c));
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/TheMistressOfFate/Cards/NecessaryCorrectionCardController.cs
+++ b/CauldronMods/Controller/Villains/TheMistressOfFate/Cards/NecessaryCorrectionCardController.cs
@@ -20,7 +20,7 @@ namespace Cauldron.TheMistressOfFate
         public override IEnumerator Play()
         {
             //"When this card enters play, {TheMistressOfFate} deals the {H - 1} hero targets with the highest HP 10 psychic damage each.",
-            IEnumerator coroutine = DealDamageToHighestHP(CharacterCard, 1, (Card c) => IsHero(c), c => 10, DamageType.Psychic, numberOfTargets: () => H - 1);
+            IEnumerator coroutine = DealDamageToHighestHP(CharacterCard, 1, (Card c) => IsHeroTarget(c), c => 10, DamageType.Psychic, numberOfTargets: () => H - 1);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/TheMistressOfFate/Cards/ToDustCardController.cs
+++ b/CauldronMods/Controller/Villains/TheMistressOfFate/Cards/ToDustCardController.cs
@@ -23,7 +23,7 @@ namespace Cauldron.TheMistressOfFate
             //"{TheMistressOfFate} deals the hero target with the second highest HP 15 projectile damage.",
             var storedTarget = new List<Card>();
             var previewDamage = new DealDamageAction(GetCardSource(), new DamageSource(GameController, CharacterCard), null, 15, DamageType.Projectile);
-            IEnumerator coroutine = GameController.FindTargetWithHighestHitPoints(2, (Card c) => IsHero(c), storedTarget, dealDamageInfo: new List<DealDamageAction> { previewDamage }, cardSource: GetCardSource());
+            IEnumerator coroutine = GameController.FindTargetWithHighestHitPoints(2, (Card c) => IsHeroTarget(c), storedTarget, dealDamageInfo: new List<DealDamageAction> { previewDamage }, cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/TheRam/Cards/BarrierBusterCardController.cs
+++ b/CauldronMods/Controller/Villains/TheRam/Cards/BarrierBusterCardController.cs
@@ -39,7 +39,7 @@ namespace Cauldron.TheRam
             IEnumerator coroutine;
             if(RamIfInPlay != null)
             {
-                coroutine = DealDamage(GetRam, (Card c) => IsHero(c), cardsDestroyed + 3, DamageType.Melee);
+                coroutine = DealDamage(GetRam, (Card c) => !IsVillainTarget(c), cardsDestroyed + 3, DamageType.Melee);
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/TheRam/Cards/FallBackCardController.cs
+++ b/CauldronMods/Controller/Villains/TheRam/Cards/FallBackCardController.cs
@@ -21,7 +21,7 @@ namespace Cauldron.TheRam
             //"When this card enters play, {TheRam} deals each Up Close hero target {H - 1} melee damage."
             if (RamIfInPlay != null)
             {
-                IEnumerator damage = DealDamage(RamIfInPlay, (Card c) => c.IsInPlayAndHasGameText && c.IsTarget && IsHero(c) && IsUpClose(c), H - 1, DamageType.Melee);
+                IEnumerator damage = DealDamage(RamIfInPlay, (Card c) => c.IsInPlayAndHasGameText && IsHeroTarget(c) && IsUpClose(c), H - 1, DamageType.Melee);
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(damage);

--- a/CauldronMods/Controller/Villains/TheRam/CharacterCards/TheRamCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/TheRam/CharacterCards/TheRamCharacterCardController.cs
@@ -46,7 +46,7 @@ namespace Cauldron.TheRam
                 AddSideTrigger(AddIncreaseDamageTrigger((DealDamageAction dd) => dd.Target == this.Card && dd.DamageSource != null && dd.DamageSource.Card != null && dd.DamageSource.IsCard && IsUpClose(dd.DamageSource.Card), 1));
 
                 //"At the end of the villain turn, {TheRam} deals the hero target with the highest HP {H - 1} melee damage."
-                AddSideTrigger(AddDealDamageAtEndOfTurnTrigger(TurnTaker, this.Card, (Card c) => c.IsInPlayAndHasGameText && IsHero(c), TargetType.HighestHP, H - 1, DamageType.Melee));
+                AddSideTrigger(AddDealDamageAtEndOfTurnTrigger(TurnTaker, this.Card, (Card c) => c.IsInPlayAndHasGameText && IsHeroTarget(c), TargetType.HighestHP, H - 1, DamageType.Melee));
 
                 if (IsGameAdvanced)
                 {
@@ -69,7 +69,7 @@ namespace Cauldron.TheRam
                 AddSideTrigger(AddTrigger(upCloseLeaves, (MoveCardAction mc) => GameController.FlipCard(this, cardSource:GetCardSource()), TriggerType.FlipCard, TriggerTiming.After));
 
                 //"At the end of the villain turn, {TheRam} deals the hero target with the highest HP {H - 1} melee damage."
-                AddSideTrigger(AddDealDamageAtEndOfTurnTrigger(TurnTaker, this.Card, (Card c) => c.IsInPlayAndHasGameText && IsHero(c), TargetType.HighestHP, H - 1, DamageType.Melee));
+                AddSideTrigger(AddDealDamageAtEndOfTurnTrigger(TurnTaker, this.Card, (Card c) => c.IsInPlayAndHasGameText && IsHeroTarget(c), TargetType.HighestHP, H - 1, DamageType.Melee));
 
                 //"Increase damage dealt to {TheRam} by hero targets by 1.",
                 AddSideTrigger(AddIncreaseDamageTrigger((DealDamageAction dd) => dd.Target == this.Card && dd.DamageSource != null && dd.DamageSource.Card != null && dd.DamageSource.IsTarget && IsHero(dd.DamageSource.Card), 1));

--- a/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfFireCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfFireCardController.cs
@@ -34,7 +34,7 @@ namespace Cauldron.Tiamat
             if (characterCard.IsInPlayAndHasGameText && (!characterCard.IsFlipped || base.FindCardController(characterCard) is FutureTiamatCharacterCardController))
             {
                 Func<Card, int?> X = (Card c) => new int?(PlusNumberOfThisCardInTrash(2));
-                coroutine = base.DealDamage(characterCard, (Card c) => IsHero(c), X, DamageType.Fire);
+                coroutine = base.DealDamage(characterCard, (Card c) => IsHeroTarget(c), X, DamageType.Fire);
 
                 if (base.UseUnityCoroutines)
                 {

--- a/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfIceCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfIceCardController.cs
@@ -23,7 +23,7 @@ namespace Cauldron.Tiamat
             if (characterCard.IsInPlayAndHasGameText && (!characterCard.IsFlipped || base.FindCardController(characterCard) is FutureTiamatCharacterCardController))
             {
                 Func<Card, int?> X = (Card c) => new int?(PlusNumberOfThisCardInTrash(2));
-                coroutine = base.DealDamage(characterCard, (Card c) => IsHero(c), X, DamageType.Cold);
+                coroutine = base.DealDamage(characterCard, (Card c) => IsHeroTarget(c), X, DamageType.Cold);
 
                 if (base.UseUnityCoroutines)
                 {

--- a/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfLightningCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/Cards/ElementOfLightningCardController.cs
@@ -36,7 +36,7 @@ namespace Cauldron.Tiamat
             //If {Tiamat}, The Eye of the Storm is active, she deals each hero target 2+X lightning damage, where X is the number of Element of Lightning cards in the villain trash.
             if (characterCard.IsInPlayAndHasGameText && (!characterCard.IsFlipped || base.FindCardController(characterCard) is FutureTiamatCharacterCardController))
             {
-                coroutine = base.DealDamage(characterCard, (Card c) => IsHero(c), (Card c) => PlusNumberOfThisCardInTrash(2), DamageType.Lightning);
+                coroutine = base.DealDamage(characterCard, (Card c) => IsHeroTarget(c), (Card c) => PlusNumberOfThisCardInTrash(2), DamageType.Lightning);
 
                 if (base.UseUnityCoroutines)
                 {

--- a/CauldronMods/Controller/Villains/Tiamat/Cards/SkyBreakerCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/Cards/SkyBreakerCardController.cs
@@ -19,7 +19,7 @@ namespace Cauldron.Tiamat
         {
             //The Head with the highest HP deals each hero target {H + 2} infernal damage.
             TargetInfo targetInfo = new TargetInfo(HighestLowestHP.HighestHP, 1, 1, new LinqCardCriteria((Card c) => c.DoKeywordsContain("head") && c.IsTarget, "the head with the highest HP"));
-            IEnumerator coroutine = base.DealDamage(null, (Card c) => c.IsTarget && IsHero(c), base.H + 2, DamageType.Infernal, damageSourceInfo: targetInfo);
+            IEnumerator coroutine = base.DealDamage(null, (Card c) => IsHeroTarget(c), base.H + 2, DamageType.Infernal, damageSourceInfo: targetInfo);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/2199/FutureTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/2199/FutureTiamatCharacterCardController.cs
@@ -67,7 +67,7 @@ namespace Cauldron.Tiamat
         private IEnumerator EndOfTurnResponse(PhaseChangeAction action)
         {
             //...{Tiamat} deals the hero target with the highest HP {H} energy damage. 
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHero(c), (Card c) => Game.H, DamageType.Energy);
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => Game.H, DamageType.Energy);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);
@@ -80,7 +80,7 @@ namespace Cauldron.Tiamat
             //...Then, if {Tiamat} deals no damage this turn, each hero target deals itself 3 projectile damage.
             if (!this.DidDealDamageThisTurn())
             {
-                coroutine = base.GameController.DealDamageToSelf(this.DecisionMaker, (Card c) => IsHero(c), (Card c) => 3, DamageType.Projectile, base.GetCardSource());
+                coroutine = base.GameController.DealDamageToSelf(this.DecisionMaker, (Card c) => IsHeroTarget(c), (Card c) => 3, DamageType.Projectile, base.GetCardSource());
                 if (base.UseUnityCoroutines)
                 {
                     yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/Instructions/HydraFrigidEarthTiamatInstructionsCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/ElementalHydra/Instructions/HydraFrigidEarthTiamatInstructionsCardController.cs
@@ -63,7 +63,7 @@ namespace Cauldron.Tiamat
         private IEnumerator DealDamageResponse(PhaseChangeAction action)
         {
             //...if {WinterTiamatCharacter} is active, she deals the hero target with the lowest HP 1 cold damage.
-            IEnumerator coroutine = base.DealDamageToLowestHP(base.FirstHeadCardController().Card, 1, (Card c) => IsHero(c), (Card c) => new int?(1), DamageType.Cold);
+            IEnumerator coroutine = base.DealDamageToLowestHP(base.FirstHeadCardController().Card, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(1), DamageType.Cold);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/Regular/InfernoTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/Regular/InfernoTiamatCharacterCardController.cs
@@ -67,7 +67,7 @@ namespace Cauldron.Tiamat
         //Deal H-2 Fire damage to highest hero target
         private IEnumerator DealDamageResponse(PhaseChangeAction phaseChange)
         {
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => c.IsTarget && IsHero(c), (Card c) => new int?(base.H - 2), DamageType.Fire);
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(base.H - 2), DamageType.Fire);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/Regular/StormTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/Regular/StormTiamatCharacterCardController.cs
@@ -68,7 +68,7 @@ namespace Cauldron.Tiamat
         //Deal H-2 Lightning damage to highest hero target
         private IEnumerator DealDamageResponse(PhaseChangeAction phaseChange)
         {
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => c.IsTarget && IsHero(c), (Card c) => new int?(base.H - 2), DamageType.Lightning);
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(base.H - 2), DamageType.Lightning);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Tiamat/CharacterCards/Regular/WinterTiamatCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Tiamat/CharacterCards/Regular/WinterTiamatCharacterCardController.cs
@@ -87,7 +87,7 @@ namespace Cauldron.Tiamat
         //Deal H-2 Cold damage to highest hero target
         private IEnumerator DealDamageResponse(PhaseChangeAction phaseChange)
         {
-            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => c.IsTarget && IsHero(c), (Card c) => new int?(base.H - 2), DamageType.Cold);
+            IEnumerator coroutine = base.DealDamageToHighestHP(base.Card, 1, (Card c) => IsHeroTarget(c), (Card c) => new int?(base.H - 2), DamageType.Cold);
             if (base.UseUnityCoroutines)
             {
                 yield return base.GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Villains/Vector/Cards/BioterrorSquadCardController.cs
+++ b/CauldronMods/Controller/Villains/Vector/Cards/BioterrorSquadCardController.cs
@@ -80,7 +80,7 @@ namespace Cauldron.Vector
         {
             int damageAmount = Game.H;
 
-            IEnumerator damageRoutine = DealDamageToHighestHP(Card, 1, c => IsHero(c) && c.IsInPlay, c => damageAmount, DamageType.Projectile);
+            IEnumerator damageRoutine = DealDamageToHighestHP(Card, 1, c => IsHeroTarget(c) && c.IsInPlay, c => damageAmount, DamageType.Projectile);
 
             IEnumerator damageRoutine2 = DealDamage(CharacterCard, Card, DamageToDealSelf, DamageType.Toxic, cardSource: GetCardSource());
 

--- a/CauldronMods/Controller/Villains/Vector/Cards/BloodSampleCardController.cs
+++ b/CauldronMods/Controller/Villains/Vector/Cards/BloodSampleCardController.cs
@@ -39,7 +39,7 @@ namespace Cauldron.Vector
 
         public override IEnumerator Play()
         {
-            IEnumerator damageRoutine = this.DealDamage(base.CharacterCard, c => IsHero(c) && c.IsInPlay, 
+            IEnumerator damageRoutine = this.DealDamage(base.CharacterCard, c => IsHeroTarget(c) && c.IsInPlay, 
                 DamageToDeal, DamageType.Toxic);
             
             if (base.UseUnityCoroutines)


### PR DESCRIPTION
Throughout many cards in Cauldron, IsHero was used by itself for hero targets, which resulted in things like heroic infinitor not working correctly. This resolves that issue. 