### PR TITLE
Create irradiated markers at runtime. Move Pyre code to extension methods.

### DIFF
--- a/CauldronMods/Controller/Heroes/Pyre/CardSubClasses/PyreUtilities.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CardSubClasses/PyreUtilities.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+using Handelabra.Sentinels.Engine.Controller;
+using Handelabra.Sentinels.Engine.Model;
+
+using Handelabra;
+
+namespace Cauldron.Pyre
+{
+
+    public static class PyreExtensionMethods
+    {
+        private const string IrradiationEffectFunction = "FakeIrradiationStatusEffectFunction";
+        public const string CascadeKeyword = "cascade";
+        public const string Irradiated = "{Rad}";
+
+        public static void ShowIrradiatedCardsInHands(this CardController co, SpecialStringMaker maker)
+        {
+            foreach (HeroTurnTaker hero in co.GameController.Game.HeroTurnTakers)
+            {
+                maker.ShowListOfCardsAtLocation(hero.Hand, new LinqCardCriteria((Card c) => c.IsIrradiated(), Irradiated));
+            }
+        }
+        public static void ShowIrradiatedCount(this CardController co, SpecialStringMaker maker, bool reverse = false)
+        {
+            string descriptor = reverse ? $"non-{Irradiated}" : Irradiated;
+            maker.ShowNumberOfCardsAtLocations(() => co.GameController.AllHeroes.Where(htt => !htt.IsIncapacitatedOrOutOfGame).Select(htt => htt.Hand), new LinqCardCriteria((Card c) => c.IsIrradiated() != reverse, descriptor));
+        }
+
+        public static bool IsIrradiated(this Card c)
+        {
+            if (c != null && (c.IsInHand || c.Location.IsRevealed))
+            {
+                return c.IsByIrradiationMarker();
+            }
+            return false;
+        }
+
+        public static bool IsByIrradiationMarker(this Card c)
+        {
+            if (c != null)
+            {
+                return c.NextToLocation.Cards.Any((Card nextTo) => nextTo.IsIrradiatedCard());
+            }
+            return false;
+        }
+
+        public static bool IsCascade(this GameController g, Card c)
+        {
+            return g.DoesCardContainKeyword(c, CascadeKeyword);
+        }
+
+        public static bool IsIrradiatedCard(this Card c)
+        {
+            return c.Identifier == "IrradiatedMarker" && c.Definition.ParentDeck.Identifier == "Pyre";
+        }
+
+        public static IEnumerator IrradiateCard(this CardController co, Card cardToIrradiate)
+        {
+            if (cardToIrradiate.IsIrradiated() || ! cardToIrradiate.Location.IsHand)
+            {
+                yield break;
+            }
+
+            var marker = co.TurnTakerControllerWithoutReplacements.TurnTaker.GetAllCards(realCardsOnly: false).Where((Card c) => c.IsIrradiatedCard() && c.Location.IsOffToTheSide).FirstOrDefault();
+            if (marker == null)
+            {
+                // Need to synthesise a card.
+                var anyIrradiated = co.GameController.FindCardsWhere(c => c.IsIrradiatedCard(), realCardsOnly: false).First();
+                if (anyIrradiated == null)
+                {
+                    throw new InvalidOperationException("Couldn't find any IrradiatedMarker cards");
+                }
+
+                marker = new Card(anyIrradiated.Definition, co.TurnTakerControllerWithoutReplacements.TurnTaker, 0);
+                co.TurnTakerControllerWithoutReplacements.TurnTaker.OffToTheSide.AddCard(marker);
+
+                var newController = CardControllerFactory.CreateInstance(marker, co.TurnTakerControllerWithoutReplacements);
+                co.TurnTakerControllerWithoutReplacements.AddCardController(newController);
+            }
+
+            IEnumerator coroutine = co.GameController.MoveCard(co.DecisionMaker, marker, cardToIrradiate.NextToLocation, doesNotEnterPlay: true, cardSource: co.GetCardSource());
+            if (co.UseUnityCoroutines)
+            {
+                yield return co.GameController.StartCoroutine(coroutine);
+            }
+            else
+            {
+                co.GameController.ExhaustCoroutine(coroutine);
+            }
+
+            var irradiateEffect = new OnPhaseChangeStatusEffect(co.CardWithoutReplacements, IrradiationEffectFunction, $"{cardToIrradiate.Title} is {Irradiated} until it leaves {cardToIrradiate.Location.GetFriendlyName()}.", new TriggerType[] { TriggerType.Hidden }, cardToIrradiate);
+            irradiateEffect.CardMovedExpiryCriteria.Card = cardToIrradiate;
+
+            coroutine = co.GameController.AddStatusEffect(irradiateEffect, true, co.GetCardSource());
+            if (co.UseUnityCoroutines)
+            {
+                yield return co.GameController.StartCoroutine(coroutine);
+            }
+            else
+            {
+                co.GameController.ExhaustCoroutine(coroutine);
+            }
+        }
+
+        public static IEnumerator ClearIrradiation(this CardController co,  Card card)
+        {
+            var marks = card?.NextToLocation.Cards.Where((Card c) => c.IsIrradiatedCard());
+            if (marks != null && marks.Any())
+            {
+                IEnumerator coroutine = co.BulkMoveCard(co.DecisionMaker, marks, co.TurnTaker.OffToTheSide, false, false, co.DecisionMaker, false);
+                if (co.UseUnityCoroutines)
+                {
+                    yield return co.GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    co.GameController.ExhaustCoroutine(coroutine);
+                }
+            }
+            var irradiationEffects = co.GameController.StatusEffectControllers.Where((StatusEffectController sec) => sec.StatusEffect is OnPhaseChangeStatusEffect opc && (opc.MethodToExecute == IrradiationEffectFunction && opc.CardMovedExpiryCriteria.Card == card)).Select(sec => sec.StatusEffect).ToList();
+            foreach (StatusEffect effect in irradiationEffects)
+            {
+                IEnumerator coroutine = co.GameController.ExpireStatusEffect(effect, co.GetCardSource());
+                if (co.UseUnityCoroutines)
+                {
+                    yield return co.GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    co.GameController.ExhaustCoroutine(coroutine);
+                }
+            }
+        }
+    }
+
+}

