### PR TITLE
Fix typo from recent Superstorm Akela fix

### DIFF
--- a/CauldronMods/Controller/Environments/SuperstormAkela/CardSubClasses/SuperstormAkelaCardController.cs
+++ b/CauldronMods/Controller/Environments/SuperstormAkela/CardSubClasses/SuperstormAkelaCardController.cs
@@ -232,7 +232,7 @@ namespace Cauldron.SuperstormAkela
             {
                 yield break;
             }
-            Log.Debug($"{this.Card.Title} is using {otherCard.Title} to refresh the UI for {card.Title}");}
+            Log.Debug($"{this.Card.Title} is using {otherCard.Title} to refresh the UI for {card.Title}");
             CardSource otherCardSource = FindCardController(otherCard).GetCardSource();
 
             int? currentHP = card.IsTarget ? card.HitPoints : null;


### PR DESCRIPTION
Typo in a recently merged pull request added a } where it shouldn't be