### PR TITLE
Fix Knight imbued vitality bug

### DIFF
--- a/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/TheKnightCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/CardSubClasses/TheKnightCardController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Handelabra;
 
 namespace Cauldron.TheKnight
 {
@@ -120,6 +121,31 @@ namespace Cauldron.TheKnight
             }
 
             return this.CharacterCard;
+        }
+
+        // Lightly modified copy of CardController.AdjustTargetnessResponse, which is unfortunately private.
+        protected IEnumerator AdjustTargetnessResponseNotPrivate(GameAction a, Card card, int maxHP)
+        {
+            if (a is RemoveTargetAction rta)
+            {
+                IEnumerator coroutine = CancelAction(rta);
+                if (UseUnityCoroutines)
+                {
+                    yield return GameController.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    GameController.ExhaustCoroutine(coroutine);
+                }
+                rta.CardToRemoveTarget.SetMaximumHP(maxHP, alsoSetHP: false);
+            }
+            else if (a is BulkRemoveTargetsAction brta)
+            {
+                brta.RemoveCardsFromBulkProcess(c => c == card).ForEach(delegate (Card c)
+                {
+                    c.SetMaximumHP(maxHP, alsoSetHP: false);
+                });
+            }
         }
     }
 }

--- a/CauldronMods/Controller/Heroes/TheKnight/Cards/PlateHelmCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/Cards/PlateHelmCardController.cs
@@ -1,4 +1,5 @@
-﻿using Handelabra.Sentinels.Engine.Controller;
+﻿using Handelabra;
+using Handelabra.Sentinels.Engine.Controller;
 using Handelabra.Sentinels.Engine.Model;
 using System;
 using System.Collections;
@@ -13,11 +14,28 @@ namespace Cauldron.TheKnight
         {
         }
 
+        public override void AddStartOfGameTriggers()
+        {
+            AddTrigger(
+                (RemoveTargetAction r) => r.CardToRemoveTarget == Card,
+                (RemoveTargetAction a) => AdjustTargetnessResponseNotPrivate(a, Card, 3),
+                TriggerType.CancelAction,
+                TriggerTiming.Before,
+                outOfPlayTrigger: true
+            );
+
+            AddTrigger(
+                (BulkRemoveTargetsAction r) => r.CardsToRemoveTargets.Any((Card c) => c == Card),
+                (BulkRemoveTargetsAction a) => AdjustTargetnessResponseNotPrivate(a, Card, 3),
+                TriggerType.CancelAction,
+                TriggerTiming.Before,
+                outOfPlayTrigger: true
+            );
+        }
+
         public override void AddTriggers()
         {
             base.AddRedirectDamageTrigger(dd => IsEquipmentEffectingCard(dd.Target), c => base.Card, true);
-
-            base.AddMaintainTargetTriggers((Card c) => c.Owner == base.Card.Owner && c.Identifier == Card.Identifier, 3, new List<string> { "equipment" });
 
             base.AddTriggers();
         }

--- a/CauldronMods/Controller/Heroes/TheKnight/Cards/PlateMailCardController.cs
+++ b/CauldronMods/Controller/Heroes/TheKnight/Cards/PlateMailCardController.cs
@@ -13,11 +13,28 @@ namespace Cauldron.TheKnight
         {
         }
 
+        public override void AddStartOfGameTriggers()
+        {
+            AddTrigger(
+                (RemoveTargetAction r) => r.CardToRemoveTarget == Card,
+                (RemoveTargetAction a) => AdjustTargetnessResponseNotPrivate(a, Card, 5),
+                TriggerType.CancelAction,
+                TriggerTiming.Before,
+                outOfPlayTrigger: true
+            );
+
+            AddTrigger(
+                (BulkRemoveTargetsAction r) => r.CardsToRemoveTargets.Any((Card c) => c == Card),
+                (BulkRemoveTargetsAction a) => AdjustTargetnessResponseNotPrivate(a, Card, 5),
+                TriggerType.CancelAction,
+                TriggerTiming.Before,
+                outOfPlayTrigger: true
+            );
+        }
+
         public override void AddTriggers()
         {
             base.AddRedirectDamageTrigger(dd => IsEquipmentEffectingCard(dd.Target), c => base.Card, true);
-
-            base.AddMaintainTargetTriggers((Card c) => c.Owner == base.Card.Owner && c.Identifier == Card.Identifier, 5, new List<string> { "equipment" });
 
             base.AddTriggers();
         }

--- a/Testing/Heroes/TheKnightTests.cs
+++ b/Testing/Heroes/TheKnightTests.cs
@@ -917,6 +917,81 @@ namespace CauldronTests
             AssertNotTarget(equip);
         }
 
