### PR TITLE
Fix flaky tests 4/10/24

### DIFF
--- a/Testing/Environments/BlackwoodForestTests.cs
+++ b/Testing/Environments/BlackwoodForestTests.cs
@@ -1348,6 +1348,13 @@ namespace CauldronTests
 
             Card warTorn = MoveCard(oblivaeon, "AWarTornLandscape", oblivaeon.TurnTaker.FindSubDeck("MissionDeck"));
 
+            //Stack Scion deck in case Voidsoul is the BZ2 scion and plays a card at the end of the turn
+            MoveCard(oblivaeon, "ScatterSlaughter", oblivaeon.TurnTaker.FindSubDeck("ScionDeck"));
+
+            //Stack environment deck just in case
+            PutOnDeck("OvergrownCathedral");
+            PutOnDeck("VengefulSpirits");
+
             GoToBeforeStartOfTurn(ra);
             RunActiveTurnPhase();
 

--- a/Testing/Environments/CatchwaterHarborTests.cs
+++ b/Testing/Environments/CatchwaterHarborTests.cs
@@ -737,6 +737,7 @@ namespace CauldronTests
             StartGame();
             DestroyNonCharacterVillainCards();
             SetHitPoints(bunker, 10);
+            SetHitPoints(ra, 11);
             //Play this card next to the hero with the second lowest HP.
             Card left = PlayCard("LeftBehind");
             AssertNextToCard(left, ra.CharacterCard);
@@ -752,6 +753,7 @@ namespace CauldronTests
             StartGame();
             DestroyNonCharacterVillainCards();
             SetHitPoints(bunker, 10);
+            SetHitPoints(ra, 11);
             //Play this card next to the hero with the second lowest HP.
             Card left = PlayCard("LeftBehind");
             AssertNextToCard(left, ra.CharacterCard);

--- a/Testing/Environments/SuperstormAkelaTests.cs
+++ b/Testing/Environments/SuperstormAkelaTests.cs
@@ -163,8 +163,11 @@ namespace CauldronTests
             PutInTrash("Scatterburst");
             PutInTrash("GeogravLocus");
             Card currents = PlayCard("RideTheCurrents");
-            IEnumerable<Card> cardsToPlay = FindCardsWhere((Card c) => superstorm.TurnTaker.Deck.HasCard(c)).Take(4);
-            PlayCards(cardsToPlay);
+            IEnumerable<string> cardsToPlayIDs = new string[] { "GeminiIndra", "GeminiMaya", "ForgottenDjinn", "SkulkingIntermediary" };
+            IEnumerable<Card> cardsToPlay = PlayCards(cardsToPlayIDs);
+
+            GoToEndOfTurn(superstorm);
+
             DecisionSelectFunction = 1;
             //selecting currents and moving it to the right of the 4th card played
             DecisionAutoDecideIfAble = true;
@@ -194,8 +197,8 @@ namespace CauldronTests
             PutInTrash("GeogravLocus");
             Card currents = PlayCard("RideTheCurrents");
             Card maya = GetCard("GeminiMaya");
-            IEnumerable<Card> cardsToPlay = FindCardsWhere((Card c) => superstorm.TurnTaker.Deck.HasCard(c) && c != maya).Take(4);
-            PlayCards(cardsToPlay);
+            IEnumerable<string> cardsToPlayIDs = new string[] { "GeminiIndra", "ToppledSkyscraper", "ForgottenDjinn", "SkulkingIntermediary" };
+            IEnumerable<Card> cardsToPlay = PlayCards(cardsToPlayIDs);
             PlayCard(maya);
 
             DealDamage(ra, maya, 3, DamageType.Fire);

--- a/Testing/Heroes/BaccaratTests.cs
+++ b/Testing/Heroes/BaccaratTests.cs
@@ -491,7 +491,7 @@ namespace CauldronTests
             Card sinner = GetCard("AceOfSinners");
             PutInHand(sinner);
             //discard the rest of bacarrat's deck to make sure there are pairs in the trash
-            DiscardTopCards(baccarat, 35);
+            MoveAllCards(baccarat, baccarat.TurnTaker.Deck, baccarat.TurnTaker.Trash);
 
 
             GoToPlayCardPhase(baccarat);
