### PR TITLE
Fix for Forewarned Infinite Loop

### DIFF
--- a/CauldronMods/Controller/Heroes/Vanish/Cards/ForewarnedCardController.cs
+++ b/CauldronMods/Controller/Heroes/Vanish/Cards/ForewarnedCardController.cs
@@ -62,17 +62,15 @@ namespace Cauldron.Vanish
         private IEnumerator DestroyCardReponse()
         {
             var cardSource = GetCardSource();
-            foreach (var httc in GameController.HeroTurnTakerControllers.Where(httc => httc.BattleZone == BattleZone && GameController.CanDrawCards(httc, cardSource) && httc.HeroTurnTaker.NumberOfCardsInHand < 3))
+            SelectTurnTakersDecision decision = new SelectTurnTakersDecision(base.GameController, DecisionMaker, new LinqTurnTakerCriteria((TurnTaker tt) => tt.IsPlayer && base.GameController.IsTurnTakerVisibleToCardSource(tt, cardSource) && CanDrawCards(FindHeroTurnTakerController(tt.ToHero()))), SelectionType.DrawCard, allowAutoDecide: true, cardSource: cardSource);
+            IEnumerator coroutine = base.GameController.SelectTurnTakersAndDoActionEx(decision, (TurnTaker tt) => DrawCardsUntilHandSizeReached(FindHeroTurnTakerController(tt.ToHero()), 3), cardSource: cardSource);
+            if (base.UseUnityCoroutines)
             {
-                var coroutine = DrawCardsUntilHandSizeReached(httc, 3);
-                if (base.UseUnityCoroutines)
-                {
-                    yield return base.GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    base.GameController.ExhaustCoroutine(coroutine);
-                }
+                yield return base.GameController.StartCoroutine(coroutine);
+            }
+            else
+            {
+                base.GameController.ExhaustCoroutine(coroutine);
             }
         }
     }


### PR DESCRIPTION
Fixes infinite loop caused by Forewarned trying to make other heroes draw cards when she or they are Isolated. Now the player is prompted to choose the order for heroes to draw cards, and heroes that are not visible to Vanish are not included.

I'm not sure how to handle unit testing for this issue, since the fail state is an infinite loop.