### PR TITLE
1579 wasteland ronin cricket incap not working correctly

### DIFF
--- a/CauldronMods/Controller/Heroes/Cricket/CharacterCards/WastelandRoninCricketCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Cricket/CharacterCards/WastelandRoninCricketCharacterCardController.cs
@@ -157,7 +157,7 @@ namespace Cauldron.Cricket
 
         public override void AddSideTriggers()
         {
-            if (base.CharacterCard.IsFlipped)
+            if (base.Card.IsFlipped)
             {
                 //This looks for when a power is used that has been setup to be duplicated as per Incap 2
                 base.AddSideTrigger(base.AddTrigger<UsePowerAction>(action => action.Power.CardController.GetCardPropertyJournalEntryBoolean(Incap2PropKey) == true, UsePowerAgainResponse, TriggerType.UsePower, TriggerTiming.After));

--- a/Testing/Heroes/CricketVariantTests.cs
+++ b/Testing/Heroes/CricketVariantTests.cs
@@ -646,7 +646,58 @@ namespace CauldronTests
 
         }
 
+        [Test()]
+        public void TestWastelandRoninCricketIncap2_Oblivaeon_Rewind()
+        {
+            SetupGameController(new string[] { "OblivAeon", "Cauldron.Cricket/WastelandRoninCricketCharacter", "Legacy", "Haka", "Cauldron.WindmillCity", "MobileDefensePlatform", "InsulaPrimalis", "Cauldron.VaultFive", "Cauldron.Northspar" }, shieldIdentifier: "PrimaryObjective");
 
+            StartGame();
+            Card crick = cricket.CharacterCard;
+            SetupIncap(oblivaeon);
+            MoveCard(oblivaeon, "ScatterSlaughter", oblivaeon.TurnTaker.FindSubDeck("ScionDeck"));
+            MoveCards(oblivaeon, FindCardsWhere((Card c) => c.Identifier == "AeonThrall"), oblivaeon.TurnTaker.FindSubDeck("AeonMenDeck"));
+
+            //Replace Cricket with Bunker
+            GoToAfterEndOfTurn(oblivaeon);
+            DecisionSelectFromBoxIdentifiers = new string[] { "BunkerCharacter" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Bunker";
+            RunActiveTurnPhase();
+
+            //Use incap ability and select Motivational Charge
+            ResetDecisions();
+            Card charge = PlayCard("MotivationalCharge");
+            DecisionSelectCard = charge;
+            GoToBeforeStartOfTurn(bunker);
+            DecisionSelectFunction = 2;
+            DecisionIncapacitatedAbilityIndex = 1;
+            RunActiveTurnPhase();
+
+            //Check that Motivational Charge gets used twice
+            DecisionSelectTarget = oblivaeon.CharacterCard;
+            QuickHPStorage(oblivaeon);
+            UsePower(charge);
+            QuickHPCheck(-4);
+
+            GoToEndOfTurn(oblivaeon);
+
+            //Reload the game
+            SaveAndLoad(GameController);
+
+            //This time, select Mere
+            ResetDecisions();
+            Card mere = PlayCard("Mere");
+            DecisionSelectCard = mere;
+            GoToBeforeStartOfTurn(bunker);
+            DecisionSelectFunction = 2;
+            DecisionIncapacitatedAbilityIndex = 1;
+            RunActiveTurnPhase();
+
+            //Check that Mere gets used twice
+            DecisionSelectTarget = oblivaeon.CharacterCard;
+            QuickHPStorage(oblivaeon);
+            UsePower(mere);
+            QuickHPCheck(-4);
+        }
 
         [Test()]
         public void TestWastelandRoninCricketIncap2CosmicWeapon()


### PR DESCRIPTION
The issue here was that if you reload the game after Wasteland Ronin Cricket is incapped and replaced with a new hero, her second incap ability does not work. It will create the status effect, but not allow you to use the power twice.

The cause of the issue was that in AddSideTriggers(), Cricket is checking if base.CharacterCard is flipped before adding the trigger for incap 2. Since Cricket was replaced with a new hero, base.CharacterCard now refers to that hero's character card, which is not flipped, so when the game is reloaded it never adds the trigger to make the incap ability work. It works before reloading because in that case, the trigger is added when Cricket flips.

The fix is to check if base.Card is flipped instead of base.CharacterCard.