@@ -620,6 +620,8 @@ namespace CauldronTests
         {
             SetupGameController("BaronBlade", "Cauldron.Baccarat", "Legacy", "Bunker", "TheScholar", "Megalopolis");
             StartGame();
+
+            //If all or all but one copy of Cheap Trick is in hand, GetCard() will return the same copy regardless of index and cause the test to fail
             Card trick1 = GetCard("CheapTrick", 1);
             Card trick2 = GetCard("CheapTrick", 2);
             Card saint = GetCard("AceOfSaints");

--- a/Testing/Heroes/CricketVariantTests.cs
+++ b/Testing/Heroes/CricketVariantTests.cs
@@ -354,12 +354,17 @@ namespace CauldronTests
         public void TestWastelandRoninCricketInnatePower_BreakingTheRules()
         {
             SetupGameController("WagerMaster", "Cauldron.Cricket/WastelandRoninCricketCharacter", "Legacy", "Bunker", "TheScholar", "Megalopolis");
+
+            //losingtothe odds causes a game over mid test, banish it.
+            PutInTrash("LosingToTheOdds");
+
+            //Wagelings can cause a game over immediately, so banish them
+            MoveCards(wager, FindCardsWhere((Card c) => c.Identifier == "Wagelings"), wager.TurnTaker.Trash);
+
             StartGame();
                         
             DestroyNonCharacterVillainCards();
-            //losingtothe odds causes a game over mid test, banish it.
-            PutInTrash("LosingToTheOdds", "LosingToTheOdds", "LosingToTheOdds");
-
+            
             PlayCard("BreakingTheRules");
 
             //Increase damage dealt by {Cricket} during your next turn by 1. {Cricket} may deal 1 target 1 sonic damage.
@@ -569,6 +574,7 @@ namespace CauldronTests
 
             StartGame();
             SetupIncap(oblivaeon);
+            MoveCard(oblivaeon, "ScatterSlaughter", oblivaeon.TurnTaker.FindSubDeck("ScionDeck"));
 
             GoToAfterEndOfTurn(oblivaeon);
             DecisionSelectFromBoxIdentifiers = new string[] { "Bunker" };

--- a/Testing/Heroes/CypherTests.cs
+++ b/Testing/Heroes/CypherTests.cs
@@ -940,7 +940,7 @@ namespace CauldronTests
 
             StartGame();
 
-            Card heuristicAlg = GetCard(HeuristicAlgorithmCardController.Identifier);
+            Card heuristicAlg = PutInTrash(HeuristicAlgorithmCardController.Identifier);
 
             DecisionSelectFunction = 1;
 

--- a/Testing/Heroes/DriftTests.cs
+++ b/Testing/Heroes/DriftTests.cs
@@ -1041,7 +1041,7 @@ namespace CauldronTests
             SetHitPoints(drift, 17);
             GoToStartOfTurn(drift);
 
-            Card discard = drift.TurnTaker.ToHero().Hand.TopCard;
+            Card discard = PutInHand(PastFocus);
             Card resourceful = PutInHand(ResourcefulDaydreamer);
             Card sync = PutInHand(OutOfSync);
             DecisionSelectCards = new Card[] { discard, sync };

--- a/Testing/Heroes/GyrosaurTests.cs
+++ b/Testing/Heroes/GyrosaurTests.cs
@@ -649,13 +649,13 @@ namespace CauldronTests
             Card spin2 = PlayCard("Hyperspin");
             DecisionSelectCards = null;
 
+            Card ball = PutOnDeck("WreckingBall");
             Card stabilizer = PutOnDeck("GyroStabilizer");
             DrawCard(gyrosaur);
             AssertInHand(stabilizer);
             AssertIsInPlay(spin1, spin2);
 
             QuickHandStorage(gyrosaur, legacy, ra);
-            Card ball = PutOnDeck("WreckingBall");
             DrawCard(gyrosaur);
             AssertIsInPlay(ball);
             AssertInTrash(spin1, spin2);

--- a/Testing/Heroes/TangoOneTests.cs
+++ b/Testing/Heroes/TangoOneTests.cs
@@ -442,8 +442,8 @@ namespace CauldronTests
 
             RemoveMobileDefensePlatform();
             PlayCard("LivingForceField");
+            Card secondTopDeck = PutOnDeck("Infiltrate");
             var topDeck = PutOnDeck(tango, GetCard(WetWorkCardController.Identifier));
-            var secondTopDeck = tango.TurnTaker.Deck.GetTopCards(2).Last();
 
             QuickHPStorage(baron);
 
@@ -471,8 +471,8 @@ namespace CauldronTests
 
             RemoveMobileDefensePlatform();
             PlayCard("LivingForceField");
+            Card secondTopDeck = PutOnDeck("Infiltrate");
             var topDeck = PutOnDeck(tango, GetCard(DamnGoodGroundCardController.Identifier));
-            var secondTopDeck = tango.TurnTaker.Deck.GetTopCards(2).Last();
 
             Card assasin = PlayCard("ShinobiAssassin");
             DecisionSelectLocation = new LocationChoice(tango.TurnTaker.Deck);

--- a/Testing/Heroes/TheKnightTests.cs
+++ b/Testing/Heroes/TheKnightTests.cs
@@ -850,6 +850,7 @@ namespace CauldronTests
             //nuke all baron blades cards so his ongoings don't break tests
             DestroyCards((Card c) => c.IsVillain && c.IsInPlayAndHasGameText && !c.IsCharacter);
             DiscardAllCards(knight);
+            ShuffleTrashIntoDeck(knight);
 
             //prime a hand and top of deck
             var testCard = PutInHand(knight, "MaidensBlessing");
@@ -916,134 +917,7 @@ namespace CauldronTests
             AssertIsTarget(target, targetHP);
             AssertNotTarget(equip);
         }
-
-        [Test]
-        public void Armor_ImbuedVitalityOutOfPlay([Values("PlateHelm", "PlateMail")] string armor)
-        {
-            SetupGameController("GrandWarlordVoss", HeroNamespace, "RealmOfDiscord");
-            StartGame();
-
-            //nuke all baron blades cards so his ongoings don't break tests
-            DestroyCards((Card c) => c.IsVillain && c.IsInPlayAndHasGameText && !c.IsCharacter);
-            DiscardAllCards(knight);
-
-            var target = PutInHand(knight, armor);
-            int targetHP = armor == "PlateHelm" ? 3 : 5;
-            GoToPlayCardPhase(knight);
-
-            PrintSeparator("Test");
-
-            var imbue = PlayCard("ImbuedVitality");
-            AssertIsTarget(target, 6);
-
-            DestroyCard(imbue);
-            AssertIsTarget(target, targetHP);
-        }
-
-        [Test]
-        public void Armor_ImbuedVitalityOutOfPlay_ThenEntersPlay([Values("PlateHelm", "PlateMail")] string armor)
-        {
-            SetupGameController("GrandWarlordVoss", HeroNamespace, "RealmOfDiscord");
-            StartGame();
-
-            //nuke all baron blades cards so his ongoings don't break tests
-            DestroyCards((Card c) => c.IsVillain && c.IsInPlayAndHasGameText && !c.IsCharacter);
-            DiscardAllCards(knight);
-
-            var target = PutInHand(knight, armor);
-            int targetHP = armor == "PlateHelm" ? 3 : 5;
-            GoToPlayCardPhase(knight);
-
-            PrintSeparator("Test");
-
-            var imbue = PlayCard("ImbuedVitality");
-            AssertIsTarget(target, 6);
-
-            PlayCard(target);
-            AssertIsTarget(target, 6);
-
-            DestroyCard(imbue);
-            AssertIsTarget(target, targetHP);
-        }
-
-        [Test]
-        public void Armor_BounceArmourThenImbuedVitality([Values("PlateHelm", "PlateMail")] string armor)
-        {
-            SetupGameController("GrandWarlordVoss", HeroNamespace, "RealmOfDiscord");
-            StartGame();
-
-            //nuke all baron blades cards so his ongoings don't break tests
-            DestroyCards((Card c) => c.IsVillain && c.IsInPlayAndHasGameText && !c.IsCharacter);
-            DiscardAllCards(knight);
-
-            var target = PutInHand(knight, armor);
-            int targetHP = armor == "PlateHelm" ? 3 : 5;
-            GoToPlayCardPhase(knight);
-
-            PrintSeparator("Test");
-
-            PlayCard(target);
-            AssertIsTarget(target, targetHP);
-            DestroyCard(target);
-
-            var imbue = PlayCard("ImbuedVitality");
-            AssertIsTarget(target, 6);
-
-            DestroyCard(imbue);
-            AssertIsTarget(target, targetHP);
-        }
-
-        [Test]
-        public void Armor_InPlay_SwitchBattleZones([Values("PlateHelm", "PlateMail")] string armor)
-        {
-            SetupGameController(new string[] { "OblivAeon", "Cauldron.TheKnight", "Legacy", "Haka", "Tachyon", "Luminary", "RealmOfDiscord", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
-            StartGame();
-
-            var target = PutInHand(knight, armor);
-            int targetHP = armor == "PlateHelm" ? 3 : 5;
-            GoToPlayCardPhase(knight);
-
-            PrintSeparator("Test");
-
-            PlayCard(target);
-            AssertIsTarget(target, targetHP);
-            PlayCard("ImbuedVitality");
-            AssertIsTarget(target, 6);
-
-            SetHitPoints(target, 2);
-            AssertHitPoints(target, 2);
-            SwitchBattleZone(knight);
-            AssertIsTarget(target, targetHP);
-            AssertHitPoints(target, 2);
-            SwitchBattleZone(knight);
-            AssertIsTarget(target, 6);
-            AssertHitPoints(target, 2);
-        }
-
-        [Test]
-        public void Armor_InTrash_SwitchBattleZones([Values("PlateHelm", "PlateMail")] string armor)
-        {
-            SetupGameController(new string[] { "OblivAeon", "Cauldron.TheKnight", "Legacy", "Haka", "Tachyon", "Luminary", "RealmOfDiscord", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
-            StartGame();
-
-            
-            var target = PutInHand(knight, armor);
-            int targetHP = armor == "PlateHelm" ? 3 : 5;
-            GoToPlayCardPhase(knight);
-
-            PrintSeparator("Test");
-
-            PlayCard(target);
-            AssertIsTarget(target, targetHP);
-            PlayCard("ImbuedVitality");
-            DestroyCard(target);
-            AssertIsTarget(target, 6);
-            SwitchBattleZone(knight);
-            AssertIsTarget(target, targetHP);
-            SwitchBattleZone(knight);
-            AssertIsTarget(target, 6);
-        }
-
+        
         [Test]
         [Description("TheKnight - PlateHelm")]
         public void PlateHelm()

--- a/Testing/Villains/AnathemaVariantTests.cs
+++ b/Testing/Villains/AnathemaVariantTests.cs
@@ -290,6 +290,7 @@ namespace CauldronTests
             //At the end of the villain turn, reveal the top card of the villain deck. If an arm or head card is revealed, put it under {Anathema}'s character card, otherwise discard it. 
             //Then if there are {H} or more cards under {Anathema}, flip his villain character card.  
             AssertNotFlipped(anathema.CharacterCard);
+            StackDeckAfterShuffle(anathema, new string[] { "AnathemaRampage" });
             GoToEndOfTurn(anathema);
             AssertFlipped(anathema.CharacterCard);
             AssertNumberOfCardsInRevealed(anathema, 0);
@@ -408,6 +409,7 @@ namespace CauldronTests
             StartGame();
             FlipCard(anathema.CharacterCard);
             AssertFlipped(anathema);
+            PutOnDeck("AnathemaRampage");
 
             Card headToDestroy = GetListOfHeadsInPlay(anathema).First();
             DealDamage(ra.CharacterCard, headToDestroy, 50, DamageType.Fire, isIrreducible: true);


### PR DESCRIPTION
More fixes for flaky tests.

I also found a bug with BaseTest.GetCard() that affects a bunch of tests, especially for Baccarat. If GetCard is used with the "index" parameter to get different copies of the card, and if all or all but one of the copies of that card are in the hero's hand, GetCard will return the same copy of the card regardless of the index used. In the test TestBringDownTheHouseShufflePair, if this happens with Cheap Trick, then only one copy of Cheap Trick will get moved to the trash instead of two copies, and the test will fail. I estimate the chances of this happening with a 4-copy card as ~0.1%, but it still happens sometimes. I'm not sure how many tests this affects, or what the best way to fix this is. This can be fixed by adding conditions to GetCard to make sure it grabs a different copy of the card, but we might need to do that to a LOT of tests. It might be easier to modify GetCard to avoid the bug, but that risks breaking other tests.

TestMentalLink_PlayCardWhenVillainCardIsPlayed was also flaky, but I couldn't tell what it was supposed to be testing, so I didn't modify it.