+        [Test]
+        public void Armor_ImbuedVitalityOutOfPlay([Values("PlateHelm", "PlateMail")] string armor)
+        {
+            SetupGameController("GrandWarlordVoss", HeroNamespace, "RealmOfDiscord");
+            StartGame();
+
+            //nuke all baron blades cards so his ongoings don't break tests
+            DestroyCards((Card c) => c.IsVillain && c.IsInPlayAndHasGameText && !c.IsCharacter);
+            DiscardAllCards(knight);
+
+            var target = PutInHand(knight, armor);
+            int targetHP = armor == "PlateHelm" ? 3 : 5;
+            GoToPlayCardPhase(knight);
+
+            PrintSeparator("Test");
+
+            var imbue = PlayCard("ImbuedVitality");
+            AssertIsTarget(target, 6);
+
+            DestroyCard(imbue);
+            AssertIsTarget(target, targetHP);
+        }
+
+        [Test]
+        public void Armor_ImbuedVitalityOutOfPlay_ThenEntersPlay([Values("PlateHelm", "PlateMail")] string armor)
+        {
+            SetupGameController("GrandWarlordVoss", HeroNamespace, "RealmOfDiscord");
+            StartGame();
+
+            //nuke all baron blades cards so his ongoings don't break tests
+            DestroyCards((Card c) => c.IsVillain && c.IsInPlayAndHasGameText && !c.IsCharacter);
+            DiscardAllCards(knight);
+
+            var target = PutInHand(knight, armor);
+            int targetHP = armor == "PlateHelm" ? 3 : 5;
+            GoToPlayCardPhase(knight);
+
+            PrintSeparator("Test");
+
+            var imbue = PlayCard("ImbuedVitality");
+            AssertIsTarget(target, 6);
+
+            PlayCard(target);
+            AssertIsTarget(target, 6);
+
+            DestroyCard(imbue);
+            AssertIsTarget(target, targetHP);
+        }
+
+        [Test]
+        public void Armor_BounceArmourThenImbuedVitality([Values("PlateHelm", "PlateMail")] string armor)
+        {
+            SetupGameController("GrandWarlordVoss", HeroNamespace, "RealmOfDiscord");
+            StartGame();
+
+            //nuke all baron blades cards so his ongoings don't break tests
+            DestroyCards((Card c) => c.IsVillain && c.IsInPlayAndHasGameText && !c.IsCharacter);
+            DiscardAllCards(knight);
+
+            var target = PutInHand(knight, armor);
+            int targetHP = armor == "PlateHelm" ? 3 : 5;
+            GoToPlayCardPhase(knight);
+
+            PrintSeparator("Test");
+
+            PlayCard(target);
+            AssertIsTarget(target, targetHP);
+            DestroyCard(target);
+
+            var imbue = PlayCard("ImbuedVitality");
+            AssertIsTarget(target, 6);
+
+            DestroyCard(imbue);
+            AssertIsTarget(target, targetHP);
+        }
 
         [Test]
         [Description("TheKnight - PlateHelm")]

--- a/Testing/Heroes/TheKnightTests.cs
+++ b/Testing/Heroes/TheKnightTests.cs
@@ -994,6 +994,57 @@ namespace CauldronTests
         }
 
         [Test]
+        public void Armor_InPlay_SwitchBattleZones([Values("PlateHelm", "PlateMail")] string armor)
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.TheKnight", "Legacy", "Haka", "Tachyon", "Luminary", "RealmOfDiscord", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            var target = PutInHand(knight, armor);
+            int targetHP = armor == "PlateHelm" ? 3 : 5;
+            GoToPlayCardPhase(knight);
+
+            PrintSeparator("Test");
+
+            PlayCard(target);
+            AssertIsTarget(target, targetHP);
+            PlayCard("ImbuedVitality");
+            AssertIsTarget(target, 6);
+
+            SetHitPoints(target, 2);
+            AssertHitPoints(target, 2);
+            SwitchBattleZone(knight);
+            AssertIsTarget(target, targetHP);
+            AssertHitPoints(target, 2);
+            SwitchBattleZone(knight);
+            AssertIsTarget(target, 6);
+            AssertHitPoints(target, 2);
+        }
+
+        [Test]
+        public void Armor_InTrash_SwitchBattleZones([Values("PlateHelm", "PlateMail")] string armor)
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.TheKnight", "Legacy", "Haka", "Tachyon", "Luminary", "RealmOfDiscord", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
+            StartGame();
+
+            
+            var target = PutInHand(knight, armor);
+            int targetHP = armor == "PlateHelm" ? 3 : 5;
+            GoToPlayCardPhase(knight);
+
+            PrintSeparator("Test");
+
+            PlayCard(target);
+            AssertIsTarget(target, targetHP);
+            PlayCard("ImbuedVitality");
+            DestroyCard(target);
+            AssertIsTarget(target, 6);
+            SwitchBattleZone(knight);
+            AssertIsTarget(target, targetHP);
+            SwitchBattleZone(knight);
+            AssertIsTarget(target, 6);
+        }
+
+        [Test]
         [Description("TheKnight - PlateHelm")]
         public void PlateHelm()
         {


### PR DESCRIPTION
Closes #1682.

Moves the target maintenance triggers for the Knight's equipment targets to out-of-play triggers, added at the start of the game. Also tests.