### PR TITLE
Anathema Evolved - Body Parts Die at Negative HP

### DIFF
--- a/CauldronMods/Controller/Villains/Anathema/CharacterCards/AcceleratedEvolutionAnathemaCharacterCardController.cs
+++ b/CauldronMods/Controller/Villains/Anathema/CharacterCards/AcceleratedEvolutionAnathemaCharacterCardController.cs
@@ -80,21 +80,7 @@ namespace Cauldron.Anathema
             }
 
             base.AddDefeatedIfDestroyedTriggers();
-            AddTrigger<PhaseChangeAction>(pca => pca.FromPhase != null && pca.FromPhase.TurnTaker == TurnTaker && pca.ToPhase.TurnTaker != TurnTaker, pca => AttemptDestructionAsNeeded(), TriggerType.Hidden, TriggerTiming.After);
-        }
-
-        private IEnumerator AttemptDestructionAsNeeded()
-        {
-            IEnumerable<Card> cardsToDestroy = GameController.FindCardsWhere(c => IsPotentialIndestructibleBodyPart(c) && c.HitPoints != null && c.HitPoints.Value <= 0);
-            IEnumerator coroutine = GameController.DestroyCards(DecisionMaker, new LinqCardCriteria(c => cardsToDestroy.Contains(c), "body parts 0 or less to try to destroy"), autoDecide: true, showOutput: false, cardSource: GetCardSource());
-            if (UseUnityCoroutines)
-            {
-                yield return GameController.StartCoroutine(coroutine);
-            }
-            else
-            {
-                GameController.ExhaustCoroutine(coroutine);
-            }
+            AddTrigger<PhaseChangeAction>(pca => true, pca =>  GameController.DestroyAnyCardsThatShouldBeDestroyed(cardSource: GetCardSource()), TriggerType.Hidden, TriggerTiming.After);
         }
 
         private IEnumerator AdvancedEndOfTurnFrontResponse(PhaseChangeAction arg)

--- a/Testing/Villains/AnathemaVariantTests.cs
+++ b/Testing/Villains/AnathemaVariantTests.cs
@@ -399,6 +399,25 @@ namespace CauldronTests
         }
 
         [Test()]
+        public void TestAcceleratedEvolutionHeadIndestructibilityTest_FlippedVillainTurn_NegativeHP()
+        {
+            //Flipped: Arm and head cards are indestructible during the villain turn.
+
+            SetupGameController("Cauldron.Anathema/AcceleratedEvolutionAnathemaCharacter", "Legacy", "Ra", "Haka", "Megalopolis");
+            StartGame();
+            FlipCard(anathema.CharacterCard);
+            AssertFlipped(anathema);
+
+            GoToEndOfTurn();
+            Card headToDestroy = GetListOfHeadsInPlay(anathema).First();
+            DealDamage(ra.CharacterCard, headToDestroy, headToDestroy.HitPoints.Value + 2, DamageType.Fire, isIrreducible: true);
+            DestroyCard(headToDestroy, ra.CharacterCard);
+            AssertInPlayArea(anathema, headToDestroy);
+            GoToNextTurn();
+            AssertInTrash(anathema, headToDestroy);
+        }
+
+        [Test()]
         public void TestAcceleratedEvolutionHeadIndestructibilityTest_FlippedHeroTurn()
         {
             //Flipped: Arm and head cards are indestructible during the villain turn.


### PR DESCRIPTION
Closes #1643 

I'm not sure why they aren't auto destroying when indestructibility disappears if they have negative HP, but this is a workaround that will scan for any negative hp body parts on transition away from Anathema's turn