### PR TITLE
Fix for First Response Doc Havoc Incap 3 Allowing Destruction of Non-Target Environment Cards

### DIFF
--- a/CauldronMods/Controller/Heroes/DocHavoc/CharacterCards/FirstResponseDocHavocCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/DocHavoc/CharacterCards/FirstResponseDocHavocCharacterCardController.cs
@@ -111,7 +111,7 @@ namespace Cauldron.DocHavoc
                     //==============================================================
 
                     coroutine = base.GameController.SelectAndDestroyCards(base.HeroTurnTakerController,
-                        new LinqCardCriteria(c => c.IsEnvironment, "environment"),
+                        new LinqCardCriteria(c => c.IsEnvironmentTarget, "environment target"),
                         Incapacitate3CardsToDestroy,
                         requiredDecisions: 0, cardSource: GetCardSource());
 

--- a/Testing/Heroes/DocHavocPromoTests.cs
+++ b/Testing/Heroes/DocHavocPromoTests.cs
@@ -283,13 +283,13 @@ namespace CauldronTests
 
             StartGame();
 
-            PutIntoPlay("EnragedTRex");
-            Card enragedTRex = GetCardInPlay("EnragedTRex");
+            Card enragedTRex = PutIntoPlay("EnragedTRex");
+            Card velociraptorPack = PutIntoPlay("VelociraptorPack");
+            Card obsidianField = PutIntoPlay("ObsidianField");
 
-            PutIntoPlay("ObsidianField");
-            Card obsidianField = GetCardInPlay("ObsidianField");
-
-            DecisionSelectCards = new[] { enragedTRex, obsidianField };
+            DecisionSelectCards = new[] { enragedTRex, velociraptorPack };
+            AssertNumberOfChoicesInNextDecision(2, selectionType: SelectionType.DestroyCard);
+            AssertNextDecisionChoices(new List<Card>() { enragedTRex, velociraptorPack }, new List<Card>() { obsidianField });
 
             SetHitPoints(doc.CharacterCard, 1);
             DealDamage(baron, doc, 2, DamageType.Melee);
@@ -301,7 +301,8 @@ namespace CauldronTests
             // Assert
             AssertIncapacitated(doc);
             AssertInTrash(enragedTRex);
-            AssertInTrash(obsidianField);
+            AssertInTrash(velociraptorPack);
+            AssertInPlayArea(env, obsidianField);
         }
 
         [Test]
@@ -337,6 +338,9 @@ namespace CauldronTests
 
             StartGame();
 
+            // put non-target in play
+            Card obsidianField = PlayCard("ObsidianField");
+
             SetHitPoints(doc.CharacterCard, 1);
             DealDamage(baron, doc, 2, DamageType.Melee);
 
@@ -346,8 +350,10 @@ namespace CauldronTests
 
             // Assert
             AssertIncapacitated(doc);
+            AssertInPlayArea(env, obsidianField);
             AssertNumberOfCardsInTrash(env, 0);
         }
+
         [Test]
         public void TestFutureDocHavocLoads()
         {


### PR DESCRIPTION
Closes #1694 