### PR TITLE
fix logic for shift tracks for when drift is representative of earth

### DIFF
--- a/CauldronMods/Controller/Heroes/Drift/CardSubClasses/DriftSubCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Drift/CardSubClasses/DriftSubCharacterCardController.cs
@@ -793,11 +793,14 @@ namespace Cauldron.Drift
             Card modelCard;
             CardController cardController;
             Dictionary<Card, CardController> cardToControllerDict = new Dictionary<Card, CardController>();
-            string overrideNamespace = TurnTaker.QualifiedIdentifier;
-            List<string> list = new List<string>();
-            list.Add(overrideNamespace);
+            string overrideNamespace; 
+            List<string> list;
             foreach (CardDefinition trackDefinition in shiftTrackDefinitions)
             {
+                overrideNamespace = $"{trackDefinition.Namespace}.{DriftDeckDefinition.Identifier}";
+                list = new List<string>();
+                list.Add(overrideNamespace);
+                list.Add(trackDefinition.QualifiedIdentifier);
                 modelCard = new Card(trackDefinition, TurnTaker, 0);
                 TurnTaker.OffToTheSide.AddCard(modelCard);
                 shiftTracks.Add(modelCard);

--- a/Testing/Heroes/DriftTests.cs
+++ b/Testing/Heroes/DriftTests.cs
@@ -1264,5 +1264,22 @@ namespace CauldronTests
             GoToPlayCardPhase(drift);
             DealDamage(drift, haka, 1, DamageType.Melee);
         }
+
+        [Test()]
+        public void TestDriftAsRepresentativeOfEarth()
+        {
+            SetupGameController(new string[] { "BaronBlade", "Legacy", "Haka", "Tachyon", "TheCelestialTribunal" });
+            StartGame();
+
+            DecisionSelectFromBoxIdentifiers = new string[] { "Cauldron.DriftCharacter" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Cauldron.Drift";
+
+            Card representative = PlayCard("RepresentativeOfEarth");
+
+            PrintJournal();
+
+            SaveAndLoad();
+
+        }
     }
 }


### PR DESCRIPTION
From BartKF:

> Choosing Drift as the Representative of Earth makes it impossible to load saves. Apparently something is expecting The Celestial Tribunal's deck to have a card with the identifier TheCelestialTribunal, and when it doesn't, the save refuses to load.

This was a result in bad logic for the loading of the Shift Tracks. Fixing this logic resolved the issue.