### PR TITLE
Fix softlock when Gyrosaur is Representative of Earth

### DIFF
--- a/CauldronMods/Controller/Heroes/Gyrosaur/CardSubClasses/GyrosaurUtilityCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Gyrosaur/CardSubClasses/GyrosaurUtilityCharacterCardController.cs
@@ -112,11 +112,14 @@ namespace Cauldron.Gyrosaur
 
         protected void ShowCrashInHandCount(bool otherInHand = false)
         {
-            var standard = SpecialStringMaker.ShowNumberOfCardsAtLocation(HeroTurnTaker.Hand, new LinqCardCriteria((Card c) => IsCrash(c), "crash"));
-            if (otherInHand)
+            if (this.TurnTaker.IsPlayer)
             {
-                standard.Condition = () => !Card.Location.IsHand;
-                SpecialStringMaker.ShowNumberOfCardsAtLocation(HeroTurnTaker.Hand, new LinqCardCriteria((Card c) => c != this.Card && IsCrash(Card))).Condition = () => Card.Location.IsHand;
+                var standard = SpecialStringMaker.ShowNumberOfCardsAtLocation(HeroTurnTaker.Hand, new LinqCardCriteria((Card c) => IsCrash(c), "crash"));
+                if (otherInHand)
+                {
+                    standard.Condition = () => !Card.Location.IsHand;
+                    SpecialStringMaker.ShowNumberOfCardsAtLocation(HeroTurnTaker.Hand, new LinqCardCriteria((Card c) => c != this.Card && IsCrash(Card))).Condition = () => Card.Location.IsHand;
+                }
             }
         }
 

--- a/Testing/Heroes/GyrosaurTests.cs
+++ b/Testing/Heroes/GyrosaurTests.cs
@@ -1687,5 +1687,22 @@ namespace CauldronTests
             QuickHPCheck(0, 0, 0, 0, 0, -2);
         }
         #endregion Test Wrecking Ball
+
+        #region Test Representative of Earth
+        [Test()]
+        public void TestGyrosaurAsRepresentativeOfEarth()
+        {
+            SetupGameController(new string[] { "BaronBlade", "Legacy", "Haka", "Tachyon", "TheCelestialTribunal" });
+            StartGame();
+
+            DecisionSelectFromBoxIdentifiers = new string[] { "Cauldron.GyrosaurCharacter" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Cauldron.Gyrosaur";
+
+            Card representative = PlayCard("RepresentativeOfEarth");
+
+            PrintJournal();
+
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Gyrosaur causes a softlock when picked for Representative of Earth due to her special strings looking at the number of crash cards in her hand. Added check for TurnTaker.IsPlayer to ShowCrashInHandCount to prevent this.