### PR TITLE
Fix softlock when Starlight of Asheron is Representative of Earth

### DIFF
--- a/CauldronMods/Controller/Heroes/Starlight/CharacterCards/StarlightOfAsheronCharacterCardController.cs
+++ b/CauldronMods/Controller/Heroes/Starlight/CharacterCards/StarlightOfAsheronCharacterCardController.cs
@@ -11,7 +11,10 @@ namespace Cauldron.Starlight
         public StarlightOfAsheronCharacterCardController(Card card, TurnTakerController turnTakerController) : base(card, turnTakerController)
         {
             IsCoreCharacterCard = false;
-            SpecialStringMaker.ShowNumberOfCardsAtLocation(HeroTurnTaker.Hand, new LinqCardCriteria((Card c) => IsConstellation(c), "constellation"));
+            if (base.TurnTaker.IsPlayer)
+            {
+                SpecialStringMaker.ShowNumberOfCardsAtLocation(HeroTurnTaker.Hand, new LinqCardCriteria((Card c) => IsConstellation(c), "constellation"));
+            }
         }
 
         public override IEnumerator UsePower(int index = 0)

--- a/Testing/Heroes/StarlightVariantTests.cs
+++ b/Testing/Heroes/StarlightVariantTests.cs
@@ -946,7 +946,20 @@ namespace CauldronTests
             AssertInPlayArea(ra, c2);
             AssertInTrash(c3);
         }
+        
+        [Test()]
+        public void TestAsheronAsRepresentativeOfEarth()
+        {
+            SetupGameController(new string[] { "BaronBlade", "Legacy", "Haka", "Tachyon", "TheCelestialTribunal" });
+            StartGame();
 
+            DecisionSelectFromBoxIdentifiers = new string[] { "Cauldron.StarlightOfAsheronCharacter" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Cauldron.Starlight";
+
+            Card representative = PlayCard("RepresentativeOfEarth");
+
+            PrintJournal();
+        }
 
     }
 }


### PR DESCRIPTION
Starlight of Asheron causes a softlock when picked for Representative of Earth due to her special strings looking at the number of constellation cards in her hand. Added check for TurnTaker.IsPlayer to her constructor to prevent this.