--- a/CauldronMods/Controller/Heroes/Pyre/CardSubClasses/PyreUtilityCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CardSubClasses/PyreUtilityCardController.cs
@@ -12,10 +12,6 @@ namespace Cauldron.Pyre
 {
     public abstract class PyreUtilityCardController : CardController
     {
-        private const string IrradiationEffectFunction = "FakeIrradiationStatusEffectFunction";
-        public const string CascadeKeyword = "cascade";
-        public const string Irradiated = "{Rad}";
-
         protected enum CustomMode
         {
             CardToIrradiate,
@@ -27,81 +23,6 @@ namespace Cauldron.Pyre
 
         protected PyreUtilityCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-        }
-
-        protected void ShowIrradiatedCardsInHands()
-        {
-            foreach (HeroTurnTaker hero in Game.HeroTurnTakers)
-            {
-                SpecialStringMaker.ShowListOfCardsAtLocation(hero.Hand, new LinqCardCriteria((Card c) => IsIrradiated(c), Irradiated));
-            }
-        }
-        protected void ShowIrradiatedCount(bool reverse = false)
-        {
-            string descriptor = reverse ? $"non-{Irradiated}" : Irradiated;
-            SpecialStringMaker.ShowNumberOfCardsAtLocations(() => GameController.AllHeroes.Where(htt => !htt.IsIncapacitatedOrOutOfGame).Select(htt => htt.Hand), new LinqCardCriteria((Card c) => IsIrradiated(c) != reverse, descriptor));
-        }
-
-        protected bool IsIrradiated(Card c)
-        {
-            if (c != null && (c.IsInHand || c.Location.IsRevealed))
-            {
-                return IsByIrradiationMarker(c);
-            }
-            return false;
-        }
-        protected bool IsByIrradiationMarker(Card c)
-        {
-            if (c != null)
-            {
-                return c.NextToLocation.Cards.Any((Card nextTo) => nextTo.Identifier == "IrradiatedMarker");
-            }
-            return false;
-        }
-        protected bool IsCascade(Card c)
-        {
-            return GameController.DoesCardContainKeyword(c, CascadeKeyword);
-        }
-
-        protected IEnumerator IrradiateCard(Card cardToIrradiate)
-        {
-            if(IsIrradiated(cardToIrradiate))
-            {
-                yield break;
-            }
-            var marker = TurnTakerControllerWithoutReplacements.TurnTaker.GetAllCards(realCardsOnly: false).Where((Card c) => !c.IsRealCard && c.Location.IsOffToTheSide).FirstOrDefault();
-            if (marker != null && cardToIrradiate.Location.IsHand)
-            {
-                IEnumerator coroutine = GameController.MoveCard(DecisionMaker, marker, cardToIrradiate.NextToLocation, doesNotEnterPlay: true, cardSource: GetCardSource());
-                if (UseUnityCoroutines)
-                {
-                    yield return GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    GameController.ExhaustCoroutine(coroutine);
-                }
-
-                var irradiateEffect = new OnPhaseChangeStatusEffect(CardWithoutReplacements, IrradiationEffectFunction, $"{cardToIrradiate.Title} is {Irradiated} until it leaves {cardToIrradiate.Location.GetFriendlyName()}.", new TriggerType[] { TriggerType.Hidden }, cardToIrradiate);
-                irradiateEffect.CardMovedExpiryCriteria.Card = cardToIrradiate;
-
-                coroutine = AddStatusEffect(irradiateEffect, true);
-                if (UseUnityCoroutines)
-                {
-                    yield return GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    GameController.ExhaustCoroutine(coroutine);
-                }
-                /*
-                if(PyreTTC != null)
-                {
-                    PyreTTC.AddIrradiatedSpecialString(cardToIrradiate);
-                }
-                */
-            }
-            yield break;
         }
 
         protected IEnumerator SelectAndIrradiateCardsInHand(HeroTurnTakerController decisionMaker, TurnTaker playerWithHand, int maxCards, int? minCards = null, List<SelectCardDecision> storedResults = null, Func<Card, bool> additionalCriteria = null)
@@ -117,7 +38,7 @@ namespace Cauldron.Pyre
                 handCriteria = (Card c) => c != null && c.Location == playerWithHand.ToHero().Hand;
             }
 
-            var fullCriteria = new LinqCardCriteria((Card c) => handCriteria(c) && !IsIrradiated(c) && additionalCriteria(c), $"non-{Irradiated}");
+            var fullCriteria = new LinqCardCriteria((Card c) => handCriteria(c) && !c.IsIrradiated() && additionalCriteria(c), $"non-{PyreExtensionMethods.Irradiated}");
             if(storedResults == null)
             {
                 storedResults = new List<SelectCardDecision>();
@@ -128,7 +49,7 @@ namespace Cauldron.Pyre
             }
             var oldMode = CurrentMode;
             CurrentMode = CustomMode.CardToIrradiate;
-            IEnumerator coroutine = GameController.SelectCardsAndDoAction(decisionMaker, fullCriteria, SelectionType.Custom, IrradiateCard, maxCards, false, minCards, storedResults, cardSource: GetCardSource());
+            IEnumerator coroutine = GameController.SelectCardsAndDoAction(decisionMaker, fullCriteria, SelectionType.Custom, c => this.IrradiateCard(c), maxCards, false, minCards, storedResults, cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);
@@ -138,37 +59,6 @@ namespace Cauldron.Pyre
                 GameController.ExhaustCoroutine(coroutine);
             }
             CurrentMode = oldMode;
