### PR TITLE
Fix wager master tests

### DIFF
--- a/Testing/Environments/FSCContinuanceWandererTests.cs
+++ b/Testing/Environments/FSCContinuanceWandererTests.cs
@@ -302,6 +302,7 @@ namespace CauldronTests
             //This card is immune to damage dealt by targets with less than 10HP.
             SetupGameController("LaCapitan", "Guise", "Parse", "Haka", "Tachyon", "Cauldron.FSCContinuanceWanderer");
             StartGame();
+            DestroyCard("LaParadojaMagnifica");
             GoToPlayCardPhase(env);
             PlayCard("PrehistoricBehemoth");
             //At the end of the environment turn, this card deals the {H - 2} targets 2 melee damage each.
@@ -703,6 +704,13 @@ namespace CauldronTests
         public void TestTimeFreezeWithTurnOrderReversed()
         {
             SetupGameController("WagerMaster", "Legacy", "Ra", "Haka", "Cauldron.FSCContinuanceWanderer");
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
 
             var conditions = FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsCondition);
@@ -746,6 +754,13 @@ namespace CauldronTests
         public void TestTimeFreezeWithTurnAndPhaseOrderReversed()
         {
             SetupGameController("WagerMaster", "Legacy", "Ra", "Haka", "Cauldron.FSCContinuanceWanderer");
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
 
             var conditions = FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsCondition);
@@ -780,6 +795,13 @@ namespace CauldronTests
         public void TestTimeFreezeWithPhaseOrderReversed()
         {
             SetupGameController("WagerMaster", "Legacy", "Ra", "Haka", "Cauldron.FSCContinuanceWanderer");
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
 
             var conditions = FindCardsWhere((Card c) => c.IsInPlayAndHasGameText && c.IsCondition);

--- a/Testing/Environments/NorthsparTests.cs
+++ b/Testing/Environments/NorthsparTests.cs
@@ -1112,6 +1112,13 @@ namespace CauldronTests
         public void TestFrozenSolid_SkipPlay()
         {
             SetupGameController(new string[] { "WagerMaster", "AbsoluteZero", "Legacy", "Ra", "Tachyon", "Haka", "Cauldron.Northspar" });
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
             SetHitPoints(az, 10);
             SetHitPoints(legacy, 10);
@@ -1135,6 +1142,13 @@ namespace CauldronTests
         public void TestFrozenSolid_NoPowerCanPlay()
         {
             SetupGameController(new[] { "WagerMaster", "AbsoluteZero", "Legacy", "Ra", "TheSentinels", "Cauldron.Northspar" });
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
 
             SetHitPoints(az, 10);

--- a/Testing/Heroes/CricketVariantTests.cs
+++ b/Testing/Heroes/CricketVariantTests.cs
@@ -354,12 +354,17 @@ namespace CauldronTests
         public void TestWastelandRoninCricketInnatePower_BreakingTheRules()
         {
             SetupGameController("WagerMaster", "Cauldron.Cricket/WastelandRoninCricketCharacter", "Legacy", "Bunker", "TheScholar", "Megalopolis");
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
                         
             DestroyNonCharacterVillainCards();
-            //losingtothe odds causes a game over mid test, banish it.
-            PutInTrash("LosingToTheOdds", "LosingToTheOdds", "LosingToTheOdds");
-
+            
             PlayCard("BreakingTheRules");
 
             //Increase damage dealt by {Cricket} during your next turn by 1. {Cricket} may deal 1 target 1 sonic damage.
@@ -569,6 +574,7 @@ namespace CauldronTests
 
             StartGame();
             SetupIncap(oblivaeon);
+            MoveCard(oblivaeon, "ScatterSlaughter", oblivaeon.TurnTaker.FindSubDeck("ScionDeck"));
 
             GoToAfterEndOfTurn(oblivaeon);
             DecisionSelectFromBoxIdentifiers = new string[] { "Bunker" };
@@ -630,6 +636,8 @@ namespace CauldronTests
             DecisionSelectFromBoxIdentifiers = new string[] { "AbsoluteZero" };
             DecisionSelectFromBoxTurnTakerIdentifier = "AbsoluteZero";
             RunActiveTurnPhase();
+
+            ResetDecisions();
 
             GoToBeforeStartOfTurn(az);
             DecisionSelectFunction = 3;

--- a/Testing/Heroes/StarlightTests.cs
+++ b/Testing/Heroes/StarlightTests.cs
@@ -1330,11 +1330,17 @@ namespace CauldronTests
         public void TestPillarsOfCreation_Timing_BreakingTheRules()
         {
             SetupGameController("WagerMaster", "Cauldron.Starlight", "Haka", "Ra", "RealmOfDiscord");
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
             DecisionAutoDecideIfAble = true;
             DestroyNonCharacterVillainCards();
-            //losingtothe odds causes a game over mid test, banish it.
-            PutInTrash("LosingToTheOdds", "LosingToTheOdds", "LosingToTheOdds");
+            
 
             var card = PutInHand("AncientConstellationA");
             PutInHand("AncientConstellationB");

--- a/Testing/Villains/TiamatHydraTests.cs
+++ b/Testing/Villains/TiamatHydraTests.cs
@@ -1718,6 +1718,13 @@ namespace CauldronTests
         public void TestNoWinConditionWhenInfernoMouthInstructionsFrontOut()
         {
             SetupGameController(new string[] { "Cauldron.Tiamat/HydraWinterTiamatCharacter", "WagerMaster", "Parse", "Bunker", "Haka", "Megalopolis" });
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
             IEnumerable<Card> wagerCardsToDestroy = FindCardsWhere((Card c) => c.Owner == wager.TurnTaker && c.IsInPlay);
             DestroyCards(wagerCardsToDestroy);


### PR DESCRIPTION
Tests involving Wager Master can fail due to a RNG game over if Losing to the Odds is in play, or if every starting condition is a Wageling. This pull request fixes all tests involving Wager Master by moving those cards to the trash before starting the game.