### PR TITLE
1636 terminus full moon express triggers before guilty verdict regardless of play order

### DIFF
--- a/CauldronMods/Controller/Heroes/Terminus/Cards/GuiltyVerdictCardController.cs
+++ b/CauldronMods/Controller/Heroes/Terminus/Cards/GuiltyVerdictCardController.cs
@@ -36,7 +36,7 @@ namespace Cauldron.Terminus
         public override void AddTriggers()
         {
             base.AddTrigger<DealDamageAction>((dda) => IsHero(dda.Target) && dda.IsSuccessful && dda.Amount >= 3 && !dda.IsPretend, StoreIsHero, TriggerType.HiddenLast, TriggerTiming.Before);
-            base.AddTrigger<DealDamageAction>((dda) => dda.Amount >= 3 && RecentDamageIds.Contains(dda.InstanceIdentifier), DealDamageActionResponse, TriggerType.ModifyTokens, TriggerTiming.After);
+            base.AddTrigger<DealDamageAction>((dda) => dda.Amount >= 3 && RecentDamageIds.Contains(dda.InstanceIdentifier), DealDamageActionResponse, TriggerType.ModifyTokens, TriggerTiming.After, actionType: ActionDescription.DamageTaken);
             base.AddTriggers();
         }
 

--- a/Testing/Heroes/TerminusTest.cs
+++ b/Testing/Heroes/TerminusTest.cs
@@ -1095,6 +1095,30 @@ namespace CauldronTests
             AssertMaxNumberOfDecisions(1);
             UsePower(terminus);
         }
+        [Test]
+        public void TestGuiltyVerdictAmbiguousDecision()
+        {
+            SetupGameController("BaronBlade", "Cauldron.Terminus", "Legacy", "Bunker", "Megalopolis");
+            StartGame();
+            DestroyNonCharacterVillainCards();
+
+            Card guilty = PlayCard("GuiltyVerdict");
+            Card express = PlayCard("FullMoonExpress");
+            TokenPool tokenPool;
+            tokenPool = terminus.CharacterCard.FindTokenPool("TerminusWrathPool");
+            AddTokensToPool(tokenPool, 3);
+            DecisionSelectCard = guilty;
+            DecisionSelectFunction = 1;
+            DecisionYesNo = true;
+
+            //When Guilty Verdict and another card should trigger off of the same damage, it should give a decision for which one will activate first
+            //If it doesn't work correctly, it will always activate Full Moon Express before Guilty Verdict
+            QuickHPStorage(baron);
+            QuickTokenPoolStorage(tokenPool);
+            DealDamage(baron, terminus, 4, DamageType.Melee);
+            QuickHPCheck(-3);
+            QuickTokenPoolCheck(-3);
+        }
         #endregion Test Guilty Verdict
 
         #region Test Immortal Coils


### PR DESCRIPTION
Fixes issue where Guilty Verdict always triggered after other cards that trigger from the same damage, instead of giving a choice of which one should act first.