-            yield break;
-        }
-        protected IEnumerator ClearIrradiation(Card card)
-        {
-            //Log.Debug($"ClearIrradiation called on {card.Title}");
-            var marks = card?.NextToLocation.Cards.Where((Card c) => !c.IsRealCard && c.Identifier == "IrradiatedMarker");
-            if (marks != null && marks.Any())
-            {
-                IEnumerator coroutine = BulkMoveCard(DecisionMaker, marks, TurnTaker.OffToTheSide, false, false, DecisionMaker, false);
-                if (UseUnityCoroutines)
-                {
-                    yield return GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    GameController.ExhaustCoroutine(coroutine);
-                }
-            }
-            var irradiationEffects = GameController.StatusEffectControllers.Where((StatusEffectController sec) => sec.StatusEffect is OnPhaseChangeStatusEffect opc && (opc.MethodToExecute == IrradiationEffectFunction && opc.CardMovedExpiryCriteria.Card == card)).Select(sec => sec.StatusEffect).ToList();
-            foreach (StatusEffect effect in irradiationEffects)
-            {
-                IEnumerator coroutine = GameController.ExpireStatusEffect(effect, GetCardSource());
-                if (UseUnityCoroutines)
-                {
-                    yield return GameController.StartCoroutine(coroutine);
-                }
-                else
-                {
-                    GameController.ExhaustCoroutine(coroutine);
-                }
-            }
             yield break;
         }
 
@@ -189,7 +79,6 @@ namespace Cauldron.Pyre
             }
 
             return base.GetCustomDecisionText(decision);
-
         }
     }
 }

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/AtmosphereScrubbersCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/AtmosphereScrubbersCardController.cs
@@ -12,7 +12,7 @@ namespace Cauldron.Pyre
     {
         public AtmosphereScrubbersCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCardsInHands();
+            this.ShowIrradiatedCardsInHands(SpecialStringMaker);
         }
 
         public override IEnumerator Play()
@@ -74,7 +74,7 @@ namespace Cauldron.Pyre
             }
 
             var card = GetSelectedCard(storedCard);
-            bool wasIrradiated = IsIrradiated(card);
+            bool wasIrradiated = card.IsIrradiated();
 
             var storedDiscard = new List<DiscardCardAction>();
             coroutine = GameController.DiscardCard(heroTTC, card, new IDecision[] { storedCard.FirstOrDefault() }, TurnTaker, storedDiscard, GetCardSource());

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/AtomicPunchCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/AtomicPunchCardController.cs
@@ -12,7 +12,7 @@ namespace Cauldron.Pyre
     {
         public AtomicPunchCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCount(true);
+            this.ShowIrradiatedCount(SpecialStringMaker, reverse: true);
         }
 
         public override IEnumerator Play()

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/CellularIrradiationCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/CellularIrradiationCardController.cs
@@ -12,7 +12,7 @@ namespace Cauldron.Pyre
     {
         public CellularIrradiationCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCount();
+            this.ShowIrradiatedCount(SpecialStringMaker);
         }
 
         public override IEnumerator Play()
@@ -46,12 +46,12 @@ namespace Cauldron.Pyre
             //dynamic, in case eg. Pyre plays it on himself and uses his power to up his count
             Func<int> irradiatedCardsInHand = delegate
             {
-                return heroTTC.HeroTurnTaker.Hand.Cards.Where((Card c) => IsIrradiated(c)).Count();
+                return heroTTC.HeroTurnTaker.Hand.Cards.Where((Card c) => c.IsIrradiated()).Count();
             };
             
             if(irradiatedCardsInHand() == 0)
             {
-                coroutine = GameController.SendMessageAction($"{heroTTC.Name} has no {Irradiated} cards in hand, so nothing happens.", Priority.Medium, GetCardSource());
+                coroutine = GameController.SendMessageAction($"{heroTTC.Name} has no {PyreExtensionMethods.Irradiated} cards in hand, so nothing happens.", Priority.Medium, GetCardSource());
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/CherenkovDriveCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/CherenkovDriveCardController.cs
@@ -27,7 +27,7 @@ namespace Cauldron.Pyre
 
         private IEnumerator EndOfTurnIrradiateResponse(PhaseChangeAction _)
         {
-            var viableHeroes = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(c => !IsIrradiated(c)) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
+            var viableHeroes = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(c => !c.IsIrradiated()) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
             var decision = new SelectTurnTakerDecision(GameController, DecisionMaker, viableHeroes, SelectionType.Custom, cardSource: GetCardSource());
             CurrentMode = CustomMode.PlayerToIrradiate;
             IEnumerator coroutine = GameController.SelectTurnTakerAndDoAction(decision, IrradiateCardInHandAndMaybeUsePower);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/ChromodynamicsCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/ChromodynamicsCardController.cs
@@ -24,13 +24,13 @@ namespace Cauldron.Pyre
         }
         public ChromodynamicsCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCount();
+            this.ShowIrradiatedCount(SpecialStringMaker);
         }
 
         public override void AddTriggers()
         {
             //"Whenever a player plays a {PyreIrradiate} card, {Pyre} deals 1 target 1 energy damage."
-            AddTrigger((PlayCardAction pc) => IsIrradiated(pc.CardToPlay) && !pc.IsPutIntoPlay, NoteIrradiatedPlay, TriggerType.Hidden, TriggerTiming.Before);
+            AddTrigger((PlayCardAction pc) => pc.CardToPlay.IsIrradiated() && !pc.IsPutIntoPlay, NoteIrradiatedPlay, TriggerType.Hidden, TriggerTiming.Before);
             AddTrigger((PlayCardAction pc) => RecentIrradiatedCardPlays.Contains(pc.InstanceIdentifier), IrradiatedPlayResponse, TriggerType.DealDamage, TriggerTiming.After, requireActionSuccess: false);
         }
         private IEnumerator NoteIrradiatedPlay(PlayCardAction pc)

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/ContainmentBreachCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/ContainmentBreachCardController.cs
@@ -27,8 +27,8 @@ namespace Cauldron.Pyre
 
         public ContainmentBreachCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCount();
