### PR TITLE
Tango One - Shinobi Assassin + Chameleon Armor/Critical Hit

### DIFF
--- a/CauldronMods/Controller/Heroes/TangoOne/Cards/ChameleonArmorCardController.cs
+++ b/CauldronMods/Controller/Heroes/TangoOne/Cards/ChameleonArmorCardController.cs
@@ -26,12 +26,15 @@ namespace Cauldron.TangoOne
 
         public override void AddTriggers()
         {
-            base.AddTrigger<DealDamageAction>(dda => dda.Target.Equals(this.CharacterCard) && dda.Amount > 0,
+            base.AddTrigger<DealDamageAction>(dda => dda.Target.Equals(this.CharacterCard) && dda.Amount > 0 && !dda.IsPretend,
                 this.RevealTopCardFromDeckResponse,
                 new TriggerType[]
                 {
                     TriggerType.ImmuneToDamage
                 }, TriggerTiming.Before, orderMatters: true, isConditional: false, requireActionSuccess: true, isActionOptional: true);
+
+            // Add a prevention in Pretend to get a better damage preview (but it still doesn't seem to work as intended?)
+            AddPreventDamageTrigger((DealDamageAction dda) => dda.Target.Equals(this.CharacterCard) && dda.Amount > 0 && dda.IsPretend, isPreventEffect: true);
         }
 
         private IEnumerator RevealTopCardFromDeckResponse(DealDamageAction dda)

--- a/CauldronMods/Controller/Heroes/TangoOne/Cards/CriticalHitCardController.cs
+++ b/CauldronMods/Controller/Heroes/TangoOne/Cards/CriticalHitCardController.cs
@@ -29,10 +29,12 @@ namespace Cauldron.TangoOne
 
         public override void AddTriggers()
         {
-            base.AddTrigger<DealDamageAction>(dda => dda.DamageSource != null && dda.DamageSource.IsSameCard(base.CharacterCard) && dda.Amount > 0,
+            base.AddTrigger<DealDamageAction>(dda => dda.DamageSource != null && dda.DamageSource.IsSameCard(base.CharacterCard) && !dda.IsPretend,
                 this.RevealTopCardFromDeckResponse,
                 new TriggerType[] { TriggerType.IncreaseDamage },
                 TriggerTiming.Before, null, isConditional: false, requireActionSuccess: true, isActionOptional: true);
+            // Add an IncreaseDamageTrigger in Pretend to get a better damage preview (but it still doesn't seem to work as intended?)
+            AddIncreaseDamageTrigger(dda => dda.DamageSource != null && dda.DamageSource.IsSameCard(base.CharacterCard) && dda.IsPretend, dda => 3);
         }
 
         private IEnumerator RevealTopCardFromDeckResponse(DealDamageAction dda)

--- a/Testing/Heroes/TangoOneTests.cs
+++ b/Testing/Heroes/TangoOneTests.cs
@@ -366,6 +366,34 @@ namespace CauldronTests
         }
 
         [Test]
+        public void TestChameleonArmorDiscardShinobiAssassin()
+        {
+            // Arrange
+            SetupGameController("BaronBlade", DeckNamespace, "Ra", "Legacy", "TheTempleOfZhuLong");
+            StartGame();
+
+            PutOnDeck(tango, GetCard(FarsightCardController.Identifier));
+
+            Card assasin = PlayCard("ShinobiAssassin");
+            DecisionSelectLocation = new LocationChoice(tango.TurnTaker.Deck);
+            DestroyCard(assasin);
+
+            DecisionYesNo = true;
+            QuickHPStorage(tango);
+
+            // Act
+            GoToStartOfTurn(tango);
+            PutInHand(ChameleonArmorCardController.Identifier);
+            PlayCard(ChameleonArmorCardController.Identifier);
+
+            DealDamage(baron, tango, 5, DamageType.Cold);
+
+            // Assert
+            QuickHPCheck(-5);
+            
+        }
+
+        [Test]
         public void TestChameleonArmorDontDiscard()
         {
             // Arrange
@@ -395,7 +423,8 @@ namespace CauldronTests
 
             RemoveMobileDefensePlatform();
             PlayCard("LivingForceField");
-            var topDeck = PutOnDeck(tango, GetCard(DamnGoodGroundCardController.Identifier));
+            var topDeck = PutOnDeck(tango, GetCard(WetWorkCardController.Identifier));
+            var secondTopDeck = tango.TurnTaker.Deck.GetTopCards(2).Last();
 
             QuickHPStorage(baron);
 
@@ -410,7 +439,40 @@ namespace CauldronTests
             // Assert
             QuickHPCheck(0);
 
-            AssertOnTopOfDeck(tango, topDeck);
+            AssertOnTopOfDeck(tango, secondTopDeck);
+            
+        }
+
+        [Test]
+        public void TestCriticalHitDamageShinobiAssassin()
+        {
+            // Arrange
+            SetupGameController("BaronBlade", DeckNamespace, "Ra", "Legacy", "TheTempleOfZhuLong");
+            StartGame();
+
+            RemoveMobileDefensePlatform();
+            PlayCard("LivingForceField");
+            var topDeck = PutOnDeck(tango, GetCard(DamnGoodGroundCardController.Identifier));
+            var secondTopDeck = tango.TurnTaker.Deck.GetTopCards(2).Last();
+
+            Card assasin = PlayCard("ShinobiAssassin");
+            DecisionSelectLocation = new LocationChoice(tango.TurnTaker.Deck);
+            DestroyCard(assasin);
+
+            QuickHPStorage(baron);
+
+            DecisionYesNo = true;
+            DecisionSelectTarget = baron.CharacterCard;
+
+            // Act
+            GoToPlayCardPhase(tango);
+            PlayCard(CriticalHitCardController.Identifier);
+            DealDamage(tango.CharacterCard.ResponsibleTarget, baron.CharacterCard, 0, DamageType.Infernal);
+
+            // Assert
+            QuickHPCheck(-2); //+3 critical, -1 living force field
+
+            AssertOnTopOfDeck(tango, secondTopDeck);
         }
 
         [Test]

--- a/Testing/Heroes/TangoOneTests.cs
+++ b/Testing/Heroes/TangoOneTests.cs
@@ -394,6 +394,25 @@ namespace CauldronTests
         }
 
         [Test]
+        public void TestChameleonArmorAmbiguousOutcome()
+        {
+            // Arrange
+            SetupGameController("BaronBlade", DeckNamespace, "Ra", "Legacy", "TheTempleOfZhuLong");
+            StartGame();
+
+            PutOnDeck(tango, GetCard(FarsightCardController.Identifier));
+
+            Card assasin = PlayCard("ShinobiAssassin");
+            DecisionSelectLocation = new LocationChoice(tango.TurnTaker.Deck);
+            DestroyCard(assasin);
+
+            // Act
+            PlayCard(ChameleonArmorCardController.Identifier);
+            var preview = GetDamagePreviewResults(baron, tango, 5, DamageType.Cold);
+            AssertDamagePreviewResultNotKnowable(preview, 0);
+        }
+
+        [Test]
         public void TestChameleonArmorDontDiscard()
         {
             // Arrange


### PR DESCRIPTION
Closes #1596 

After thorough testing, I figured out that the infinite loop was happening during the Pretend phase. 

I added standalone triggers in Pretend to try to get the Damage Preview to not show the Error message, but it didn't work. If others have thoughts on how to get that to show as expected, I'm happy to see those