### PR TITLE
Fix for Superstorm Akela Flip Bug

### DIFF
--- a/CauldronMods/Controller/Environments/SuperstormAkela/CardSubClasses/SuperstormAkelaCardController.cs
+++ b/CauldronMods/Controller/Environments/SuperstormAkela/CardSubClasses/SuperstormAkelaCardController.cs
@@ -226,12 +226,13 @@ namespace Cauldron.SuperstormAkela
 
             // grab the card source for some other card visible to this card so the action can finish after initial flip
             Card otherCard = FindCardsWhere(c => c.IsInPlayAndHasGameText && c.Title != card.Title && GameController.IsCardVisibleToCardSource(c, GetCardSource())).TakeRandomFirstOrDefault(Game.RNG);
-            Log.Debug($"{this.Card.Title} is using {otherCard.Title} to refresh the UI for {card.Title}");
+            
             // if no other cards found, then we don't need to worry about refreshing the UI
             if(otherCard is null)
             {
                 yield break;
             }
+            Log.Debug($"{this.Card.Title} is using {otherCard.Title} to refresh the UI for {card.Title}");}
             CardSource otherCardSource = FindCardController(otherCard).GetCardSource();
 
             int? currentHP = card.IsTarget ? card.HitPoints : null;

--- a/CauldronMods/Controller/Environments/SuperstormAkela/CardSubClasses/SuperstormAkelaCardController.cs
+++ b/CauldronMods/Controller/Environments/SuperstormAkela/CardSubClasses/SuperstormAkelaCardController.cs
@@ -225,8 +225,8 @@ namespace Cauldron.SuperstormAkela
             IEnumerator coroutine2;
 
             // grab the card source for some other card visible to this card so the action can finish after initial flip
-            Card otherCard = FindCardsWhere(c => c.IsInPlayAndHasGameText && c.Title != Card.Title && GameController.IsCardVisibleToCardSource(c, GetCardSource())).TakeRandomFirstOrDefault(Game.RNG);
-            
+            Card otherCard = FindCardsWhere(c => c.IsInPlayAndHasGameText && c.Title != card.Title && GameController.IsCardVisibleToCardSource(c, GetCardSource())).TakeRandomFirstOrDefault(Game.RNG);
+            Log.Debug($"{this.Card.Title} is using {otherCard.Title} to refresh the UI for {card.Title}");
             // if no other cards found, then we don't need to worry about refreshing the UI
             if(otherCard is null)
             {


### PR DESCRIPTION
When the environment needs to refresh the UI when a card moves positions, it does this by flipping the card and then flipping it back. It chooses a random card to be the CardSource for this flip. It was coded to never choose the card that was calling `RefreshUI()` as the source, but I think the correct behavior should be to never choose the card that is being flipped as the CardSource. With the original behavior, it would occasionally choose the card that flipped, which would then be unable to flip back to the front side because it can't cause things while flipped. In unit tests, this would occasionally cause the test `TestRideTheCurrents_MoveTargetsAround` to fail.

I also added a debug line to help diagnose issues like this with Akela's cards in the future.