-            SpecialStringMaker.ShowNumberOfCardsAtLocation(() =>TurnTaker.Trash, new LinqCardCriteria((Card c) => IsCascade(c), "cascade"));
+            this.ShowIrradiatedCount(SpecialStringMaker);
+            SpecialStringMaker.ShowNumberOfCardsAtLocation(() =>TurnTaker.Trash, new LinqCardCriteria((Card c) => GameController.IsCascade(c), "cascade"));
 
         }
         public override bool ShouldBeDestroyedNow()
@@ -38,7 +38,7 @@ namespace Cauldron.Pyre
         public override void AddTriggers()
         {
             //"Whenever a player plays a {PyreIrradiate} card, increase energy damage dealt by {Pyre} by 1 until the end of your turn. Then shuffle a Cascade card from your trash into your deck.",
-            AddTrigger((PlayCardAction pc) => IsIrradiated(pc.CardToPlay) && !pc.IsPutIntoPlay, NoteIrradiatedPlay, TriggerType.Hidden, TriggerTiming.Before);
+            AddTrigger((PlayCardAction pc) => pc.CardToPlay.IsIrradiated() && !pc.IsPutIntoPlay, NoteIrradiatedPlay, TriggerType.Hidden, TriggerTiming.Before);
             AddTrigger((PlayCardAction pc) => RecentIrradiatedCardPlays.Contains(pc.InstanceIdentifier), IrradiatedPlayResponse, new TriggerType[]
                 {
                     TriggerType.IncreaseDamage,
@@ -76,9 +76,9 @@ namespace Cauldron.Pyre
                     GameController.ExhaustCoroutine(coroutine);
                 }
                 //Then shuffle a Cascade card from your trash into your deck.
-                if (TurnTaker.Trash.Cards.Any((Card c) => IsCascade(c)))
+                if (TurnTaker.Trash.Cards.Any((Card c) => GameController.IsCascade(c)))
                 {
-                    var cardToMove = TurnTaker.Trash.Cards.Where((Card c) => IsCascade(c)).FirstOrDefault();
+                    var cardToMove = TurnTaker.Trash.Cards.Where((Card c) => GameController.IsCascade(c)).FirstOrDefault();
                     coroutine = GameController.SendMessageAction($"{Card.Title} shuffles {cardToMove.Title} into {TurnTaker.Deck.GetFriendlyName()}.", Priority.Medium, GetCardSource(), new Card[] { cardToMove });
                     if (UseUnityCoroutines)
                     {

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/FissionRegulatorCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/FissionRegulatorCardController.cs
@@ -12,7 +12,7 @@ namespace Cauldron.Pyre
     {
         public FissionRegulatorCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            SpecialStringMaker.ShowNumberOfCardsAtLocation(() => TurnTaker.Deck, new LinqCardCriteria((Card c) => IsCascade(c), "cascade"));
+            SpecialStringMaker.ShowNumberOfCardsAtLocation(() => TurnTaker.Deck, new LinqCardCriteria((Card c) => GameController.IsCascade(c), "cascade"));
         }
 
         public readonly string RogueFissionCascadeIdentifier = "RogueFissionCascade";
@@ -68,7 +68,7 @@ namespace Cauldron.Pyre
             }
 
             //Then put a Cascade card from your trash on top of your deck...
-            var cascadeInTrash = FindCardsWhere((Card c) => c.Location == TurnTaker.Trash && IsCascade(c)).FirstOrDefault();
+            var cascadeInTrash = FindCardsWhere((Card c) => c.Location == TurnTaker.Trash && GameController.IsCascade(c)).FirstOrDefault();
             if(cascadeInTrash != null)
             {
                 coroutine = GameController.SendMessageAction($"{Card.Title} moves {cascadeInTrash.Title} to the top of {TurnTaker.Deck.GetFriendlyName()}.", Priority.Medium, GetCardSource(), new Card[] { cascadeInTrash });

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/FracturedControlRodCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/FracturedControlRodCardController.cs
@@ -14,7 +14,7 @@ namespace Cauldron.Pyre
 
         public FracturedControlRodCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCardsInHands();
+            this.ShowIrradiatedCardsInHands(SpecialStringMaker);
         }
 
         public override void AddStartOfGameTriggers()
@@ -44,7 +44,7 @@ namespace Cauldron.Pyre
         {
             //"Whenever a player discards a {PyreIrradiate} card, they may destroy this card to play the discarded card."
 
-            AddTrigger((MoveCardAction mc) => mc.IsDiscard && IsIrradiated(mc.CardToMove) && mc.CanChangeDestination && IsFirstOrOnlyCopyOfThisCardInPlay() && GameController.CanPlayCard(FindCardController(mc.CardToMove)) == CanPlayCardResult.CanPlay && GameController.IsTurnTakerVisibleToCardSource(mc.Origin.OwnerTurnTaker, GetCardSource()), PlayDiscardedCardFromMove, TriggerType.PlayCard, TriggerTiming.Before);
+            AddTrigger((MoveCardAction mc) => mc.IsDiscard && mc.CardToMove.IsIrradiated() && mc.CanChangeDestination && IsFirstOrOnlyCopyOfThisCardInPlay() && GameController.CanPlayCard(FindCardController(mc.CardToMove)) == CanPlayCardResult.CanPlay && GameController.IsTurnTakerVisibleToCardSource(mc.Origin.OwnerTurnTaker, GetCardSource()), PlayDiscardedCardFromMove, TriggerType.PlayCard, TriggerTiming.Before);
         }
 
         private IEnumerator PlayDiscardedCardFromMove(MoveCardAction mc)
@@ -66,7 +66,7 @@ namespace Cauldron.Pyre
 
             if(DidPlayerAnswerYes(storedYesNo))
             {
-                coroutine = ClearIrradiation(cardToPlay);
+                coroutine = this.ClearIrradiation(cardToPlay);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);
@@ -119,7 +119,7 @@ namespace Cauldron.Pyre
 
         private IEnumerator MarkIrradiatedPlay(PlayCardAction pc)
         {
-            WasPlayedIrradiated = IsIrradiated(Card);
+            WasPlayedIrradiated = Card.IsIrradiated();
             yield return null;
             yield break;
         }

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/GammaBurstCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/GammaBurstCardController.cs
@@ -12,7 +12,7 @@ namespace Cauldron.Pyre
     {
         public GammaBurstCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCount(true);
+            this.ShowIrradiatedCount(SpecialStringMaker, reverse: true);
         }
         public override IEnumerator Play()
         {

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/HalfLifeCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/HalfLifeCardController.cs
@@ -31,7 +31,7 @@ namespace Cauldron.Pyre
             //{PyreIrradiate} that card until it leaves your hand. 
             if(DidSelectCard(storedResults))
             {
-                coroutine = IrradiateCard(GetSelectedCard(storedResults));
+                coroutine = this.IrradiateCard(GetSelectedCard(storedResults));
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/IonTraceCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/IonTraceCardController.cs
@@ -12,13 +12,13 @@ namespace Cauldron.Pyre
     {
         public IonTraceCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCount();
+            this.ShowIrradiatedCount(SpecialStringMaker);
         }
 
         public override IEnumerator Play()
         {
             //"Two players may each select a non-{PyreIrradiate} card in their hand and move a card that shares a keyword with it from their trash to their hand. {PyreIrradiate} any cards selected or moved this way until they leave their hands.",
-            var selectHeroes = new SelectTurnTakersDecision(GameController, DecisionMaker, new LinqTurnTakerCriteria((TurnTaker tt) => IsHero(tt) && !tt.IsIncapacitatedOrOutOfGame && GameController.IsTurnTakerVisibleToCardSource(tt, GetCardSource()) && tt.ToHero().Hand.Cards.Any((card) => !IsIrradiated(card))), SelectionType.ReturnToHand, 2, false, 2, cardSource: GetCardSource());
+            var selectHeroes = new SelectTurnTakersDecision(GameController, DecisionMaker, new LinqTurnTakerCriteria((TurnTaker tt) => IsHero(tt) && !tt.IsIncapacitatedOrOutOfGame && GameController.IsTurnTakerVisibleToCardSource(tt, GetCardSource()) && tt.ToHero().Hand.Cards.Any((card) => !card.IsIrradiated())), SelectionType.ReturnToHand, 2, false, 2, cardSource: GetCardSource());
             IEnumerator coroutine = GameController.SelectTurnTakersAndDoAction(selectHeroes, RescueAndIrradiateCards, cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
@@ -78,7 +78,7 @@ namespace Cauldron.Pyre
             //{PyreIrradiate} any cards selected or moved this way until they leave their hands.",
             if(DidSelectCard(storedTrashCard))
             {
-                coroutine = IrradiateCard(GetSelectedCard(storedTrashCard));
+                coroutine = this.IrradiateCard(GetSelectedCard(storedTrashCard));
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/NeutronForcefieldCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/NeutronForcefieldCardController.cs
@@ -89,7 +89,7 @@ namespace Cauldron.Pyre
         }
         private IEnumerator MarkIrradiatedPlay(PlayCardAction pc)
         {
-            WasPlayedIrradiated = IsIrradiated(Card);
+            WasPlayedIrradiated = Card.IsIrradiated();
             yield return null;
             yield break;
         }

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/ParticleColliderCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/ParticleColliderCardController.cs
@@ -12,7 +12,7 @@ namespace Cauldron.Pyre
     {
         public ParticleColliderCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
-            ShowIrradiatedCardsInHands();
+            this.ShowIrradiatedCardsInHands(SpecialStringMaker);
             SpecialStringMaker.ShowIfElseSpecialString(() => FindCardsWhere(c => c.IsInPlayAndHasGameText && c.Identifier == ThermonuclearCoreIdentifier).Any(), () => "Thermonuclear Core is in play.", () => "Thermonuclear Core is not in play.");
         }
 
@@ -24,7 +24,7 @@ namespace Cauldron.Pyre
             int numDamage = GetPowerNumeral(2, 1);
             int numBoost = GetPowerNumeral(3, 3);
             //"1 player may play a {PyreIrradiate} card now. 
-            var selectHeroes = new SelectTurnTakersDecision(GameController, DecisionMaker, new LinqTurnTakerCriteria((TurnTaker tt) => IsHero(tt) && !tt.IsIncapacitatedOrOutOfGame && GameController.IsTurnTakerVisibleToCardSource(tt, GetCardSource()) && tt.ToHero().Hand.Cards.Any((Card c) => IsIrradiated(c) && GameController.CanPlayCard(FindCardController(c)) == CanPlayCardResult.CanPlay), $"hero with {Irradiated} cards in hand"), SelectionType.PlayCard, numPlayers, false, numPlayers, cardSource: GetCardSource());
+            var selectHeroes = new SelectTurnTakersDecision(GameController, DecisionMaker, new LinqTurnTakerCriteria((TurnTaker tt) => IsHero(tt) && !tt.IsIncapacitatedOrOutOfGame && GameController.IsTurnTakerVisibleToCardSource(tt, GetCardSource()) && tt.ToHero().Hand.Cards.Any((Card c) => c.IsIrradiated() && GameController.CanPlayCard(FindCardController(c)) == CanPlayCardResult.CanPlay), $"hero with {PyreExtensionMethods.Irradiated} cards in hand"), SelectionType.PlayCard, numPlayers, false, numPlayers, cardSource: GetCardSource());
             IEnumerator coroutine = GameController.SelectTurnTakersAndDoAction(selectHeroes, PlayIrradiatedCard, cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
@@ -179,7 +179,7 @@ namespace Cauldron.Pyre
         private IEnumerator PlayIrradiatedCard(TurnTaker tt)
         {
             var heroTTC = FindHeroTurnTakerController(tt.ToHero());
-            IEnumerator coroutine = GameController.SelectAndPlayCardFromHand(heroTTC, true, cardCriteria: new LinqCardCriteria((Card c) => IsIrradiated(c), Irradiated), cardSource: GetCardSource());
+            IEnumerator coroutine = GameController.SelectAndPlayCardFromHand(heroTTC, true, cardCriteria: new LinqCardCriteria((Card c) => c.IsIrradiated(), PyreExtensionMethods.Irradiated), cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/RogueFissionCascadeCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/RogueFissionCascadeCardController.cs
@@ -16,7 +16,7 @@ namespace Cauldron.Pyre
         {
             AddThisCardControllerToList(CardControllerListType.EnteringGameCheck);
             AddInhibitorException((GameAction ga) => ga is PlayCardAction && Card.Location.IsHand);
-            ShowIrradiatedCount();
+            this.ShowIrradiatedCount(SpecialStringMaker);
         }
         private const string LocationKnown = "CascadeLocationKnownKey";
         public override void AddStartOfGameTriggers()
@@ -124,8 +124,8 @@ namespace Cauldron.Pyre
         public override IEnumerator Play()
         {
             //"{Pyre} deals each hero with {PyreIrradiate} cards in their hand X energy damage, where X is the number of {PyreIrradiate} cards in all hands.",
-            Func<int> NumIrradiatedCardsInHand = () => GameController.GetAllCards().Where((Card c) => IsIrradiated(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource())).Count();
-            IEnumerator coroutine = DealDamage(CharacterCard, (Card c) =>  IsHeroCharacterCard(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource()) && c.Owner.ToHero().Hand.Cards.Any((Card inHand) => IsIrradiated(inHand)), c => NumIrradiatedCardsInHand(), DamageType.Energy);
+            Func<int> NumIrradiatedCardsInHand = () => GameController.GetAllCards().Where((Card c) => c.IsIrradiated() && GameController.IsCardVisibleToCardSource(c, GetCardSource())).Count();
+            IEnumerator coroutine = DealDamage(CharacterCard, (Card c) =>  IsHeroCharacterCard(c) && GameController.IsCardVisibleToCardSource(c, GetCardSource()) && c.Owner.ToHero().Hand.Cards.Any((Card inHand) => inHand.IsIrradiated()), c => NumIrradiatedCardsInHand(), DamageType.Energy);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/Cards/ThermonuclearCoreCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/Cards/ThermonuclearCoreCardController.cs
@@ -14,7 +14,7 @@ namespace Cauldron.Pyre
         {
             AddThisCardControllerToList(CardControllerListType.EnteringGameCheck);
             AddInhibitorException((GameAction ga) => (ga is MakeDecisionAction || ga is MoveCardAction || ga is AddStatusEffectAction) && Card.Location.IsHand);
-            ShowIrradiatedCount();
+            this.ShowIrradiatedCount(SpecialStringMaker);
         }
         public override void AddStartOfGameTriggers()
         {
@@ -44,7 +44,7 @@ namespace Cauldron.Pyre
         private IEnumerator EntersHandResponse()
         {
             //"When this card enters your hand, select 1 non-{PyreIrradiate} card in your hand. {PyreIrradiate} that card until it leaves your hand.",
-            IEnumerator coroutine = GameController.SendMessageAction($"{Card.Title} {Irradiated} a card in {Card.Location.GetFriendlyName()}", Priority.Medium, GetCardSource(), showCardSource: true);
+            IEnumerator coroutine = GameController.SendMessageAction($"{Card.Title} {PyreExtensionMethods.Irradiated} a card in {Card.Location.GetFriendlyName()}", Priority.Medium, GetCardSource(), showCardSource: true);
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);
@@ -71,7 +71,7 @@ namespace Cauldron.Pyre
         }
         private IEnumerator SelectHeroToDrawIrradiatedCard(PhaseChangeAction pc)
         {
-            var validHeroes = GameController.AllHeroControllers.Where(httc => GameController.IsTurnTakerVisibleToCardSource(httc.HeroTurnTaker, GetCardSource()) && !httc.HeroTurnTaker.Hand.Cards.Any((Card c) => IsIrradiated(c)) && GameController.CanDrawCards(httc, GetCardSource())).Select(httc => httc.TurnTaker).ToList();
+            var validHeroes = GameController.AllHeroControllers.Where(httc => GameController.IsTurnTakerVisibleToCardSource(httc.HeroTurnTaker, GetCardSource()) && !httc.HeroTurnTaker.Hand.Cards.Any((Card c) => c.IsIrradiated()) && GameController.CanDrawCards(httc, GetCardSource())).Select(httc => httc.TurnTaker).ToList();
             IEnumerator coroutine;
             if (!validHeroes.Any())
             {
@@ -123,7 +123,7 @@ namespace Cauldron.Pyre
 
             if (DidDrawCards(drawStorage))
             {
-                coroutine = IrradiateCard(drawStorage.FirstOrDefault().DrawnCard);
+                coroutine = this.IrradiateCard(drawStorage.FirstOrDefault().DrawnCard);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/CharacterCards/ExpeditionOblaskPyreCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CharacterCards/ExpeditionOblaskPyreCharacterCardController.cs
@@ -37,7 +37,7 @@ namespace Cauldron.Pyre
                 case 0:
                     {
                         //"One player may discard a {PyreIrradiate} card. If they do, each player may play a card now.",
-                        var heroesWithIrradiated = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(card => IsIrradiated(card)) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
+                        var heroesWithIrradiated = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(card => card.IsIrradiated()) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
                         var selectHero = new SelectTurnTakerDecision(GameController, DecisionMaker, heroesWithIrradiated, SelectionType.DiscardCard, true, cardSource: GetCardSource());
                         coroutine = GameController.SelectTurnTakerAndDoAction(selectHero, DiscardForEverybodyPlays);
                         if (UseUnityCoroutines)
@@ -87,7 +87,7 @@ namespace Cauldron.Pyre
             //May discard a {PyreIrradiate} card
             var heroTTC = FindHeroTurnTakerController(tt.ToHero());
             var storedDiscard = new List<DiscardCardAction>();
-            IEnumerator coroutine = GameController.SelectAndDiscardCard(heroTTC, true, card => IsIrradiated(card), storedDiscard, responsibleTurnTaker: TurnTaker, cardSource: GetCardSource());
+            IEnumerator coroutine = GameController.SelectAndDiscardCard(heroTTC, true, card => card.IsIrradiated(), storedDiscard, responsibleTurnTaker: TurnTaker, cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/CharacterCards/PyreCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CharacterCards/PyreCharacterCardController.cs
@@ -30,9 +30,9 @@ namespace Cauldron.Pyre
             }
 
             //Shuffle a cascade card from your trash into your deck."
-            if(TurnTaker.Trash.Cards.Any((Card c) => IsCascade(c)))
+            if(TurnTaker.Trash.Cards.Any((Card c) => GameController.IsCascade(c)))
             {
-                var cardToMove = TurnTaker.Trash.Cards.Where((Card c) => IsCascade(c)).FirstOrDefault();
+                var cardToMove = TurnTaker.Trash.Cards.Where((Card c) => GameController.IsCascade(c)).FirstOrDefault();
                 coroutine = GameController.SendMessageAction($"{Card.Title} shuffles {cardToMove.Title} into {TurnTaker.Deck.GetFriendlyName()}.", Priority.Medium, GetCardSource(), new Card[] { cardToMove });
                 if (UseUnityCoroutines)
                 {
@@ -82,7 +82,7 @@ namespace Cauldron.Pyre
 
             if(DidDrawCards(drawStorage))
             {
-                coroutine = IrradiateCard(drawStorage.FirstOrDefault().DrawnCard);
+                coroutine = this.IrradiateCard(drawStorage.FirstOrDefault().DrawnCard);
                 if (UseUnityCoroutines)
                 {
                     yield return GameController.StartCoroutine(coroutine);
@@ -103,7 +103,7 @@ namespace Cauldron.Pyre
                 case 0:
                     {
                         //"One player may discard a {PyreIrradiate} card to draw a card, play a card, and use a power now.",
-                        var heroesWithIrradiated = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(card => IsIrradiated(card)) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
+                        var heroesWithIrradiated = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(card => card.IsIrradiated()) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
                         var selectHero = new SelectTurnTakerDecision(GameController, DecisionMaker, heroesWithIrradiated, SelectionType.DiscardCard, true, cardSource: GetCardSource());
                         coroutine = GameController.SelectTurnTakerAndDoAction(selectHero, DiscardForDrawPlayPower);
                         if (UseUnityCoroutines)
@@ -170,7 +170,7 @@ namespace Cauldron.Pyre
             //One player may discard a {PyreIrradiate} card...
             var heroTTC = FindHeroTurnTakerController(tt.ToHero());
             var storedDiscard = new List<DiscardCardAction>();
-            IEnumerator coroutine = GameController.SelectAndDiscardCard(heroTTC, true, card => IsIrradiated(card), storedDiscard, responsibleTurnTaker: TurnTaker, cardSource: GetCardSource());
+            IEnumerator coroutine = GameController.SelectAndDiscardCard(heroTTC, true, card => card.IsIrradiated(), storedDiscard, responsibleTurnTaker: TurnTaker, cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/CharacterCards/UnstablePyreCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CharacterCards/UnstablePyreCharacterCardController.cs
@@ -18,7 +18,7 @@ namespace Cauldron.Pyre
 
             int numCards = GetPowerNumeral(0, 1);
             //"{PyreIrradiate} 1 non-{PyreIrradiate} card in a player's hand until it leaves their hand."
-            var viableHeroes = GameController.AllHeroes.Where(htt => GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource()) && htt.Hand.Cards.Any(c => !IsIrradiated(c))).Select(htt => htt as TurnTaker);
+            var viableHeroes = GameController.AllHeroes.Where(htt => GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource()) && htt.Hand.Cards.Any(c => !c.IsIrradiated())).Select(htt => htt as TurnTaker);
             var decision = new SelectTurnTakerDecision(GameController, DecisionMaker, viableHeroes, SelectionType.Custom, cardSource: GetCardSource());
             CurrentMode = CustomMode.PlayerToIrradiate;
             IEnumerator coroutine = GameController.SelectTurnTakerAndDoAction(decision, tt => SelectAndIrradiateCardsInHand(DecisionMaker, tt, numCards, numCards));
@@ -59,9 +59,9 @@ namespace Cauldron.Pyre
             }
 
             //Shuffle a cascade card from your trash into your deck.
-            if (TurnTaker.Trash.Cards.Any((Card c) => IsCascade(c)))
+            if (TurnTaker.Trash.Cards.Any((Card c) => GameController.IsCascade(c)))
             {
-                var cardToMove = TurnTaker.Trash.Cards.Where((Card c) => IsCascade(c)).FirstOrDefault();
+                var cardToMove = TurnTaker.Trash.Cards.Where((Card c) => GameController.IsCascade(c)).FirstOrDefault();
                 coroutine = GameController.SendMessageAction($"{Card.Title} shuffles {cardToMove.Title} into {TurnTaker.Deck.GetFriendlyName()}.", Priority.Medium, GetCardSource(), new Card[] { cardToMove });
                 if (UseUnityCoroutines)
                 {
@@ -104,7 +104,7 @@ namespace Cauldron.Pyre
                 case 0:
                     {
                         //"One player may discard a {PyreIrradiate} card. If they do, 1 target regains 4 HP.",
-                        var heroesWithIrradiated = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(card => IsIrradiated(card)) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
+                        var heroesWithIrradiated = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(card => card.IsIrradiated()) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
                         var selectHero = new SelectTurnTakerDecision(GameController, DecisionMaker, heroesWithIrradiated, SelectionType.DiscardCard, true, cardSource: GetCardSource());
                         coroutine = GameController.SelectTurnTakerAndDoAction(selectHero, DiscardForGainHP);
                         if (UseUnityCoroutines)
@@ -154,7 +154,7 @@ namespace Cauldron.Pyre
         {
             var heroTTC = FindHeroTurnTakerController(tt.ToHero());
             var storedDiscard = new List<DiscardCardAction>();
-            IEnumerator coroutine = GameController.SelectAndDiscardCard(heroTTC, true, card => IsIrradiated(card), storedDiscard, responsibleTurnTaker: TurnTaker, cardSource: GetCardSource());
+            IEnumerator coroutine = GameController.SelectAndDiscardCard(heroTTC, true, card => card.IsIrradiated(), storedDiscard, responsibleTurnTaker: TurnTaker, cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/Controller/Heroes/Pyre/CharacterCards/WastelandRoninPyreCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Pyre/CharacterCards/WastelandRoninPyreCharacterCardController.cs
@@ -67,7 +67,7 @@ namespace Cauldron.Pyre
                 case 0:
                     {
                         //"One player may discard a {PyreIrradiate} card. If they do, they deal 3 targets 3 energy damage each.",
-                        var heroesWithIrradiated = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(card => IsIrradiated(card)) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
+                        var heroesWithIrradiated = GameController.AllHeroes.Where(htt => htt.Hand.Cards.Any(card => card.IsIrradiated()) && GameController.IsTurnTakerVisibleToCardSource(htt, GetCardSource())).Select(htt => htt as TurnTaker);
                         var selectHero = new SelectTurnTakerDecision(GameController, DecisionMaker, heroesWithIrradiated, SelectionType.DiscardCard, true, cardSource: GetCardSource());
                         coroutine = GameController.SelectTurnTakerAndDoAction(selectHero, DiscardForDamage);
                         if (UseUnityCoroutines)
@@ -119,7 +119,7 @@ namespace Cauldron.Pyre
             //One player may discard a {PyreIrradiate} card...
             var heroTTC = FindHeroTurnTakerController(tt.ToHero());
             var storedDiscard = new List<DiscardCardAction>();
-            IEnumerator coroutine = GameController.SelectAndDiscardCard(heroTTC, true, card => IsIrradiated(card), storedDiscard, responsibleTurnTaker: TurnTaker, cardSource: GetCardSource());
+            IEnumerator coroutine = GameController.SelectAndDiscardCard(heroTTC, true, card => card.IsIrradiated(), storedDiscard, responsibleTurnTaker: TurnTaker, cardSource: GetCardSource());
             if (UseUnityCoroutines)
             {
                 yield return GameController.StartCoroutine(coroutine);

--- a/CauldronMods/DeckLists/Hero/PyreDeckList.json
+++ b/CauldronMods/DeckLists/Hero/PyreDeckList.json
@@ -455,7 +455,7 @@
         },
         {
             "identifier": "IrradiatedMarker",
-            "count": 40,
+            "count": 1,
             "title": "Irradiated",
             "keywords": ["mark"],
             "isReal": false,

--- a/Testing/Heroes/PyreTests.cs
+++ b/Testing/Heroes/PyreTests.cs
@@ -354,16 +354,16 @@ namespace CauldronTests
             StartGamePyre();
 
             DiscardAllCards(pyre);
-            AssertNumberOfCardsAtLocation(pyre.TurnTaker.OffToTheSide, 40);
+            AssertNumberOfCardsAtLocation(pyre.TurnTaker.OffToTheSide, 1);
             DecisionSelectTurnTaker = legacy.TurnTaker;
             Card ring = PutOnDeck("TheLegacyRing");
             UsePower(pyre);
-            AssertNumberOfCardsAtLocation(pyre.TurnTaker.OffToTheSide, 39);
+            AssertNumberOfCardsAtLocation(pyre.TurnTaker.OffToTheSide, 0);
 
             AssertIrradiated(ring);
             DealDamage(baron, legacy, 50, DTM);
             AssertNotIrradiated(ring);
-            AssertNumberOfCardsAtLocation(pyre.TurnTaker.OffToTheSide, 40);
+            AssertNumberOfCardsAtLocation(pyre.TurnTaker.OffToTheSide, 1);
         }
         [Test]
         public void TestAtmosphereScrubbersPlayGrantsPower()


### PR DESCRIPTION
Changes the way Pyre's markers work so that we only have one marker in the decklist and make new ones at runtime when we need them. This means we can irradiate more than 40 cards and also when you open pyre's cardlist you only see one copy of the marker card and it doesn't have to count to 40.

Also moves a bunch of code to extension methods, and makes the "is this an irradiated marker card?" check a bit more specific and consistent.