### PR TITLE
Fix Lady of the Wood 2199 OblivAeon rewind bug

### DIFF
--- a/CauldronMods/Controller/Heroes/LadyOfTheWood/CharacterCards/FutureLadyOfTheWoodCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/LadyOfTheWood/CharacterCards/FutureLadyOfTheWoodCharacterCardController.cs
@@ -262,7 +262,7 @@ namespace Cauldron.LadyOfTheWood
                 CardController inhibitedCard = FindCardController(item);
                 base.GameController.AddInhibitorException(inhibitedCard, (GameAction ga) => true);
                 List<string> list = new List<string>();
-                list.Add(base.TurnTaker.Identifier);
+                list.Add(base.TurnTaker.QualifiedIdentifier);
                 list.Add(item.Identifier);
                 base.GameController.AddCardPropertyJournalEntry(item, "OverrideTurnTaker", list);
             }

--- a/Testing/Heroes/LadyOfTheWoodVariantTests.cs
+++ b/Testing/Heroes/LadyOfTheWoodVariantTests.cs
@@ -761,7 +761,20 @@ namespace CauldronTests
 
         }
 
-
+        [Test()]
+        public void TestFutureLadyOfTheWoodOblivAeonRewindSoftlockBug()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.LadyOfTheWood/FutureLadyOfTheWoodCharacter", "Bunker",  "Tachyon", "Luminary", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+            DestroyCard(ladyWood);
+            DecisionSelectFromBoxTurnTakerIdentifier = "Legacy";
+            DecisionSelectFromBoxIdentifiers = new string[] { "LegacyCharacter" };
+            GoToAfterEndOfTurn(oblivaeon);
+            RunActiveTurnPhase();
+            GoToPlayCardPhase(legacy);
+            var T = new TestDelegate(() =>SaveAndLoad(GameController));
+            Assert.DoesNotThrow(T,"Failed to reload the game",null);
+        }
 
     }
 }


### PR DESCRIPTION
The issue was caused by the game not being able to find Lady of the Wood's deck list after reloading the game, since it was looking for "LadyOfTheWoodDeckList" instead of "Cauldron.LadyOfTheWoodDeckList". The solution was to use TurnTaker.QualifiedIdentifier instead of TurnTaker.Identifier when handling the season cards after Lady is incapped, so after Lady's TurnTaker is replaced, the game can find the deck list in order to add the season cards to the new TurnTaker.