### PR TITLE
St Simeons 4.1.1 crash fix

### DIFF
--- a/CauldronMods/Controller/Environments/StSimeonsCatacombs/CardSubClasses/StSimeonsGhostCardController.cs
+++ b/CauldronMods/Controller/Environments/StSimeonsCatacombs/CardSubClasses/StSimeonsGhostCardController.cs
@@ -56,7 +56,9 @@ namespace Cauldron.StSimeonsCatacombs
         }
         protected bool IsAffectedCardInPlay()
         {
-            bool identiferInPlay = base.FindCardsWhere(c => c.IsInPlayAndHasGameText && AffectedIdentifiers.Contains(c.Identifier)).Any();
+            //As of Sentinels 4.1.1, CardController.FindCardsWhere automatically checks card visibility, which caused an infinite loop since AskIfCardIsVisibleToCardSource references IsAffectedCardInPlay.
+            //Fixed by using GameController.FindCardsWhere instead, and making sure the parameter visibleToCard is null
+            bool identiferInPlay = GameController.FindCardsWhere(c => c.IsInPlayAndHasGameText && AffectedIdentifiers.Contains(c.Identifier), false, null, BattleZone).Any();
             return FlipIdentiferInPlayCondition ? !identiferInPlay : identiferInPlay;
         }
 
@@ -65,7 +67,7 @@ namespace Cauldron.StSimeonsCatacombs
 
         protected Card GetAffectedCardInPlay()
         {
-            IEnumerable<Card> cardsInPlay = base.FindCardsWhere(c => (FlipIdentiferInPlayCondition ? !c.IsInPlayAndHasGameText : c.IsInPlayAndHasGameText) && AffectedIdentifiers.Contains(c.Identifier));
+            IEnumerable<Card> cardsInPlay = GameController.FindCardsWhere(c => (FlipIdentiferInPlayCondition ? !c.IsInPlayAndHasGameText : c.IsInPlayAndHasGameText) && AffectedIdentifiers.Contains(c.Identifier));
             return cardsInPlay.FirstOrDefault();
         }
 
@@ -73,7 +75,7 @@ namespace Cauldron.StSimeonsCatacombs
         {
             get
             {
-                return FindCardsWhere(c => AffectedIdentifiers.Contains(c.Identifier));
+                return GameController.FindCardsWhere(c => AffectedIdentifiers.Contains(c.Identifier));
             }
         }
 

--- a/CauldronMods/Controller/Environments/StSimeonsCatacombs/CardSubClasses/StSimeonsRoomCardController.cs
+++ b/CauldronMods/Controller/Environments/StSimeonsCatacombs/CardSubClasses/StSimeonsRoomCardController.cs
@@ -56,7 +56,9 @@ namespace Cauldron.StSimeonsCatacombs
 
         private IEnumerable<Card> FindAllRoomsButThisOne()
         {
-            return FindCardsWhere((Card c) => IsDefinitionRoom(c) && c != base.Card);
+            //As of Sentinels 4.1.1, CardController.FindCardsWhere automatically checks card visibility, which caused an infinite loop since AskIfCardIsVisibleToCardSource references FindAllRoomsButThisOne.
+            //Fixed by using GameController.FindCardsWhere instead, and making sure the parameter visibleToCard is null
+            return base.GameController.FindCardsWhere((Card c) => IsDefinitionRoom(c) && c != base.Card, false, null, BattleZone);
         }
     }
 }

--- a/CauldronMods/Controller/Environments/StSimeonsCatacombs/CardSubClasses/StSimeonsRoomCardController.cs
+++ b/CauldronMods/Controller/Environments/StSimeonsCatacombs/CardSubClasses/StSimeonsRoomCardController.cs
@@ -58,7 +58,7 @@ namespace Cauldron.StSimeonsCatacombs
         {
             //As of Sentinels 4.1.1, CardController.FindCardsWhere automatically checks card visibility, which caused an infinite loop since AskIfCardIsVisibleToCardSource references FindAllRoomsButThisOne.
             //Fixed by using GameController.FindCardsWhere instead, and making sure the parameter visibleToCard is null
-            return base.GameController.FindCardsWhere((Card c) => IsDefinitionRoom(c) && c != base.Card, false, null, BattleZone);
+            return GameController.FindCardsWhere((Card c) => IsDefinitionRoom(c) && c != Card, false, null, BattleZone);
         }
     }
 }

--- a/CauldronMods/Controller/Villains/Menagerie/Cards/SecuritySphereCardController.cs
+++ b/CauldronMods/Controller/Villains/Menagerie/Cards/SecuritySphereCardController.cs
@@ -75,7 +75,7 @@ namespace Cauldron.Menagerie
 
         private TurnTaker GetCapturedHero()
         {
-            Card prize = FindCardsWhere(new LinqCardCriteria((Card c) => base.FindCardController(c) is PrizedCatchCardController)).FirstOrDefault();
+            Card prize = GameController.FindCardsWhere(new LinqCardCriteria((Card c) => base.FindCardController(c) is PrizedCatchCardController), battleZone: BattleZone).FirstOrDefault();
             if (prize.IsInPlayAndHasGameText && prize.Location.IsNextToCard)
             {
                 return prize.Location.OwnerCard.Owner;

--- a/Testing/Environments/StSimeonsCatacombsTests.cs
+++ b/Testing/Environments/StSimeonsCatacombsTests.cs
@@ -2601,5 +2601,17 @@ namespace CauldronTests
             PrintSpecialStringsForCard(possessor);
 
         }
+
+        [Test()]
+        public void TestStSimeonsCrash()
+        {
+            //Version 4.1.1 created an infinite loop in St Simeon's cards due to chanegs in FindCardsWhere.
+            //This test exposes the issue, but it doesn't fail if the issue occurs since the issue is an infinite loop.
+            SetupGameController("Ambuscade", "Legacy", "Cauldron.Cypher", "Cauldron.DocHavoc", "Cauldron.TheStranger", "Cauldron.StSimeonsCatacombs");
+            StartGame();
+
+            GoToEndOfTurn(FindEnvironment());
+            GoToEndOfTurn(ambuscade);
+        }
     }
 }


### PR DESCRIPTION
Changes to FindCardsWhere caused an infinite loop in St Simeon's Catacombs, crashing the game. This pull request fixes the issue and adds a unit test.